### PR TITLE
Alternative websocket API PORT error

### DIFF
--- a/configs/app/api.ts
+++ b/configs/app/api.ts
@@ -16,7 +16,7 @@ const socketSchema = getEnvValue(process.env.NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL)
 const api = Object.freeze({
   host: apiHost,
   endpoint: apiEndpoint,
-  socket: `${ socketSchema }://${ apiHost }`,
+  socket: `${ socketSchema }://${ apiHost }:${ apiPort}`,
   basePath: stripTrailingSlash(getEnvValue(process.env.NEXT_PUBLIC_API_BASE_PATH) || ''),
 });
 


### PR DESCRIPTION
This is a screenshot when Error adding ENV API PORT
![image](https://github.com/blockscout/frontend/assets/22586872/96a80bae-73ce-49bb-8a16-cdad6857ab27)

This is an alternative if you use the HOST IP Address API, then the PORT must be added to the API code too and no errors occur on the websocket

![image](https://github.com/blockscout/frontend/assets/22586872/aaf719f4-6223-4784-94a4-500ab0c4289e)
