### PR TITLE
Fixed issue with empty 'Sponsored' text prompt without AdBanner in DetailsInfoItem of TokenDetails Page.

### DIFF
--- a/ui/shared/DetailsSponsoredItem.tsx
+++ b/ui/shared/DetailsSponsoredItem.tsx
@@ -1,10 +1,13 @@
 import { GridItem } from '@chakra-ui/react';
 import React from 'react';
 
+import config from 'configs/app';
 import * as cookies from 'lib/cookies';
 import useIsMobile from 'lib/hooks/useIsMobile';
 import AdBanner from 'ui/shared/ad/AdBanner';
 import DetailsInfoItem from 'ui/shared/DetailsInfoItem';
+
+const feature = config.features.adsBanner;
 
 interface Props {
   isLoading?: boolean;
@@ -14,7 +17,7 @@ const DetailsSponsoredItem = ({ isLoading }: Props) => {
   const isMobile = useIsMobile();
   const hasAdblockCookie = cookies.get(cookies.NAMES.ADBLOCK_DETECTED);
 
-  if (hasAdblockCookie) {
+  if (!feature.isEnabled || hasAdblockCookie) {
     return null;
   }
 


### PR DESCRIPTION
Fix [#1146 ](https://github.com/blockscout/frontend/issues/1146)
