### PR TITLE
Update favicon-generator.dev.sh

### DIFF
--- a/tools/scripts/favicon-generator.dev.sh
+++ b/tools/scripts/favicon-generator.dev.sh
@@ -1,9 +1,15 @@
-secrets_file="./configs/envs/.env.secrets"
+secrets_file=".env"
 favicon_folder="./public/favicon/"
-master_url="https://raw.githubusercontent.com/blockscout/frontend/main/tools/scripts/favicon.svg"
 
 if [ ! -f "$secrets_file" ]; then
     echo "Error: File '$secrets_file' not found."
+    exit 1
+fi
+
+master_url=$(grep -i '^NEXT_PUBLIC_FAVICON_MASTER_URL=' "$secrets_file" | cut -d '=' -f 2)
+
+if [ -z "$master_url" ]; then
+    echo "Error: 'NEXT_PUBLIC_FAVICON_MASTER_URL' not found in '$secrets_file'. Please add it to your .env file."
     exit 1
 fi
 


### PR DESCRIPTION
I edited the favicon:generate:dev script, which is a correction so that people can generate favicons.

**Please feel free to make corrections**

1. Picture
Error if you do not include NEXT_PUBLIC_FAVICON_MASTER_URL in .env.
![image](https://github.com/blockscout/frontend/assets/22586872/086243bb-efa8-42b1-b1bf-2cebe3c36417)
2. Picture
Image when entering the url link in the NEXT_PUBLIC_FAVICON_MASTER_URL .env that we created
![image](https://github.com/blockscout/frontend/assets/22586872/4edc63f7-7848-4228-9ae0-7e5a7f1fd6d9)


Thanks