### PR TITLE
Add app base path

### DIFF
--- a/configs/app/app.ts
+++ b/configs/app/app.ts
@@ -3,11 +3,13 @@ import { getEnvValue } from './utils';
 const appPort = getEnvValue(process.env.NEXT_PUBLIC_APP_PORT);
 const appSchema = getEnvValue(process.env.NEXT_PUBLIC_APP_PROTOCOL);
 const appHost = getEnvValue(process.env.NEXT_PUBLIC_APP_HOST);
+const appBasePath = getEnvValue(process.env.NEXT_PUBLIC_APP_BASE_PATH) || '';
+
 const baseUrl = [
   appSchema || 'https',
   '://',
   appHost,
-  appPort && ':' + appPort,
+  appPort && ':' + appPort + appBasePath,
 ].filter(Boolean).join('');
 const isDev = process.env.NODE_ENV === 'development';
 

--- a/deploy/tools/envs-validator/schema.ts
+++ b/deploy/tools/envs-validator/schema.ts
@@ -236,6 +236,7 @@ const schema = yup
     NEXT_PUBLIC_APP_HOST: yup.string().required(),
     NEXT_PUBLIC_APP_PROTOCOL: yup.string().oneOf(protocols),
     NEXT_PUBLIC_APP_PORT: yup.number().positive().integer(),
+    NEXT_PUBLIC_APP_BASE_PATH: yup.string(),
 
     // 2. Blockchain parameters
     NEXT_PUBLIC_NETWORK_NAME: yup.string().required(),

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -47,6 +47,7 @@ The app instance could be customized by passing following variables to NodeJS en
 | NEXT_PUBLIC_APP_PROTOCOL | `http \| https` | App url schema | - | `https` | `http` |
 | NEXT_PUBLIC_APP_HOST | `string` | App host | Required | - | `blockscout.com` |
 | NEXT_PUBLIC_APP_PORT | `number` | Port where app is running | - | `3000` | `3001` |
+| NEXT_PUBLIC_APP_BASE_PATH | `string` | Base path where the app is served | - | `` | `/poa/core` |
 | NEXT_PUBLIC_USE_NEXT_JS_PROXY | `boolean` | Tells the app to proxy all APIs request through the NextJS app. **We strongly advise not to use it in the production environment**, since it can lead to performance issues of the NodeJS server | - | `false` | `true` |
 
 &nbsp;

--- a/next.config.js
+++ b/next.config.js
@@ -12,8 +12,10 @@ const withRoutes = require('nextjs-routes/config')({
 const headers = require('./nextjs/headers');
 const redirects = require('./nextjs/redirects');
 const rewrites = require('./nextjs/rewrites');
+const appBasePath = process.env.NEXT_PUBLIC_APP_BASE_PATH || '';
 
 const moduleExports = withTM({
+  basePath: appBasePath,
   include: path.resolve(__dirname, 'icons'),
   reactStrictMode: true,
   webpack(config, { webpack }) {

--- a/ui/snippets/networkMenu/NetworkLogo.tsx
+++ b/ui/snippets/networkMenu/NetworkLogo.tsx
@@ -1,6 +1,7 @@
 import { Icon, Box, Image, useColorModeValue, Skeleton } from '@chakra-ui/react';
 import React from 'react';
 
+import NextLink from 'next/link';
 import { route } from 'nextjs-routes';
 
 import config from 'configs/app';
@@ -50,39 +51,41 @@ const NetworkLogo = ({ isCollapsed, onClick }: Props) => {
   const iconStyle = useColorModeValue({}, !config.UI.sidebar.icon.dark ? darkModeFilter : {});
 
   return (
-    // TODO switch to <NextLink href={ href } passHref> when main page for network will be ready
-    <Box
-      as="a"
-      href={ route({ pathname: '/' }) }
-      width={{ base: 'auto', lg: isCollapsed === false ? '120px' : '30px', xl: isCollapsed ? '30px' : '120px' }}
-      height={{ base: '24px', lg: isCollapsed === false ? '24px' : '30px', xl: isCollapsed ? '30px' : '24px' }}
-      display="inline-flex"
-      overflow="hidden"
-      onClick={ onClick }
-      flexShrink={ 0 }
-      aria-label="Link to main page"
-    >
-      { /* big logo */ }
-      <Image
-        w="auto"
-        h="100%"
-        src={ logoSrc }
-        alt={ `${ config.chain.name } network logo` }
-        fallback={ <LogoFallback isCollapsed={ isCollapsed }/> }
-        display={{ base: 'block', lg: isCollapsed === false ? 'block' : 'none', xl: isCollapsed ? 'none' : 'block' }}
-        style={ logoStyle }
-      />
-      { /* small logo */ }
-      <Image
-        w="auto"
-        h="100%"
-        src={ iconSrc }
-        alt={ `${ config.chain.name } network logo` }
-        fallback={ <LogoFallback isCollapsed={ isCollapsed } isSmall/> }
-        display={{ base: 'none', lg: isCollapsed === false ? 'none' : 'block', xl: isCollapsed ? 'block' : 'none' }}
-        style={ iconStyle }
-      />
-    </Box>
+    <NextLink href={ '/' } passHref legacyBehavior>
+      <Box
+        as="a"
+        href={ route({ pathname: '/' }) }
+        width={{ base: 'auto', lg: isCollapsed === false ? '120px' : '30px', xl: isCollapsed ? '30px' : '120px' }}
+        height={{ base: '24px', lg: isCollapsed === false ? '24px' : '30px', xl: isCollapsed ? '30px' : '24px' }}
+        display="inline-flex"
+        overflow="hidden"
+        onClick={ onClick }
+        flexShrink={ 0 }
+        aria-label="Link to main page"
+      >
+        { /* big logo */ }
+        <Image
+          w="auto"
+          h="100%"
+          src={ logoSrc }
+          alt={ `${ config.chain.name } network logo` }
+          fallback={ <LogoFallback isCollapsed={ isCollapsed }/> }
+          display={{ base: 'block', lg: isCollapsed === false ? 'block' : 'none', xl: isCollapsed ? 'none' : 'block' }}
+          style={ logoStyle }
+        />
+        { /* small logo */ }
+        <Image
+          w="auto"
+          h="100%"
+          src={ iconSrc }
+          alt={ `${ config.chain.name } network logo` }
+          fallback={ <LogoFallback isCollapsed={ isCollapsed } isSmall/> }
+          display={{ base: 'none', lg: isCollapsed === false ? 'none' : 'block', xl: isCollapsed ? 'block' : 'none' }}
+          style={ iconStyle }
+        />
+      </Box>
+    </NextLink>
+
   );
 };
 


### PR DESCRIPTION
This PR introduces the `NEXT_PUBLIC_APP_BASE_PATH` environment variable which specifies the base path at which the frontend service will be served on. This feature will allow for multiple frontend instances to be hosted on the same domain. For example we can have two frontends with the following configuration:

```
NEXT_PUBLIC_APP_HOST: www.example.com 
NEXT_PUBLIC_APP_BASE_PATH: /base-path-1
baseUrl: www.example.come/base-path-1

NEXT_PUBLIC_APP_HOST: www.example.com 
NEXT_PUBLIC_APP_BASE_PATH: /base-path-2
baseUrl: www.example.come/base-path-2
```

This change should be backwards compatible as we provide a default value for `NEXT_PUBLIC_APP_BASE_PATH` (``).  

I am currently receiving an error from pre-commit hooks saying that `process.env.*` should only be used in `app.ts` however I can't import the typescript module into the javascript next config.  Maybe we could import it after it's compiled to js or alternatively add a rule to allow it for this specific case?