### PR TITLE
Fix wallet tooltip

### DIFF
--- a/ui/snippets/walletMenu/WalletTooltip.tsx
+++ b/ui/snippets/walletMenu/WalletTooltip.tsx
@@ -2,6 +2,8 @@ import { Tooltip, useBoolean, useOutsideClick } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import React from 'react';
 
+import { SECOND } from 'lib/consts';
+
 type Props = {
   children: React.ReactNode;
   isDisabled?: boolean;
@@ -31,8 +33,8 @@ const WalletTooltip = ({ children, isDisabled, isMobile }: Props) => {
       setTimeout(() => {
         setIsTooltipShown.on();
         window.localStorage.setItem(localStorageKey, 'true');
-        setTimeout(() => setIsTooltipShown.off(), 5000);
-      }, 1000);
+        setTimeout(() => setIsTooltipShown.off(), 5 * SECOND);
+      }, SECOND);
     }
   }, [ setIsTooltipShown, localStorageKey, isDisabled, router.pathname ]);
 

--- a/ui/snippets/walletMenu/WalletTooltip.tsx
+++ b/ui/snippets/walletMenu/WalletTooltip.tsx
@@ -26,12 +26,15 @@ const WalletTooltip = ({ children, isDisabled, isMobile }: Props) => {
 
   React.useEffect(() => {
     const wasShown = window.localStorage.getItem(localStorageKey);
-    if (!isDisabled && !wasShown) {
-      setIsTooltipShown.on();
-      window.localStorage.setItem(localStorageKey, 'true');
-      setTimeout(() => setIsTooltipShown.off(), 3000);
+    const isMarketplacePage = [ '/apps', '/apps/[id]' ].includes(router.pathname);
+    if (!isDisabled && !wasShown && isMarketplacePage) {
+      setTimeout(() => {
+        setIsTooltipShown.on();
+        window.localStorage.setItem(localStorageKey, 'true');
+        setTimeout(() => setIsTooltipShown.off(), 5000);
+      }, 1000);
     }
-  }, [ setIsTooltipShown, localStorageKey, isDisabled ]);
+  }, [ setIsTooltipShown, localStorageKey, isDisabled, router.pathname ]);
 
   return (
     <Tooltip


### PR DESCRIPTION
- automatically show the tooltip only on the marketplace page
- increase the auto-hide time from 3 to 5 seconds
- add a 1 second delay before showing the tooltip to allow the page to load a bit
