### PR TITLE
Generate multiplatform image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -20,15 +20,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Check out the repo
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
     
             -   name: Set up Docker Buildx
-                uses: docker/setup-buildx-action@v2
+                uses: docker/setup-buildx-action@v3
     
             # Will automatically make nice tags, see the table here https://github.com/docker/metadata-action#basic
             -   name: Docker meta
                 id: meta
-                uses: docker/metadata-action@v4
+                uses: docker/metadata-action@v5
                 with:
                     images: ghcr.io/blockscout/frontend
     
@@ -51,13 +51,16 @@ jobs:
                     echo "ref_name: $REF_NAME"
     
             -   name: Build and push
-                uses: docker/build-push-action@v3
+                uses: docker/build-push-action@v5
                 with:
                     context: .
                     file: ./Dockerfile
                     push: true
                     cache-from: type=gha
                     tags: ${{ inputs.tags || steps.meta.outputs.tags }}
+                    platforms: |
+                        linux/amd64
+                        linux/arm64/v8
                     labels: ${{ steps.meta.outputs.labels }}
                     build-args: |
                         GIT_COMMIT_SHA=${{ env.SHORT_SHA }}


### PR DESCRIPTION
## Description and Related Issue(s)

Current GA workflow generates Docker image for a single platform (amd64). There is a demand to make it multiplatform.
Resolves https://github.com/blockscout/frontend/issues/1494

### Proposed Changes

Adds arm64 Docker image generation in `.github/workflows/publish-image.yml` workflow.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable, I have updated the list of environment variables in the [documentation](ENVS.md) and  made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
