### PR TITLE
fix(tx): when txReceipt.effectiveGasPrice is nill can't call txReceipt.effectiveGasPrice.toString()

### DIFF
--- a/ui/tx/TxDetailsDegraded.tsx
+++ b/ui/tx/TxDetailsDegraded.tsx
@@ -77,7 +77,7 @@ const TxDetailsDegraded = ({ hash, txQuery }: Props) => {
         status,
         block: tx.blockNumber ? Number(tx.blockNumber) : null,
         value: tx.value.toString(),
-        gas_price: txReceipt?.effectiveGasPrice.toString() ?? tx.gasPrice?.toString() ?? null,
+        gas_price: gasPrice?.toString() ?? null,
         base_fee_per_gas: block?.baseFeePerGas?.toString() ?? null,
         max_fee_per_gas: tx.maxFeePerGas?.toString() ?? null,
         max_priority_fee_per_gas: tx.maxPriorityFeePerGas?.toString() ?? null,


### PR DESCRIPTION
## Description and Related Issue(s)

when txReceipt.effectiveGasPrice is `nill` can't call txReceipt.effectiveGasPrice.toString() , see 

https://github.com/blockscout/frontend/blob/fe81cfe66ce8f80419e1399bc18832abf03713a5/ui/tx/TxDetailsDegraded.tsx#L69-L80