### PR TITLE
fix(tx): update tx details degraded result set to success

### DIFF
--- a/ui/tx/TxDetailsDegraded.tsx
+++ b/ui/tx/TxDetailsDegraded.tsx
@@ -95,7 +95,7 @@ const TxDetailsDegraded = ({ hash, txQuery }: Props) => {
         created_contract: txReceipt?.contractAddress ?
           { ...unknownAddress, hash: txReceipt.contractAddress, is_contract: true } :
           null,
-        result: '',
+        result: 'success',
         priority_fee: null,
         tx_burnt_fee: null,
         revert_reason: null,


### PR DESCRIPTION
## Description and Related Issue(s)

update `TxDetailsDegraded` result set to success, due to here (first line)

https://github.com/blockscout/frontend/blob/fe81cfe66ce8f80419e1399bc18832abf03713a5/ui/tx/details/TxInfo.tsx#L91-L97
