### PR TITLE
Fix message shown when there are no deposits on L2

### DIFF
--- a/ui/pages/OptimisticL2Deposits.tsx
+++ b/ui/pages/OptimisticL2Deposits.tsx
@@ -76,7 +76,7 @@ const OptimisticL2Deposits = () => {
       <DataListDisplay
         isError={ isError }
         items={ data?.items }
-        emptyText="There are no withdrawals."
+        emptyText="There are no deposits."
         content={ content }
         actionBar={ actionBar }
       />

--- a/ui/pages/ShibariumDeposits.tsx
+++ b/ui/pages/ShibariumDeposits.tsx
@@ -75,7 +75,7 @@ const L2Deposits = () => {
       <DataListDisplay
         isError={ isError }
         items={ data?.items }
-        emptyText="There are no withdrawals."
+        emptyText="There are no deposits."
         content={ content }
         actionBar={ actionBar }
       />


### PR DESCRIPTION
## Description and Related Issue(s)
Wrong text displayed when no deposits exist. Fixes #1664.

### Proposed Changes
Changed the text _There are no withdrawals_ to _There are no deposits_ in the deposits section when no deposits exist.

### Breaking or Incompatible Changes
None

### Additional Information

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable, I have updated the list of environment variables in the [documentation](ENVS.md) and  made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
