### PR TITLE
Upgrade `dappscout-iframe`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "chakra-react-select": "^4.4.3",
     "crypto-js": "^4.2.0",
     "d3": "^7.6.1",
-    "dappscout-iframe": "0.2.0",
+    "dappscout-iframe": "0.2.1",
     "dayjs": "^1.11.5",
     "dom-to-image": "^2.6.0",
     "focus-visible": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8658,10 +8658,10 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
-dappscout-iframe@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/dappscout-iframe/-/dappscout-iframe-0.2.0.tgz#f64b1c700eacd2e8a44404cfdcbecbb34afbc436"
-  integrity sha512-0C40H1mZ1j0ySJYnAG5dCvkfGfB7mtwOcF/rpD5MlYdjnua9qrR+SkoOyJiJvcQUZ1JY6MG0VDwm+00khANVQw==
+dappscout-iframe@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/dappscout-iframe/-/dappscout-iframe-0.2.1.tgz#b4718515ee4f00022af3912fac6ca1a321c156f9"
+  integrity sha512-EsiAAEk2I6hN+/E8o45WUn4BFd7aN8UvBwsIcOH79WOly0GOOHkPEO/puPkBCV0EcdxBsZIfssx3X0fSWVz5Bw==
   dependencies:
     react "^18.2.0"
     react-dom "^18.2.0"


### PR DESCRIPTION
Resolves https://github.com/blockscout/frontend/issues/1660

The previous version of `dappscout-iframe` was mistakenly published without the necessary changes 😥
