### PR TITLE
Fix: using `===` to check `NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE`

### DIFF
--- a/configs/app/meta.ts
+++ b/configs/app/meta.ts
@@ -4,7 +4,7 @@ import { getEnvValue, getExternalAssetFilePath } from './utils';
 const defaultImageUrl = '/static/og_placeholder.png';
 
 const meta = Object.freeze({
-  promoteBlockscoutInTitle: getEnvValue('NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE') || 'true',
+  promoteBlockscoutInTitle: getEnvValue('NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE') === 'true',
   og: {
     description: getEnvValue('NEXT_PUBLIC_OG_DESCRIPTION') || '',
     imageUrl: app.baseUrl + (getExternalAssetFilePath('NEXT_PUBLIC_OG_IMAGE_URL') || defaultImageUrl),

--- a/configs/app/meta.ts
+++ b/configs/app/meta.ts
@@ -4,7 +4,7 @@ import { getEnvValue, getExternalAssetFilePath } from './utils';
 const defaultImageUrl = '/static/og_placeholder.png';
 
 const meta = Object.freeze({
-  promoteBlockscoutInTitle: getEnvValue('NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE') === 'true',
+  promoteBlockscoutInTitle: getEnvValue('NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE') === 'false' ? false : true,
   og: {
     description: getEnvValue('NEXT_PUBLIC_OG_DESCRIPTION') || '',
     imageUrl: app.baseUrl + (getExternalAssetFilePath('NEXT_PUBLIC_OG_IMAGE_URL') || defaultImageUrl),


### PR DESCRIPTION
The `NEXT_PUBLIC_PROMOTE_BLOCKSCOUT_IN_TITLE` env is of type `boolean`. It is better to use `===` for strict comparison.