### PR TITLE
Fix marketplace sorting display

### DIFF
--- a/ui/marketplace/utils.ts
+++ b/ui/marketplace/utils.ts
@@ -1,16 +1,19 @@
 import type { NextRouter } from 'next/router';
 
+import config from 'configs/app';
 import getQueryParamString from 'lib/router/getQueryParamString';
 import removeQueryParam from 'lib/router/removeQueryParam';
 import type { TOption } from 'ui/shared/sort/Option';
+
+const feature = config.features.marketplace;
 
 export type SortValue = 'rating' | 'security_score';
 
 export const SORT_OPTIONS: Array<TOption<SortValue>> = [
   { title: 'Default', id: undefined },
-  { title: 'Rating', id: 'rating' },
-  { title: 'Security score', id: 'security_score' },
-];
+  (feature.isEnabled && feature.rating) && { title: 'Rating', id: 'rating' },
+  (feature.isEnabled && feature.securityReportsUrl) && { title: 'Security score', id: 'security_score' },
+].filter(Boolean) as Array<TOption<SortValue>>;
 
 export function getAppUrl(url: string | undefined, router: NextRouter) {
   if (!url) {

--- a/ui/pages/Marketplace.tsx
+++ b/ui/pages/Marketplace.tsx
@@ -137,6 +137,8 @@ const Marketplace = () => {
     return null;
   }
 
+  const showSort = SORT_OPTIONS.length > 1;
+
   return (
     <>
       <PageTitle
@@ -201,7 +203,7 @@ const Marketplace = () => {
         />
 
         <Flex gap={{ base: 2, lg: 3 }}>
-          { feature.securityReportsUrl && (
+          { showSort && (
             <Sort
               name="dapps_sorting"
               options={ SORT_OPTIONS }
@@ -214,7 +216,7 @@ const Marketplace = () => {
             onChange={ onSearchInputChange }
             placeholder="Find app by name or keyword..."
             isLoading={ isPlaceholderData }
-            size={ feature.securityReportsUrl ? 'xs' : 'sm' }
+            size={ showSort ? 'xs' : 'sm' }
             w={{ base: '100%', lg: '350px' }}
           />
         </Flex>


### PR DESCRIPTION
## Description and Related Issue(s)

Fixes the display of sorting in the marketplace. Now it is displayed only when there are security scores, and also has a rating item even when there is no rating.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
