### PR TITLE
fix: web3modal csp issue makes walletconnect unable to load icons

### DIFF
--- a/nextjs/csp/policies/walletConnect.ts
+++ b/nextjs/csp/policies/walletConnect.ts
@@ -12,6 +12,7 @@ export function walletConnect(): CspDev.DirectiveDescriptor {
   return {
     'connect-src': [
       '*.web3modal.com',
+      '*.web3modal.org',
       '*.walletconnect.com',
       'wss://relay.walletconnect.com',
       'wss://www.walletlink.org',


### PR DESCRIPTION
## Description and Related Issue(s)

Lacking *.web3modal.org in CSP header makes walletconnect unable to load icons.

![image](https://github.com/user-attachments/assets/a3f8e06b-4ef9-4214-a6a1-b42512d3b4fa)
