### PR TITLE
Favicon generator: escape special characters in master url

### DIFF
--- a/deploy/tools/favicon-generator/script.sh
+++ b/deploy/tools/favicon-generator/script.sh
@@ -33,9 +33,12 @@ CONFIG_TEMPLATE_FILE="config.template.json"
 # Path to the generated config JSON file
 CONFIG_FILE="config.json"
 
+# Escape special characters in MASTER_URL for sed
+ESCAPED_MASTER_URL=$(printf '%s\n' "$MASTER_URL" | sed -e 's/[\/&]/\\&/g')
+
 # Replace <api_key> and <master_url> placeholders in the JSON template file
 API_KEY_VALUE="$FAVICON_GENERATOR_API_KEY"
-sed -e "s|<api_key>|$API_KEY_VALUE|" -e "s|<master_url>|$MASTER_URL|" "$CONFIG_TEMPLATE_FILE" > "$CONFIG_FILE"
+sed -e "s|<api_key>|$API_KEY_VALUE|" -e "s|<master_url>|$ESCAPED_MASTER_URL|" "$CONFIG_TEMPLATE_FILE" > "$CONFIG_FILE"
 
 # Make the API POST request with JSON data from the config file
 echo "⏳ Making request to API..."


### PR DESCRIPTION
## Description and Related Issue(s)

Adjust the script to handle special characters in the master URL properly while replacing the placeholder in the config template file.

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
