### PR TITLE
Enable `Blockscout Defi` button for `Rootstock`

### DIFF
--- a/configs/envs/.env.rootstock
+++ b/configs/envs/.env.rootstock
@@ -1,0 +1,59 @@
+# Set of ENVs for Rootstock network explorer
+# https://rootstock.blockscout.com
+# This is an auto-generated file. To update all values, run "yarn preset:sync --name=rootstock_testnet"
+
+# Local ENVs
+NEXT_PUBLIC_APP_PROTOCOL=http
+NEXT_PUBLIC_APP_HOST=localhost
+NEXT_PUBLIC_APP_PORT=3000
+NEXT_PUBLIC_APP_ENV=development
+NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
+
+# Instance ENVs
+NEXT_PUBLIC_API_BASE_PATH=/
+NEXT_PUBLIC_API_HOST=rootstock.blockscout.com
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
+NEXT_PUBLIC_CONTRACT_CODE_IDES=[{'title':'Remix IDE','url':'https://remix.ethereum.org/?address={hash}&blockscout={domain}','icon_url':'https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/ide-icons/remix.png'}]
+NEXT_PUBLIC_ADMIN_SERVICE_API_HOST=https://admin-rs.services.blockscout.com
+NEXT_PUBLIC_FEATURED_NETWORKS=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/featured-networks/rsk-mainnet.json
+NEXT_PUBLIC_FOOTER_LINKS=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/footer-links/rootstock.json
+NEXT_PUBLIC_GRAPHIQL_TRANSACTION=0xf19627e63ce093a8e7dd8e571284d36c6da9f48cf2a1380b48740b11e37aedff
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs', 'coin_price', 'market_cap']
+NEXT_PUBLIC_HOMEPAGE_PLATE_BACKGROUND=rgb(255, 145, 0)
+NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=rgb(255, 255, 255)
+NEXT_PUBLIC_IS_ACCOUNT_SUPPORTED=true
+NEXT_PUBLIC_LOGOUT_URL=https://rootstock.us.auth0.com/v2/logout
+NEXT_PUBLIC_MARKETPLACE_ENABLED=true
+NEXT_PUBLIC_METADATA_SERVICE_API_HOST=https://metadata.services.blockscout.com
+NEXT_PUBLIC_NAME_SERVICE_API_HOST=https://bens.services.blockscout.com
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=RBTC
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=RBTC
+NEXT_PUBLIC_NETWORK_EXPLORERS=[{'title':'Tenderly','logo':'https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/explorer-logos/tenderly.png','baseUrl':'https://dashboard.tenderly.co','paths':{'tx':'/tx/rsk'}},{'title':'3xpl','logo':'https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/explorer-logos/3xpl.png','baseUrl':'https://3xpl.com/','paths':{'tx':'/rootstock/transaction','address':'/rootstock/address'}}]
+NEXT_PUBLIC_NETWORK_ICON=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/rootstock-short.svg
+NEXT_PUBLIC_NETWORK_ID=30
+NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/rootstock.svg
+NEXT_PUBLIC_NETWORK_NAME=Rootstock
+NEXT_PUBLIC_NETWORK_RPC_URL=https://public-node.rsk.co
+NEXT_PUBLIC_NETWORK_SHORT_NAME=Rootstock
+NEXT_PUBLIC_OG_ENHANCED_DATA_ENABLED=true
+NEXT_PUBLIC_OG_IMAGE_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/og-images/rootstock-mainnet.png
+NEXT_PUBLIC_STATS_API_HOST=https://stats-rsk-mainnet.k8s.blockscout.com
+NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER=blockscout
+NEXT_PUBLIC_VIEWS_BLOCK_HIDDEN_FIELDS=['burnt_fees','total_reward','nonce']
+NEXT_PUBLIC_VIEWS_CONTRACT_SOLIDITYSCAN_ENABLED=true
+NEXT_PUBLIC_VISUALIZE_API_HOST=https://visualizer.services.blockscout.com
+NEXT_PUBLIC_AUTH0_CLIENT_ID=IKXYLNc63mUFaoOOIJty7WnNyOgnmbiD
+NEXT_PUBLIC_GIT_COMMIT_SHA=758ca379
+NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN=4b03b67c70939e1e9e893e11b280c700
+NEXT_PUBLIC_SENTRY_DSN=https://fdcd971162e04694bf03564c5be3d291@o1222505.ingest.sentry.io/4503902500421632
+NEXT_PUBLIC_API_HOST=rootstock.blockscout.com
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_I=54b4b0f483e61045e7cf9ae9f4d8dd05
+NEXT_PUBLIC_RE_CAPTCHA_APP_SITE_KEY=6Ld0iT8aAAAAAJdju0CmAwGjW7JTDvIw-Q5pwt5T
+NEXT_PUBLIC_AUTH_URL=https://rootstock.blockscout.com
+NEXT_PUBLIC_GROWTH_BOOK_CLIENT_KEY=sdk-xrQnVZ1EB2Ty7RCh
+NEXT_PUBLIC_VIEWS_CONTRACT_SOLIDITYSCAN_ENABLED=true
+NEXT_PUBLIC_CONTRACT_INFO_API_HOST=https://contracts-info.services.blockscout.com
+NEXT_PUBLIC_OG_IMAGE_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/og-images/rootstock-mainnet.png
+NEXT_PUBLIC_HAS_CONTRACT_AUDIT_REPORTS=true
+NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS=[{'text':'Swap','icon':'swap','url':'https://app.symbiosis.finance/swap?chainIn=Rootstock&tokenIn=RBTC'},{'text':'RNS','icon':'ENS','url':'https://manager.rns.rifos.org'},{'text':'Bridge','icon':'transactions','url':'https://powpeg.rootstock.io'},{'text':'Get gas','icon':'gas','url':'https://rootstock.io/rbtc'}]


### PR DESCRIPTION
## Description

Enable `Blockscout Defi` button for Rootstock network. This change is made for https://rootstock.blockscout.com


### Additional Information

Use this env variable to update https://rootstock.blockscout.com env file to enable `Blockscout Defi` button for Rootstock.

```
NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS=[{'text':'Swap','icon':'swap','url':'https://app.symbiosis.finance/swap?chainIn=Rootstock&tokenIn=RBTC'},{'text':'RNS','icon':'ENS','url':'https://manager.rns.rifos.org'},{'text':'Bridge','icon':'transactions','url':'https://powpeg.rootstock.io'},{'text':'Get gas','icon':'gas','url':'https://rootstock.io/rbtc'}]
```

Meanwhile we are visiting blockscout dApp integration guide: https://docs.blockscout.com/using-blockscout/blockscout-apps/dapp-integration  to make these links iframe compatible. For this first phase of integration just enable the button with external links. 

## Checklist for PR author
- [X] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request

## Demo
<img width="1512" alt="Screenshot 2024-09-16 at 12 10 46 PM" src="https://github.com/user-attachments/assets/7b72f920-2701-4b92-9894-57b9d77ac314">

