### PR TITLE
Typo corrections Update CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,7 +66,7 @@ B. Pre-defined configuration:
 ## Adding new dependencies
 For all types of dependencies:
 - **Do not add** a dependency if the desired functionality is easily implementable
-- If adding a dependency is necessary, please be sure that is is well-maintained and trustworthy
+- If adding a dependency is necessary, please be sure that it is well-maintained and trustworthy
 
 &nbsp;
 


### PR DESCRIPTION
<img width="753" alt="Снимок экрана 2024-11-04 в 13 05 53" src="https://github.com/user-attachments/assets/f3e2260c-7b48-4b59-ac84-8a6fb194542c">

In the section Adding new dependencies, the sentence "please be sure that is is well-maintained and trustworthy" contains a typo: "is is" corrected to "**it is**".