### PR TITLE
Implemented an interpretation stub for failed transactions

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/frontend.iml
+++ b/.idea/frontend.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/frontend.iml" filepath="$PROJECT_DIR$/.idea/frontend.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/ui/pages/Transaction.tsx
+++ b/ui/pages/Transaction.tsx
@@ -113,7 +113,24 @@ const TransactionPageContent = () => {
     if (isCustomAppError(error)) {
       throwOnResourceLoadError({ resource: 'tx', error, isError: true });
     }
-  }
+  } else {
+          // Display a specific failure message for failed transactions
+          return (
+            <div>
+              <TextAd mb={ 6 }/>
+              <PageTitle
+                title="Transaction details"
+                backLink={ backLink }
+                contentAfter={ tags }
+                secondRow={ titleSecondRow }
+              />
+              <p style={{ color: 'red', fontWeight: 'bold', marginTop: '20px' }}>
+                Address failed to call method on address.
+              </p>
+            </div>
+          );
+        }
+      }
 
   return (
     <>


### PR DESCRIPTION
## In this adjusted code:

-  If an error occurs and showDegradedView is false, the code checks whether the error is custom. If not, it displays the message "**Address failed to call method on address**" in bold, red text.

- The error message is wrapped in a div alongside other content like the `TextAd` and `PageTitle`, ensuring the page structure is consistent.