### PR TITLE
fix(deploy-script): favicon generator

### DIFF
--- a/deploy/scripts/favicon_generator.sh
+++ b/deploy/scripts/favicon_generator.sh
@@ -4,7 +4,8 @@ master_url="${FAVICON_MASTER_URL:-$NEXT_PUBLIC_NETWORK_ICON}"
 export MASTER_URL="$master_url"
 
 cd ./deploy/tools/favicon-generator
-node "$(dirname "$0")/index.js"
+yarn install --frozen-lockfile
+node "$(pwd)/index.js"
 if [ $? -ne 0 ]; then
     cd ../../../
     exit 1


### PR DESCRIPTION
## Description and Related Issue(s)

Without this change, the script tries to execute an `index.js` located in a folder that does not have such a file.

### Proposed Changes

Use the correct folder, that is, the current working directory, to run the favicon generator.

### Breaking or Incompatible Changes

None.

### Additional Information

Running the script now also triggers a `yarn install` in the relevant directory.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
