### PR TITLE
fix: resolve type error in select component Chakra styles

### DIFF
--- a/ui/shared/forms/inputs/select/utils.ts
+++ b/ui/shared/forms/inputs/select/utils.ts
@@ -59,14 +59,14 @@ const getChakraStyles: (colorMode: ColorMode) => ChakraStylesConfig<Option> = (c
     }),
     valueContainer: (provided, state) => ({
       ...provided,
-      ...getValueContainerStyles(state.selectProps.size),
+      ...getValueContainerStyles(state.selectProps.size as Size | undefined), // Explicitly cast here
       py: 0,
     }),
     singleValue: (provided, state) => ({
       ...provided,
       mx: 0,
       transform: 'none',
-      ...getSingleValueStyles(state.selectProps.size),
+      ...getSingleValueStyles(state.selectProps.size as Size | undefined), // Explicitly cast here
     }),
   };
 };


### PR DESCRIPTION
fix: resolve type error in select component Chakra styles

- Updated utils.ts to explicitly cast `state.selectProps.size` to `Size | undefined` in `getValueContainerStyles` and `getSingleValueStyles`.
- Fixed TypeScript compatibility issues related to `SizeProp` and `Size` types.
- Ensured proper typing for Chakra styles in the select component.

This fix addresses TypeScript errors during `npx tsc --noEmit` and improves type safety.


## Description and Related Issue(s)

This pull request resolves TypeScript type errors in the `chakra-react-select` styles used in the select component. The errors were caused by an incompatible type assignment in `getValueContainerStyles` and `getSingleValueStyles`, specifically the `state.selectProps.size` property. 

### Proposed Changes

- Updated `utils.ts` to explicitly cast `state.selectProps.size` to `Size | undefined` in the `valueContainer` and `singleValue` Chakra styles.
- Ensured TypeScript compatibility and type safety by aligning with the expected `Size` type.
- No changes were made to the environment variables.

### Breaking or Incompatible Changes

No breaking or incompatible changes are introduced by this pull request. Existing functionality remains unchanged, and these updates only fix type-related issues.

### Additional Information

These updates ensure that the project passes the `npx tsc --noEmit` check without errors. The changes do not affect runtime behavior but enhance code stability and developer experience by resolving type conflicts.

## Checklist for PR author
- [x] I have tested these changes locally.

