### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -545,7 +545,7 @@ This feature is **always enabled**, but you can disable it by passing `none` val
 | url | `string` | URL of the app which will be launched in the iframe. | Required | `'https://foo.app/launch'` |
 | description | `string` | Displayed only in the modal dialog with additional info about the app. | Required | `'The best app'` |
 | site | `string` | Displayed site link | - | `'https://blockscout.com'` |
-| twitter | `string` | Displayed twitter link | - | `'https://twitter.com/blockscoutcom'` |
+| twitter | `string` | Displayed twitter link | - | `'https://x.com/blockscoutcom'` |
 | telegram | `string`  | Displayed telegram link | - | `'https://t.me/poa_network'` |
 | github | `string` | Displayed github link | - | `'https://github.com/blockscout'` |
 | internalWallet | `boolean` | `true` means that the application can automatically connect to the Blockscout wallet. | - | `true` |

--- a/mocks/account/verifiedAddresses.ts
+++ b/mocks/account/verifiedAddresses.ts
@@ -95,7 +95,7 @@ export const TOKEN_INFO_APPLICATION_BASE = {
   linkedin: 'https://linkedin.com',
   discord: 'https://discord.com',
   slack: 'https://slack.com',
-  twitter: 'https://twitter.com',
+  twitter: 'https://x.com',
   openSea: 'https://opensea.com',
   facebook: 'https://facebook.com',
   medium: 'https://medium.com',

--- a/mocks/apps/apps.ts
+++ b/mocks/apps/apps.ts
@@ -13,7 +13,7 @@ export const apps = [
     url: 'https://goerli.hop.exchange/send?token=ETH&sourceNetwork=ethereum',
     github: [ 'https://github.com/hop-protocol/hop', 'https://github.com/hop-protocol/hop-ui' ],
     discord: 'https://discord.gg/hopprotocol',
-    twitter: 'https://twitter.com/HopProtocol',
+    twitter: 'https://x.com/HopProtocol',
   },
   {
     author: 'Blockscout',

--- a/mocks/tokens/tokenInstance.ts
+++ b/mocks/tokens/tokenInstance.ts
@@ -46,7 +46,7 @@ export const base: TokenInstance = {
       },
       {
         trait_type: 'eventURL',
-        value: 'https://twitter.com/lilnounsdao?s=21&t=xAihrtwPd6avwdsQqeMXCw',
+        value: 'https://x.com/lilnounsdao?s=21&t=xAihrtwPd6avwdsQqeMXCw',
       },
       {
         trait_type: 'p1',

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -9,7 +9,7 @@ export type ExcludeUndefined<T> = T extends undefined ? never : T;
 export type KeysOfObjectOrNull<T> = keyof ExcludeNull<T>;
 
 /** Combines members of an intersection into a readable type. */
-// https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg
+// https://x.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg
 export type Evaluate<Type> = { [key in keyof Type]: Type[key] } & unknown;
 
 // Keeps in the object type only those properties that have the provided type (e.g only numbers)


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.

