### PR TITLE
Update package.json version to match latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockscout-frontend",
-  "version": "1.0.0",
+  "version": "1.37.6",
   "private": false,
   "homepage": "https://github.com/blockscout/frontend#readme",
   "engines": {


### PR DESCRIPTION
## Description and Related Issue(s)

We vendor the code of the Blockscout frontend on our side without storing the `.git` folder or any commit/tag data, so it's helpful to know what version the frontend is without that

### Proposed Changes

Sets `version` in `package.json` to match the version of the latest release on the releases page

https://github.com/blockscout/frontend/releases

### Breaking or Incompatible Changes

Assuming this field has never really been used before since it's always been 1.0.0?
