### PR TITLE
Feat/twine integration

### DIFF
--- a/lib/api/resources.ts
+++ b/lib/api/resources.ts
@@ -138,7 +138,7 @@ import type {
   TransactionsResponseWithBlobs,
   TransactionsStats,
 } from 'types/api/transaction';
-import type { TwineL2DepositsResponse } from 'types/api/twineL2';
+import type { TwineL2DepositsResponse, TwineL2WithdrawalsResponse } from 'types/api/twineL2';
 import type { TxInterpretationResponse } from 'types/api/txInterpretation';
 import type { TTxsFilters, TTxsWithBlobsFilters } from 'types/api/txsFilters';
 import type { TxStateChanges } from 'types/api/txStateChanges';
@@ -1047,6 +1047,11 @@ export const RESOURCES = {
     filterFields: [],
   },
 
+  twine_l2_withdrawals: {
+    path: '/api/v2/twine/l1_withdraws',
+    filterFields: [],
+  },
+
   // NOVES-FI
   noves_transaction: {
     path: '/api/v2/proxy/noves-fi/transactions/:hash',
@@ -1246,7 +1251,7 @@ export type PaginatedResources = 'blocks' | 'block_txs' | 'block_election_reward
 'watchlist' | 'private_tags_address' | 'private_tags_tx' |
 'domains_lookup' | 'addresses_lookup' | 'user_ops' | 'validators_stability' | 'validators_blackfort' | 'noves_address_history' |
 'token_transfers_all' | 'scroll_l2_txn_batches' | 'scroll_l2_txn_batch_txs' | 'scroll_l2_txn_batch_blocks' |
-'scroll_l2_deposits' | 'scroll_l2_withdrawals' | 'advanced_filter' | 'pools' | 'twine_l2_deposits';
+'scroll_l2_deposits' | 'scroll_l2_withdrawals' | 'advanced_filter' | 'pools' | 'twine_l2_deposits' | 'twine_l2_withdrawals';
 
 export type PaginatedResponse<Q extends PaginatedResources> = ResourcePayload<Q>;
 
@@ -1443,6 +1448,7 @@ Q extends 'advanced_filter_methods' ? AdvancedFilterMethodsResponse :
 Q extends 'pools' ? PoolsResponse :
 Q extends 'pool' ? Pool :
 Q extends 'twine_l2_deposits' ? TwineL2DepositsResponse :
+Q extends 'twine_l2_withdrawals' ? TwineL2WithdrawalsResponse :
 never;
 /* eslint-enable @stylistic/indent */
 

--- a/lib/api/resources.ts
+++ b/lib/api/resources.ts
@@ -138,6 +138,7 @@ import type {
   TransactionsResponseWithBlobs,
   TransactionsStats,
 } from 'types/api/transaction';
+import type { TwineL2DepositsResponse } from 'types/api/twineL2';
 import type { TxInterpretationResponse } from 'types/api/txInterpretation';
 import type { TTxsFilters, TTxsWithBlobsFilters } from 'types/api/txsFilters';
 import type { TxStateChanges } from 'types/api/txStateChanges';
@@ -1040,6 +1041,12 @@ export const RESOURCES = {
     filterFields: [],
   },
 
+  // TWINE L2
+  twine_l2_deposits: {
+    path: '/api/v2/twine/l1_deposits',
+    filterFields: [],
+  },
+
   // NOVES-FI
   noves_transaction: {
     path: '/api/v2/proxy/noves-fi/transactions/:hash',
@@ -1239,7 +1246,7 @@ export type PaginatedResources = 'blocks' | 'block_txs' | 'block_election_reward
 'watchlist' | 'private_tags_address' | 'private_tags_tx' |
 'domains_lookup' | 'addresses_lookup' | 'user_ops' | 'validators_stability' | 'validators_blackfort' | 'noves_address_history' |
 'token_transfers_all' | 'scroll_l2_txn_batches' | 'scroll_l2_txn_batch_txs' | 'scroll_l2_txn_batch_blocks' |
-'scroll_l2_deposits' | 'scroll_l2_withdrawals' | 'advanced_filter' | 'pools';
+'scroll_l2_deposits' | 'scroll_l2_withdrawals' | 'advanced_filter' | 'pools' | 'twine_l2_deposits';
 
 export type PaginatedResponse<Q extends PaginatedResources> = ResourcePayload<Q>;
 
@@ -1435,6 +1442,7 @@ Q extends 'advanced_filter' ? AdvancedFilterResponse :
 Q extends 'advanced_filter_methods' ? AdvancedFilterMethodsResponse :
 Q extends 'pools' ? PoolsResponse :
 Q extends 'pool' ? Pool :
+Q extends 'twine_l2_deposits' ? TwineL2DepositsResponse :
 never;
 /* eslint-enable @stylistic/indent */
 

--- a/lib/hooks/useNavItems.tsx
+++ b/lib/hooks/useNavItems.tsx
@@ -113,7 +113,8 @@ export default function useNavItems(): ReturnType {
       rollupFeature.type === 'optimistic' ||
       rollupFeature.type === 'arbitrum' ||
       rollupFeature.type === 'zkEvm' ||
-      rollupFeature.type === 'scroll'
+      rollupFeature.type === 'scroll' ||
+      rollupFeature.type === 'twine'
     )) {
       blockchainNavItems = [
         [

--- a/nextjs/getServerSideProps.ts
+++ b/nextjs/getServerSideProps.ts
@@ -78,7 +78,7 @@ export const deposits: GetServerSideProps<Props> = async(context) => {
   return base(context);
 };
 
-const WITHDRAWALS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll' ];
+const WITHDRAWALS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll', 'twine' ];
 export const withdrawals: GetServerSideProps<Props> = async(context) => {
   if (
     !config.features.beaconChain.isEnabled &&

--- a/nextjs/getServerSideProps.ts
+++ b/nextjs/getServerSideProps.ts
@@ -67,7 +67,7 @@ export const verifiedAddresses: GetServerSideProps<Props> = async(context) => {
   return account(context);
 };
 
-const DEPOSITS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll' ];
+const DEPOSITS_ROLLUP_TYPES: Array<RollupType> = [ 'optimistic', 'shibarium', 'zkEvm', 'arbitrum', 'scroll', 'twine' ];
 export const deposits: GetServerSideProps<Props> = async(context) => {
   if (!(rollupFeature.isEnabled && DEPOSITS_ROLLUP_TYPES.includes(rollupFeature.type))) {
     return {

--- a/pages/deposits/index.tsx
+++ b/pages/deposits/index.tsx
@@ -28,6 +28,10 @@ const Deposits = dynamic(() => {
     return import('ui/pages/ScrollL2Deposits');
   }
 
+  if (rollupFeature.isEnabled && rollupFeature.type === 'twine') {
+    return import('ui/pages/TwineL2Deposits');
+  }
+
   throw new Error('Deposits feature is not enabled.');
 }, { ssr: false });
 

--- a/pages/withdrawals/index.tsx
+++ b/pages/withdrawals/index.tsx
@@ -33,6 +33,10 @@ const Withdrawals = dynamic(() => {
     return import('ui/pages/BeaconChainWithdrawals');
   }
 
+  if (rollupFeature.isEnabled && rollupFeature.type === 'twine') {
+    return import('ui/pages/TwineL2Withdrawals');
+  }
+
   throw new Error('Withdrawals feature is not enabled.');
 }, { ssr: false });
 

--- a/stubs/twineL2.ts
+++ b/stubs/twineL2.ts
@@ -7,7 +7,20 @@ export const TWINE_DEPOSITS_ITEM: TwineL2DepositsItem = {
   block_number: 671,
   l1_token: '0x0000000000000000000000000000000000000000',
   l2_token: '0xa8d297d643a11ce83b432e87eebce6bee0fd2bab',
-  from_address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  from: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  to_twine_address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  amount: '1500000000000000000',
+  created_at: '2025-02-04T08:00:12.123456Z',
+};
+
+export const TWINE_WITHDRAWAL_ITEM: TwineL2DepositsItem = {
+  tx_hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  nonce: 26,
+  chain_id: 17000,
+  block_number: 671,
+  l1_token: '0x0000000000000000000000000000000000000000',
+  l2_token: '0xa8d297d643a11ce83b432e87eebce6bee0fd2bab',
+  from: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   to_twine_address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   amount: '1500000000000000000',
   created_at: '2025-02-04T08:00:12.123456Z',

--- a/stubs/twineL2.ts
+++ b/stubs/twineL2.ts
@@ -1,0 +1,14 @@
+import type { TwineL2DepositsItem } from 'types/api/twineL2';
+
+export const TWINE_DEPOSITS_ITEM: TwineL2DepositsItem = {
+  tx_hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  nonce: 26,
+  chain_id: 17000,
+  block_number: 671,
+  l1_token: '0x0000000000000000000000000000000000000000',
+  l2_token: '0xa8d297d643a11ce83b432e87eebce6bee0fd2bab',
+  from_address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  to_twine_address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  amount: '1500000000000000000',
+  created_at: '2025-02-04T08:00:12.123456Z',
+};

--- a/types/api/twineL2.ts
+++ b/types/api/twineL2.ts
@@ -1,0 +1,21 @@
+export type TwineL2DepositsItem = {
+  tx_hash: string;
+  nonce: number;
+  chain_id: number;
+  block_number: number;
+  l1_token: string;
+  l2_token: string;
+  from_address: string;
+  to_twine_address: string;
+  amount: string;
+  created_at: string;
+};
+
+export type TwineL2DepositsResponse = {
+  items: Array<TwineL2DepositsItem>;
+  next_page_params: {
+    items_count: number;
+    l1_block_number: number;
+    transaction_hash: string;
+  };
+};

--- a/types/api/twineL2.ts
+++ b/types/api/twineL2.ts
@@ -5,7 +5,7 @@ export type TwineL2DepositsItem = {
   block_number: number;
   l1_token: string;
   l2_token: string;
-  from_address: string;
+  from: string;
   to_twine_address: string;
   amount: string;
   created_at: string;
@@ -17,5 +17,26 @@ export type TwineL2DepositsResponse = {
     items_count: number;
     l1_block_number: number;
     transaction_hash: string;
+  };
+};
+
+export type TwineL2WithdrawalsItem = {
+  tx_hash: string;
+  nonce: number;
+  chain_id: number;
+  block_number: number;
+  l1_token: string;
+  l2_token: string;
+  from: string;
+  to_twine_address: string;
+  amount: string;
+  created_at: string;
+};
+
+export type TwineL2WithdrawalsResponse = {
+  items: Array<TwineL2WithdrawalsItem>;
+  next_page_params: {
+    items_count: number;
+    nonce: string;
   };
 };

--- a/types/client/rollup.ts
+++ b/types/client/rollup.ts
@@ -7,6 +7,7 @@ export const ROLLUP_TYPES = [
   'zkEvm',
   'zkSync',
   'scroll',
+  'twine',
 ] as const;
 
 export type RollupType = ArrayElement<typeof ROLLUP_TYPES>;

--- a/ui/deposits/twine/TwineDepositsListItem.tsx
+++ b/ui/deposits/twine/TwineDepositsListItem.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import type { TwineL2DepositsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
+import AddressEntity from 'ui/shared/entities/address/AddressEntity';
 import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
 import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
@@ -73,7 +74,7 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
       <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
         <AddressEntityL1
-          address={{ hash: item.from_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          address={{ hash: item.from, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
           noCopy
           truncation="constant"
@@ -81,7 +82,7 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>To (Twine Address)</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
+        <AddressEntity
           address={{ hash: item.to_twine_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
           noCopy

--- a/ui/deposits/twine/TwineDepositsListItem.tsx
+++ b/ui/deposits/twine/TwineDepositsListItem.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import type { TwineL2DepositsItem } from 'types/api/twineL2';
+
+import config from 'configs/app';
+import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
+import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
+import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import ListItemMobileGrid from 'ui/shared/ListItemMobile/ListItemMobileGrid';
+import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
+
+const rollupFeature = config.features.rollup;
+
+type Props = { item: TwineL2DepositsItem; isLoading?: boolean };
+
+const TwineDepositsListItem = ({ item, isLoading }: Props) => {
+  if (!rollupFeature.isEnabled || rollupFeature.type !== 'twine') {
+    return null;
+  }
+
+  return (
+    <ListItemMobileGrid.Container>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Block number</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <BlockEntityL1
+          number={ item.block_number }
+          isLoading={ isLoading }
+          fontSize="sm"
+          lineHeight={ 5 }
+          fontWeight={ 600 }
+        />
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <TxEntity
+          isLoading={ isLoading }
+          hash={ item.tx_hash }
+          fontSize="sm"
+          lineHeight={ 5 }
+          truncation="constant_long"
+        />
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Age</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <TimeAgoWithTooltip
+          timestamp={ item.created_at }
+          isLoading={ isLoading }
+          display="inline-block"
+        />
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Token Address</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <AddressEntityL1
+          address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          noCopy
+          truncation="constant"
+        />
+      </ListItemMobileGrid.Value>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Token Address</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <AddressEntityL1
+          address={{ hash: item.l2_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          noCopy
+          truncation="constant"
+        />
+      </ListItemMobileGrid.Value>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <AddressEntityL1
+          address={{ hash: item.from_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          noCopy
+          truncation="constant"
+        />
+      </ListItemMobileGrid.Value>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>To (Twine Address)</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <AddressEntityL1
+          address={{ hash: item.to_twine_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          noCopy
+          truncation="constant"
+        />
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Amount</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        { item.amount }
+      </ListItemMobileGrid.Value>
+
+    </ListItemMobileGrid.Container>
+  );
+};
+
+export default TwineDepositsListItem;

--- a/ui/deposits/twine/TwineDepositsTable.tsx
+++ b/ui/deposits/twine/TwineDepositsTable.tsx
@@ -1,0 +1,39 @@
+import { Table, Tbody, Th, Tr } from '@chakra-ui/react';
+import React from 'react';
+
+import type { TwineL2DepositsItem } from 'types/api/twineL2';
+
+import { default as Thead } from 'ui/shared/TheadSticky';
+
+import TwineDepositsTableItem from './TwineDepositsTableItem';
+
+ type Props = {
+   items: Array<TwineL2DepositsItem>;
+   top: number;
+   isLoading?: boolean;
+ };
+
+const TwineDepositsTable = ({ items, top, isLoading }: Props) => {
+  return (
+    <Table style={{ tableLayout: 'auto' }} minW="950px">
+      <Thead top={ top }>
+        <Tr>
+          <Th>Block No.</Th>
+          <Th>Txn hash</Th>
+          <Th>Age</Th>
+          <Th>L1 Token Address</Th>
+          <Th>L2 Token Address</Th>
+          <Th>From</Th>
+          <Th>To</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        { items.map((item, index) => (
+          <TwineDepositsTableItem key={ item.tx_hash + (isLoading ? index : '') } item={ item } isLoading={ isLoading }/>
+        )) }
+      </Tbody>
+    </Table>
+  );
+};
+
+export default TwineDepositsTable;

--- a/ui/deposits/twine/TwineDepositsTableItem.tsx
+++ b/ui/deposits/twine/TwineDepositsTableItem.tsx
@@ -1,0 +1,90 @@
+import { Td, Tr } from '@chakra-ui/react';
+import React from 'react';
+
+import type { TwineL2DepositsItem } from 'types/api/twineL2';
+
+import config from 'configs/app';
+import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
+import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
+import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
+
+const rollupFeature = config.features.rollup;
+
+ type Props = { item: TwineL2DepositsItem; isLoading?: boolean };
+
+const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
+
+  if (!rollupFeature.isEnabled || rollupFeature.type !== 'twine') {
+    return null;
+  }
+
+  return (
+    <Tr>
+      <Td verticalAlign="middle">
+        <BlockEntityL1
+          number={ item.block_number }
+          isLoading={ isLoading }
+          fontSize="sm"
+          lineHeight={ 5 }
+          fontWeight={ 600 }
+          noIcon
+        />
+      </Td>
+      <Td verticalAlign="middle">
+        <TxEntity
+          isLoading={ isLoading }
+          hash={ item.tx_hash }
+          fontSize="sm"
+          lineHeight={ 5 }
+          truncation="constant_long"
+          noIcon
+        />
+      </Td>
+      <Td verticalAlign="middle" pr={ 12 }>
+        <TimeAgoWithTooltip
+          timestamp={ item.created_at }
+          isLoading={ isLoading }
+          color="text_secondary"
+          display="inline-block"
+        />
+      </Td>
+
+      <Td verticalAlign="middle">
+        <AddressEntityL1
+          address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          truncation="constant"
+          noCopy
+        />
+      </Td>
+      <Td verticalAlign="middle">
+        <AddressEntityL1
+          address={{ hash: item.l2_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          truncation="constant"
+          noCopy
+        />
+      </Td>
+      <Td verticalAlign="middle">
+        <AddressEntityL1
+          address={{ hash: item.from_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          truncation="constant"
+          noCopy
+        />
+      </Td>
+      <Td verticalAlign="middle">
+        <AddressEntityL1
+          address={{ hash: item.to_twine_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
+          isLoading={ isLoading }
+          truncation="constant"
+          noCopy
+        />
+      </Td>
+
+    </Tr>
+  );
+};
+
+export default TwineDepositsTableItem;

--- a/ui/pages/TwineL2Deposits.tsx
+++ b/ui/pages/TwineL2Deposits.tsx
@@ -1,0 +1,62 @@
+import { Hide, Show } from '@chakra-ui/react';
+import React from 'react';
+
+import { rightLineArrow, nbsp } from 'lib/html-entities';
+import { TWINE_DEPOSITS_ITEM } from 'stubs/twineL2';
+import { generateListStub } from 'stubs/utils';
+import TwineDepositsListItem from 'ui/deposits/twine/TwineDepositsListItem';
+import TwineDepositsTable from 'ui/deposits/twine/TwineDepositsTable';
+import { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
+import DataListDisplay from 'ui/shared/DataListDisplay';
+import PageTitle from 'ui/shared/Page/PageTitle';
+import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
+
+const TwineL2Deposits = () => {
+  const { data, isError, isPlaceholderData, pagination } = useQueryWithPages({
+    resourceName: 'twine_l2_deposits',
+    options: {
+      placeholderData: generateListStub<'twine_l2_deposits'>(
+        TWINE_DEPOSITS_ITEM,
+        50,
+        {
+          next_page_params: {
+            items_count: 50,
+            l1_block_number: 9045200,
+            transaction_hash: '',
+          },
+        },
+      ),
+    },
+  });
+
+  const content = data?.items ? (
+    <>
+      <Show below="lg" ssr={ false }>
+        { data.items.map(((item, index) => (
+          <TwineDepositsListItem
+            key={ item.tx_hash + (isPlaceholderData ? index : '') }
+            isLoading={ isPlaceholderData }
+            item={ item }
+          />
+        ))) }
+      </Show>
+      <Hide below="lg" ssr={ false }>
+        <TwineDepositsTable items={ data.items } top={ pagination.isVisible ? ACTION_BAR_HEIGHT_DESKTOP : 0 } isLoading={ isPlaceholderData }/>
+      </Hide>
+    </>
+  ) : null;
+
+  return (
+    <>
+      <PageTitle title={ `Deposits (L1${ nbsp }${ rightLineArrow }${ nbsp }L2)` } withTextAd/>
+      <DataListDisplay
+        isError={ isError }
+        items={ data?.items }
+        emptyText="There are no deposits."
+        content={ content }
+      />
+    </>
+  );
+};
+
+export default TwineL2Deposits;

--- a/ui/pages/TwineL2Withdrawals.tsx
+++ b/ui/pages/TwineL2Withdrawals.tsx
@@ -1,0 +1,61 @@
+import { Hide, Show } from '@chakra-ui/react';
+import React from 'react';
+
+import { rightLineArrow, nbsp } from 'lib/html-entities';
+import { TWINE_WITHDRAWAL_ITEM } from 'stubs/twineL2';
+import { generateListStub } from 'stubs/utils';
+import TwineDepositsListItem from 'ui/deposits/twine/TwineDepositsListItem';
+import TwineDepositsTable from 'ui/deposits/twine/TwineDepositsTable';
+import { ACTION_BAR_HEIGHT_DESKTOP } from 'ui/shared/ActionBar';
+import DataListDisplay from 'ui/shared/DataListDisplay';
+import PageTitle from 'ui/shared/Page/PageTitle';
+import useQueryWithPages from 'ui/shared/pagination/useQueryWithPages';
+
+const TwineL2Withdrawals = () => {
+  const { data, isError, isPlaceholderData, pagination } = useQueryWithPages({
+    resourceName: 'twine_l2_withdrawals',
+    options: {
+      placeholderData: generateListStub<'twine_l2_withdrawals'>(
+        TWINE_WITHDRAWAL_ITEM,
+        50,
+        {
+          next_page_params: {
+            items_count: 50,
+            nonce: '',
+          },
+        },
+      ),
+    },
+  });
+
+  const content = data?.items ? (
+    <>
+      <Show below="lg" ssr={ false }>
+        { data.items.map(((item, index) => (
+          <TwineDepositsListItem
+            key={ item.tx_hash + (isPlaceholderData ? index : '') }
+            isLoading={ isPlaceholderData }
+            item={ item }
+          />
+        ))) }
+      </Show>
+      <Hide below="lg" ssr={ false }>
+        <TwineDepositsTable items={ data.items } top={ pagination.isVisible ? ACTION_BAR_HEIGHT_DESKTOP : 0 } isLoading={ isPlaceholderData }/>
+      </Hide>
+    </>
+  ) : null;
+
+  return (
+    <>
+      <PageTitle title={ `Withdrawals (L2${ nbsp }${ rightLineArrow }${ nbsp }L1)` } withTextAd/>
+      <DataListDisplay
+        isError={ isError }
+        items={ data?.items }
+        emptyText="There are no withdrawals."
+        content={ content }
+      />
+    </>
+  );
+};
+
+export default TwineL2Withdrawals;

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsListItem.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsListItem.tsx
@@ -1,91 +1,102 @@
-import { Td, Tr } from '@chakra-ui/react';
 import React from 'react';
 
-import type { TwineL2DepositsItem } from 'types/api/twineL2';
+import type { TwineL2WithdrawalsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
 import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
 import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import ListItemMobileGrid from 'ui/shared/ListItemMobile/ListItemMobileGrid';
 import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
 
 const rollupFeature = config.features.rollup;
 
- type Props = { item: TwineL2DepositsItem; isLoading?: boolean };
+type Props = { item: TwineL2WithdrawalsItem; isLoading?: boolean };
 
-const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
-
+const TwineWithdrawalsListItem = ({ item, isLoading }: Props) => {
   if (!rollupFeature.isEnabled || rollupFeature.type !== 'twine') {
     return null;
   }
 
   return (
-    <Tr>
-      <Td verticalAlign="middle">
+    <ListItemMobileGrid.Container>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Block number</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
         <BlockEntityL1
           number={ item.block_number }
           isLoading={ isLoading }
           fontSize="sm"
           lineHeight={ 5 }
           fontWeight={ 600 }
-          noIcon
         />
-      </Td>
-      <Td verticalAlign="middle">
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
         <TxEntity
           isLoading={ isLoading }
           hash={ item.tx_hash }
           fontSize="sm"
           lineHeight={ 5 }
           truncation="constant_long"
-          noIcon
         />
-      </Td>
-      <Td verticalAlign="middle" pr={ 12 }>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Age</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
         <TimeAgoWithTooltip
           timestamp={ item.created_at }
           isLoading={ isLoading }
-          color="text_secondary"
           display="inline-block"
         />
-      </Td>
+      </ListItemMobileGrid.Value>
 
-      <Td verticalAlign="middle">
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Token Address</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
         <AddressEntityL1
           address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
-          truncation="constant"
           noCopy
+          truncation="constant"
         />
-      </Td>
-      <Td verticalAlign="middle">
-        <AddressEntity
+      </ListItemMobileGrid.Value>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Token Address</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <AddressEntityL1
           address={{ hash: item.l2_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
-          truncation="constant"
           noCopy
+          truncation="constant"
         />
-      </Td>
-      <Td verticalAlign="middle">
+      </ListItemMobileGrid.Value>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
         <AddressEntityL1
           address={{ hash: item.from, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
-          truncation="constant"
           noCopy
+          truncation="constant"
         />
-      </Td>
-      <Td verticalAlign="middle">
+      </ListItemMobileGrid.Value>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>To (Twine Address)</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
         <AddressEntity
           address={{ hash: item.to_twine_address, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
-          truncation="constant"
           noCopy
+          truncation="constant"
         />
-      </Td>
+      </ListItemMobileGrid.Value>
 
-    </Tr>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Amount</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        { item.amount }
+      </ListItemMobileGrid.Value>
+
+    </ListItemMobileGrid.Container>
   );
 };
 
-export default TwineDepositsTableItem;
+export default TwineWithdrawalsListItem;

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsTable.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsTable.tsx
@@ -1,0 +1,39 @@
+import { Table, Tbody, Th, Tr } from '@chakra-ui/react';
+import React from 'react';
+
+import type { TwineL2WithdrawalsItem } from 'types/api/twineL2';
+
+import { default as Thead } from 'ui/shared/TheadSticky';
+
+import TwineWithdrawalsTableItem from './TwineL2WithdrawalsTableItem';
+
+ type Props = {
+   items: Array<TwineL2WithdrawalsItem>;
+   top: number;
+   isLoading?: boolean;
+ };
+
+const TwineDepositsTable = ({ items, top, isLoading }: Props) => {
+  return (
+    <Table style={{ tableLayout: 'auto' }} minW="950px">
+      <Thead top={ top }>
+        <Tr>
+          <Th>Block No.</Th>
+          <Th>Txn hash</Th>
+          <Th>Age</Th>
+          <Th>L1 Token Address</Th>
+          <Th>L2 Token Address</Th>
+          <Th>From</Th>
+          <Th>To</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        { items.map((item, index) => (
+          <TwineWithdrawalsTableItem key={ item.tx_hash + (isLoading ? index : '') } item={ item } isLoading={ isLoading }/>
+        )) }
+      </Tbody>
+    </Table>
+  );
+};
+
+export default TwineDepositsTable;

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsTableItem.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsTableItem.tsx
@@ -1,7 +1,7 @@
 import { Td, Tr } from '@chakra-ui/react';
 import React from 'react';
 
-import type { TwineL2DepositsItem } from 'types/api/twineL2';
+import type { TwineL2WithdrawalsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
@@ -12,9 +12,9 @@ import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
 
 const rollupFeature = config.features.rollup;
 
- type Props = { item: TwineL2DepositsItem; isLoading?: boolean };
+ type Props = { item: TwineL2WithdrawalsItem; isLoading?: boolean };
 
-const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
+const TwineWithdrawalsTableItem = ({ item, isLoading }: Props) => {
 
   if (!rollupFeature.isEnabled || rollupFeature.type !== 'twine') {
     return null;
@@ -88,4 +88,4 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
   );
 };
 
-export default TwineDepositsTableItem;
+export default TwineWithdrawalsTableItem;


### PR DESCRIPTION
## Integrate Twine custom indexer endpoints in blockscout frontend

*[Integrates Twine L2-related data into the Blockscout frontend. Since Blockscout doesn’t natively support Twine, we built a custom indexer, proxied it through the Blockscout backend, and integrated it into the frontend to display Twine-specific data seamlessly.]*

### Checklist  

- [x] Deposit and Withdrawals pages are integrated (structural changes still expected).  
- [ ] Batches page integration is pending.  
