### PR TITLE
Update display tx fee widget in txs stats

### DIFF
--- a/ui/txs/TxsStats.tsx
+++ b/ui/txs/TxsStats.tsx
@@ -105,7 +105,7 @@ const TxsStats = () => {
           isLoading={ isLoading }
         />
       ) }
-      { txFeeSum24h && (
+      { Boolean(txFeeSum24h) && (
         <StatsWidget
           label={ txsStatsQuery.data?.transactions_fee_24h?.title ?
             getLabelFromTitle(txsStatsQuery.data?.transactions_fee_24h?.title) :


### PR DESCRIPTION
## Description and Related Issue(s)

TX fee widget displays 0 when don't have transaction fee

### Evidence
* Before
<img width="1701" alt="Screenshot 2025-03-17 at 15 55 34" src="https://github.com/user-attachments/assets/27d9bb21-158e-4140-a38c-8d74ccfc06ca" />

* After
<img width="1686" alt="Screenshot 2025-03-17 at 15 56 30" src="https://github.com/user-attachments/assets/94862984-6969-42fb-895b-351609450939" />


## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
