### PR TITLE
Encode the address hash for links to the TON chain

### DIFF
--- a/.github/workflows/deploy-review.yml
+++ b/.github/workflows/deploy-review.yml
@@ -33,6 +33,7 @@ on:
             - shibarium
             - scroll_sepolia
             - stability
+            - tac
             - tac_turin
             - zkevm
             - zilliqa_prototestnet

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -383,6 +383,7 @@
               "scroll_sepolia",
               "shibarium",
               "stability_testnet",
+              "tac",
               "tac_turin",
               "zkevm",
               "zilliqa_prototestnet",

--- a/configs/envs/.env.tac
+++ b/configs/envs/.env.tac
@@ -1,0 +1,45 @@
+# Set of ENVs for TAC network explorer
+# https://explorer.tac.build
+# This is an auto-generated file. To update all values, run "yarn dev:preset:sync --name=tac"
+
+# Local ENVs
+NEXT_PUBLIC_APP_PROTOCOL=http
+NEXT_PUBLIC_APP_HOST=localhost
+NEXT_PUBLIC_APP_PORT=3000
+NEXT_PUBLIC_APP_ENV=development
+NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
+
+# Instance ENVs
+NEXT_PUBLIC_ADMIN_SERVICE_API_HOST=https://admin-rs.services.blockscout.com
+NEXT_PUBLIC_API_BASE_PATH=/
+NEXT_PUBLIC_API_HOST=explorer.tac.build
+NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
+NEXT_PUBLIC_CONTRACT_INFO_API_HOST=https://contracts-info.services.blockscout.com
+NEXT_PUBLIC_FOOTER_LINKS=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/footer-links/tac.json
+NEXT_PUBLIC_GAME_BADGE_CLAIM_LINK=https://badges.blockscout.com/mint/sherblockHolmesBadge
+NEXT_PUBLIC_GRAPHIQL_TRANSACTION=0x9e2386a15e263fffc7b481ae1a6b8d71aa94b87c7683b3f2d756bb912622d638
+NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs']
+NEXT_PUBLIC_HOMEPAGE_HERO_BANNER_CONFIG={'background':['no-repeat center/100% auto url(https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-skins/tac.jpg)'],'text_color':['rgba(242,235,255,1)'],'button':{'_default':{'background':['rgba(30,23,44,1)']},'_hover':{'background':['rgba(66,14,70,1)']}}}
+NEXT_PUBLIC_IS_ACCOUNT_SUPPORTED=true
+NEXT_PUBLIC_METADATA_SERVICE_API_HOST=https://metadata.services.blockscout.com
+NEXT_PUBLIC_NAME_SERVICE_API_HOST=https://bens.services.blockscout.com
+NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
+NEXT_PUBLIC_NETWORK_CURRENCY_NAME=TAC
+NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=TAC
+NEXT_PUBLIC_NETWORK_ICON=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/tac-light.svg
+NEXT_PUBLIC_NETWORK_ICON_DARK=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/tac-dark.svg
+NEXT_PUBLIC_NETWORK_ID=239
+NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/tac-light.svg
+NEXT_PUBLIC_NETWORK_LOGO_DARK=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/tac-dark.svg
+NEXT_PUBLIC_NETWORK_NAME=TAC
+NEXT_PUBLIC_NETWORK_RPC_URL=https://rpc.ankr.com/tac
+NEXT_PUBLIC_NETWORK_SHORT_NAME=TAC
+NEXT_PUBLIC_OG_ENHANCED_DATA_ENABLED=true
+NEXT_PUBLIC_OG_IMAGE_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/og-images/tac-turin.png
+NEXT_PUBLIC_STATS_API_BASE_PATH=/stats-service
+NEXT_PUBLIC_STATS_API_HOST=https://explorer.tac.build
+NEXT_PUBLIC_TAC_OPERATION_LIFECYCLE_API_HOST=https://tac-operation-lifecycle.k8s.blockscout.com
+NEXT_PUBLIC_TAC_TON_EXPLORER_URL=https://tonviewer.com
+NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER=blockscout
+NEXT_PUBLIC_VIEWS_TOKEN_SCAM_TOGGLE_ENABLED=true
+NEXT_PUBLIC_VISUALIZE_API_HOST=https://visualizer.services.blockscout.com

--- a/tools/preset-sync/index.ts
+++ b/tools/preset-sync/index.ts
@@ -26,6 +26,7 @@ const PRESETS = {
   scroll_sepolia: 'https://scroll-sepolia.blockscout.com',
   shibarium: 'https://www.shibariumscan.io',
   stability_testnet: 'https://stability-testnet.blockscout.com',
+  tac: 'https://explorer.tac.build',
   tac_turin: 'https://tac-turin.blockscout.com',
   zkevm: 'https://zkevm.blockscout.com',
   zksync: 'https://zksync.blockscout.com',

--- a/ui/shared/entities/address/AddressEntityTacTon.tsx
+++ b/ui/shared/entities/address/AddressEntityTacTon.tsx
@@ -27,7 +27,7 @@ const AddressEntityTacTon = (props: Props) => {
           pathname: '/address/[hash]',
           query: {
             ...props.query,
-            hash: props.address.hash,
+            hash: encodeURIComponent(props.address.hash),
           },
         });
       case tac.BlockchainType.TAC:


### PR DESCRIPTION
## Description and Related Issue(s)

Some TON addresses can contain special characters, so we need to encode them to create the correct link to the TON explorer.

Example of an incorrect link: https://explorer.tac.build/operation/0x8d6da74a1d62eed2435368c7b2b770dc58e27c0ebc42c5d36cb4eb1ec9df04c1

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
