### PR TITLE
Long token transfer value lacks word-break

### DIFF
--- a/ui/shared/TokenTransfer/TokenTransferListItem.tsx
+++ b/ui/shared/TokenTransfer/TokenTransferListItem.tsx
@@ -97,7 +97,7 @@ const TokenTransferListItem = ({
       { valueStr && (
         <Flex columnGap={ 2 } w="100%">
           <Skeleton loading={ isLoading } fontWeight={ 500 } flexShrink={ 0 }>Value</Skeleton>
-          <Skeleton loading={ isLoading } color="text.secondary">
+          <Skeleton loading={ isLoading } color="text.secondary" wordBreak="break-all" overflow="hidden">
             <span>{ valueStr }</span>
             { usd && <span> (${ usd })</span> }
           </Skeleton>


### PR DESCRIPTION
## Description and Related Issue(s)

resolves https://github.com/blockscout/frontend/issues/2434
