### PR TITLE
Add blobs to "img-src" for Helia CSP

### DIFF
--- a/nextjs/csp/policies/helia.ts
+++ b/nextjs/csp/policies/helia.ts
@@ -2,6 +2,8 @@ import type CspDev from 'csp-dev';
 
 import config from 'configs/app';
 
+import { KEY_WORDS } from '../utils';
+
 export function helia(): CspDev.DirectiveDescriptor {
   if (!config.UI.views.nft.verifiedFetch.isEnabled) {
     return {};
@@ -11,6 +13,9 @@ export function helia(): CspDev.DirectiveDescriptor {
     'connect-src': [
       'https://delegated-ipfs.dev',
       'https://trustless-gateway.link',
+    ],
+    'img-src': [
+      KEY_WORDS.BLOB,
     ],
   };
 }


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #2973 

### Proposed Changes
Adds blobs to img-src of the Content Security Policy for Helia.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
