### PR TITLE
cleanup: remove redundant Promise wrapper in multichain config loader

### DIFF
--- a/configs/multichain/config.nodejs.ts
+++ b/configs/multichain/config.nodejs.ts
@@ -25,13 +25,10 @@ function readFileConfig() {
 
 export async function load() {
   if (!value) {
-    return new Promise<MultichainConfig | undefined>((resolve) => {
-      const value = readFileConfig();
-      resolve(value);
-    });
+    return readFileConfig();
   }
 
-  return Promise.resolve(value);
+  return value;
 }
 
 export function getValue() {


### PR DESCRIPTION
## Description and Related Issue(s)
Simplify configs/multichain/config.nodejs.ts by letting the async load() return the cached value or invoke readFileConfig directly, eliminating the unnecessary Promise constructor while preserving behavior.
