### PR TITLE
Remove hover effect on flashblocks table

### DIFF
--- a/ui/blocks/Flashblocks.tsx
+++ b/ui/blocks/Flashblocks.tsx
@@ -32,20 +32,6 @@ const Flashblocks = () => {
     handleFormatChange({ checked: true });
   }, [ handleFormatChange ]);
 
-  const handleMouseEnter = React.useCallback(() => {
-    if (isRealTime && status === 'connected' && !manualModeRef.current) {
-      pause();
-      setIsRealTime(false);
-    }
-  }, [ isRealTime, pause, status ]);
-
-  const handleMouseLeave = React.useCallback(() => {
-    if (!isRealTime && status === 'connected' && !manualModeRef.current) {
-      resume();
-      setIsRealTime(true);
-    }
-  }, [ isRealTime, resume, status ]);
-
   const showAlertError = status === 'error' || status === 'disconnected';
 
   if (!flashblocksFeature.isEnabled) {
@@ -63,7 +49,7 @@ const Flashblocks = () => {
           label={ `Real-time ${ flashblocksFeature.name }s show the latest ${ flashblocksFeature.name }s with real-time updates in the chronological order. ` }
         />
       </HStack>
-      <Box hideBelow="lg" onMouseEnter={ handleMouseEnter } onMouseLeave={ handleMouseLeave }>
+      <Box hideBelow="lg">
         <FlashblocksTable
           items={ items }
           newItemsNum={ newItemsNum }


### PR DESCRIPTION
## Description and Related Issue(s)

Disable the pausing of the real-time feed mode when the user hovers over the flashblocks table.

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
