### PR TITLE
chart fix

### DIFF
--- a/ui/home/indicators/ChainIndicatorChartContent.tsx
+++ b/ui/home/indicators/ChainIndicatorChartContent.tsx
@@ -34,7 +34,7 @@ const ChainIndicatorChartContent = ({ data }: Props) => {
     <svg width="100%" height="100%" ref={ ref } cursor="pointer">
       <g transform={ `translate(${ chartMargin.left || 0 },${ chartMargin.top || 0 })` } opacity={ rect ? 1 : 0 }>
         <ChartArea
-          id={ data[0].name }
+          id={ data[0].id }
           data={ data[0].items }
           xScale={ axes.x.scale }
           yScale={ axes.y.scale }

--- a/ui/home/indicators/ChainIndicators.pw.tsx
+++ b/ui/home/indicators/ChainIndicators.pw.tsx
@@ -25,7 +25,7 @@ test.describe('daily txs chart', () => {
     await mockAssetResponse(statsMock.withSecondaryCoin.secondary_coin_image as string, './playwright/mocks/image_s.jpg');
     component = await render(<ChainIndicators/>);
     await page.waitForFunction(() => {
-      return document.querySelector('path[data-name="Tx/day"]')?.getAttribute('opacity') === '1';
+      return document.querySelector('path[data-name="daily_txs"]')?.getAttribute('opacity') === '1';
     });
     await page.hover('.ChartOverlay', { position: { x: 50, y: 50 } });
   });
@@ -50,7 +50,7 @@ test('partial data', async({ page, mockApiResponse, mockAssetResponse, render })
 
   const component = await render(<ChainIndicators/>);
   await page.waitForFunction(() => {
-    return document.querySelector('path[data-name="Tx/day"]')?.getAttribute('opacity') === '1';
+    return document.querySelector('path[data-name="daily_txs"]')?.getAttribute('opacity') === '1';
   });
   await expect(component).toHaveScreenshot();
 });


### PR DESCRIPTION
using chart name as id broke the styles for charts that have spaces in their names. fixed with using chart id as id. 