### PR TITLE
Add lowercase option for `NEXT_PUBLIC_VIEWS_NFT_MARKETPLACES`

### DIFF
--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -342,7 +342,7 @@ Settings for meta tags, OG tags and SEO
 | instance_url | `string` | URL template for NFT instance | - | - | `https://opensea.io/assets/ethereum/{hash}/{id}` |
 | logo_url | `string` | URL of marketplace logo | Required | - | `https://opensea.io/static/images/logos/opensea-logo.svg` |
 
-*Note* URL templates should contain placeholders of NFT hash (`{hash}`) and NFT id (`{id}`). This placeholders will be substituted with particular values for every collection or instance.
+*Note* URL templates should contain placeholders for the NFT hash (`{hash}` or `{hash_lowercase}`) and NFT ID (`{id}` or `{id_lowercase}`). These placeholders will be replaced with specific values or their lowercase equivalents for each collection or instance.
 
 &nbsp;
 

--- a/ui/token/TokenNftMarketplaces.tsx
+++ b/ui/token/TokenNftMarketplaces.tsx
@@ -31,7 +31,11 @@ const TokenNftMarketplaces = ({ hash, id, isLoading, appActionData, source }: Pr
       if (!hrefTemplate) {
         return null;
       }
-      const href = hrefTemplate.replace('{id}', id || '').replace('{hash}', hash || '');
+      const href = hrefTemplate
+        .replace('{id}', id || '')
+        .replace('{id_lowercase}', id?.toLowerCase() || '')
+        .replace('{hash}', hash || '')
+        .replace('{hash_lowercase}', hash?.toLowerCase() || '');
 
       return {
         href,


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #3093

### Proposed Changes
The `NEXT_PUBLIC_VIEWS_NFT_MARKETPLACES` variable now accepts `{id_lowercase}` and `{hash_lowercase}` as placeholders for URL path segments.

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
