### PR TITLE
Fix REST API docs request interceptor URL replacement

### DIFF
--- a/configs/envs/.env.mega_eth
+++ b/configs/envs/.env.mega_eth
@@ -1,5 +1,5 @@
-# Set of ENVs for MEGA Testnet v2 network explorer
-# https://megaeth-testnet-v2.blockscout.com
+# Set of ENVs for MEGA Mainnet network explorer
+# https://megaeth.blockscout.com
 # This is an auto-generated file. To update all values, run "yarn dev:preset:sync --name=mega_eth"
 
 # Local ENVs
@@ -11,11 +11,13 @@ NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
 
 # Instance ENVs
 NEXT_PUBLIC_AD_BANNER_ENABLE_SPECIFY=true
+NEXT_PUBLIC_AD_BANNER_PROVIDER=none
+NEXT_PUBLIC_AD_TEXT_PROVIDER=none
 NEXT_PUBLIC_ADDRESS_3RD_PARTY_WIDGETS=[]
 NEXT_PUBLIC_ADDRESS_3RD_PARTY_WIDGETS_CONFIG_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/widgets/config.json
 NEXT_PUBLIC_ADMIN_SERVICE_API_HOST=https://admin-rs.services.blockscout.com
 NEXT_PUBLIC_API_BASE_PATH=/
-NEXT_PUBLIC_API_HOST=megaeth-testnet-v2.blockscout.com
+NEXT_PUBLIC_API_HOST=megaeth.blockscout.com
 NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
 NEXT_PUBLIC_COLOR_THEME_DEFAULT=dark
 NEXT_PUBLIC_COLOR_THEME_OVERRIDES={'bg':{'primary':{'_light':{'value':'rgba(250,249,249)'},'_dark':{'value':'rgba(25,25,26)'}}},'text':{'primary':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(236,232,232)'}},'secondary':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(223,217,217)'}}},'hover':{'_light':{'value':'rgba(245,175,148)'},'_dark':{'value':'rgba(114,215,159)'}},'selected':{'control':{'text':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(247,250,252)'}},'bg':{'_light':{'value':'rgba(236,232,232)'},'_dark':{'value':'rgba(255,255,255,0.06)'}}},'option':{'bg':{'_light':{'value':'rgba(84,75,75)'},'_dark':{'value':'rgba(66,96,82)'}}}},'icon':{'primary':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(223,217,217)'}},'secondary':{'_light':{'value':'rgba(176,176,176)'},'_dark':{'value':'rgba(105,103,103)'}}},'button':{'primary':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(105,103,103)'}}},'link':{'primary':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(109,208,169)'}}},'graph':{'line':{'_light':{'value':'rgba(105,103,103)'},'_dark':{'value':'rgba(109,208,169)'}},'gradient':{'start':{'_light':{'value':'rgba(105,103,103,0.3)'},'_dark':{'value':'rgba(109,208,169,0.3)'}},'stop':{'_light':{'value':'rgba(105,103,103,0)'},'_dark':{'value':'rgba(109,208,169,0)'}}}},'stats':{'bg':{'_light':{'value':'rgba(236,232,232)'},'_dark':{'value':'rgba(255,255,255,0.06)'}}},'topbar':{'bg':{'_light':{'value':'rgba(236,232,232)'},'_dark':{'value':'rgba(255,255,255,0.06)'}}},'navigation':{'text':{'selected':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(247,250,252)'}}},'bg':{'selected':{'_light':{'value':'rgba(236,232,232)'},'_dark':{'value':'rgba(255,255,255,0.06)'}}}},'tabs':{'text':{'primary':{'_light':{'value':'rgba(25,25,26)'},'_dark':{'value':'rgba(236,232,232)'}}}}}
@@ -26,13 +28,11 @@ NEXT_PUBLIC_FONT_FAMILY_HEADING={'name':'Inter','url':'https://fonts.googleapis.
 NEXT_PUBLIC_GAME_BADGE_CLAIM_LINK=https://badges.blockscout.com/mint/sherblockHolmesBadge
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs']
 NEXT_PUBLIC_HOMEPAGE_HERO_BANNER_CONFIG={'background':['repeat center/auto 100% url(https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-skins/mega-eth.png)'],'text_color':['rgba(255,255,255,0.8)'],'search':{'border_width':['0px','2px']},'button':{'_default':{'background':['rgb(105,103,103)']}}}
-NEXT_PUBLIC_IS_TESTNET=true
+NEXT_PUBLIC_IS_ACCOUNT_SUPPORTED=true
 NEXT_PUBLIC_MARKETPLACE_CATEGORIES_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/marketplace-categories/megaeth-testnet.json
 NEXT_PUBLIC_MARKETPLACE_ENABLED=true
 NEXT_PUBLIC_MARKETPLACE_SUBMIT_FORM=https://airtable.com/appiy5yijZpMMSKjT/shr6uMGPKjj1DK7NL
 NEXT_PUBLIC_MARKETPLACE_SUGGEST_IDEAS_FORM=https://airtable.com/appiy5yijZpMMSKjT/pag3t82DUCyhGRZZO/form
-NEXT_PUBLIC_MEGA_ETH_SOCKET_URL_METRICS=wss://testnet-dashboard.megaeth.com/metrics
-NEXT_PUBLIC_MEGA_ETH_SOCKET_URL_RPC=wss://megaeth-testnet-v2.blockscout.com/api/v2/proxy/3rdparty/ws_megaeth_testnet_2
 NEXT_PUBLIC_METADATA_SERVICE_API_HOST=https://metadata.services.blockscout.com
 NEXT_PUBLIC_MIXPANEL_CONFIG_OVERRIDES={"record_sessions_percent": 0.5,"record_heatmap_data": true}
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
@@ -40,19 +40,19 @@ NEXT_PUBLIC_NETWORK_CURRENCY_NAME=ETH
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=ETH
 NEXT_PUBLIC_NETWORK_ICON=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/mega-eth-light.svg
 NEXT_PUBLIC_NETWORK_ICON_DARK=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/mega-eth-dark.svg
-NEXT_PUBLIC_NETWORK_ID=6343
+NEXT_PUBLIC_NETWORK_ID=4326
 NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/mega-eth-light.svg
 NEXT_PUBLIC_NETWORK_LOGO_DARK=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/mega-eth-dark.svg
-NEXT_PUBLIC_NETWORK_NAME=MEGA Testnet v2
-NEXT_PUBLIC_NETWORK_RPC_URL=https://timothy.megaeth.com/rpc
+NEXT_PUBLIC_NETWORK_NAME=MEGA Mainnet
+NEXT_PUBLIC_NETWORK_RPC_URL=https://alpha.megaeth.com/rpc
 NEXT_PUBLIC_OG_ENHANCED_DATA_ENABLED=true
 NEXT_PUBLIC_OG_IMAGE_URL=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/og-images/mega-eth.png
 NEXT_PUBLIC_PUZZLE_GAME_BADGE_CLAIM_LINK=https://badges.blockscout.com/mint/capyPuzzleBadge
-NEXT_PUBLIC_ROLLUP_L1_BASE_URL=https://eth-sepolia.blockscout.com/
+NEXT_PUBLIC_ROLLUP_L1_BASE_URL=https://eth.blockscout.com/
 NEXT_PUBLIC_ROLLUP_L2_WITHDRAWAL_URL=https://www.megaeth.com/
 NEXT_PUBLIC_ROLLUP_TYPE=optimistic
 NEXT_PUBLIC_STATS_API_BASE_PATH=/stats-service
-NEXT_PUBLIC_STATS_API_HOST=https://megaeth-testnet-v2.blockscout.com
+NEXT_PUBLIC_STATS_API_HOST=https://megaeth.blockscout.com
 NEXT_PUBLIC_TRANSACTION_INTERPRETATION_PROVIDER=blockscout
 NEXT_PUBLIC_VIEWS_CONTRACT_LANGUAGE_FILTERS=['solidity','vyper','yul','geas']
 NEXT_PUBLIC_VIEWS_TOKEN_SCAM_TOGGLE_ENABLED=true

--- a/tools/preset-sync/index.ts
+++ b/tools/preset-sync/index.ts
@@ -15,7 +15,7 @@ const PRESETS = {
   garnet: 'https://explorer.garnetchain.com',
   gnosis: 'https://gnosis.blockscout.com',
   immutable: 'https://explorer.immutable.com',
-  mega_eth: 'https://megaeth-testnet-v2.blockscout.com',
+  mega_eth: 'https://megaeth.blockscout.com',
   mekong: 'https://mekong.blockscout.com',
   neon_devnet: 'https://neon-devnet.blockscout.com',
   optimism: 'https://optimism.blockscout.com',

--- a/ui/apiDocs/utils.ts
+++ b/ui/apiDocs/utils.ts
@@ -34,9 +34,9 @@ export const REST_API_SECTIONS = [
 
         if (!req.loadSpec) {
           const newUrl = new URL(
-            req.url
-              .replace(DEFAULT_SERVER, config.apis.general.host)
-              .replace(DEFAULT_SERVER_NEW, config.apis.general.host),
+            req.url.includes(DEFAULT_SERVER) ?
+              req.url.replace(DEFAULT_SERVER, config.apis.general.host) :
+              req.url.replace(DEFAULT_SERVER_NEW, config.apis.general.host),
           );
 
           newUrl.protocol = config.apis.general.protocol + ':';


### PR DESCRIPTION
## Description and Related Issue(s)

Fixes the request interceptor in the REST API documentation snippet to correctly replace default server URLs. The previous implementation chained `.replace()` calls which could cause incorrect URL replacements when both default server patterns were present in the URL (for example, `https://megaeth.blockscout.com`).

### Proposed Changes

- Fixed the request interceptor logic in `ui/apiDocs/utils.ts` to check which default server URL is present before performing the replacement, ensuring only the correct server URL is replaced
- Updated MEGA network configuration from testnet to mainnet in `configs/envs/.env.mega_eth` and `tools/preset-sync/index.ts`

### Breaking or Incompatible Changes

None.

### Additional Information

The fix ensures that when the REST API documentation makes requests, it correctly replaces the default server URLs (`blockscout.com/poa/core` or `eth.blockscout.com`) with the configured API host, preventing potential URL replacement errors.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request