### PR TITLE
UI: Highlight color in dark theme

### DIFF
--- a/toolkit/theme/foundations/semanticTokens.ts
+++ b/toolkit/theme/foundations/semanticTokens.ts
@@ -32,6 +32,9 @@ const semanticTokens: ThemingConfig['semanticTokens'] = {
       scrollbar: {
         thumb: { value: { _light: '{colors.blackAlpha.300}', _dark: '{colors.whiteAlpha.300}' } },
       },
+      selection: {
+        bg: { value: { _light: '#E3CFE7', _dark: '#754B7D' } },
+      },
     },
 
     // FOUNDATIONS

--- a/toolkit/theme/globalCss.ts
+++ b/toolkit/theme/globalCss.ts
@@ -29,6 +29,9 @@ const globalCss: SystemConfig['globalCss'] = {
     bg: 'global.mark.bg',
     color: 'inherit',
   },
+  '::selection': {
+    bg: 'global.selection.bg',
+  },
   'svg *::selection': {
     color: 'none',
     background: 'none',


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #3206

This PR fixes the issue where text selection in dark theme was not clearly visible. The changes add proper selection background colors for both light and dark themes to improve text selection visibility and maintain design consistency.

### Proposed Changes

- Added `global.selection.bg` semantic token with light (`#E3CFE7`) and dark (`#754B7D`) theme values in `semanticTokens.ts`
- Applied the selection background color via `::selection` pseudo-element in `globalCss.ts`
- Ensures consistent and visible text selection across both themes

### Breaking or Incompatible Changes

None.

### Additional Information

This addresses the issue where text selection in dark theme was not clearly visible. The new colors provide better contrast while maintaining design consistency.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request