### PR TITLE
refactor: move ContractMethodArrayButton to shared forms components

### DIFF
--- a/ui/address/contract/methods/form/ContractMethodFieldAccordion.tsx
+++ b/ui/address/contract/methods/form/ContractMethodFieldAccordion.tsx
@@ -2,8 +2,7 @@ import { Box } from '@chakra-ui/react';
 import React from 'react';
 
 import { AccordionItem, AccordionItemContent, AccordionItemTrigger, AccordionRoot } from 'toolkit/chakra/accordion';
-
-import ContractMethodArrayButton from './ContractMethodArrayButton';
+import ArrayButton from 'ui/shared/forms/ArrayButton';
 
 export interface Props {
   label: string;
@@ -33,8 +32,8 @@ const ContractMethodFieldAccordion = ({ label, level, children, onAddClick, onRe
           <Box textStyle="sm" fontWeight={ 700 } mr="auto" color={ isInvalid ? 'text.error' : undefined }>
             { label }
           </Box>
-          { onRemoveClick && index !== undefined && <ContractMethodArrayButton index={ index } onClick={ onRemoveClick } type="remove"/> }
-          { onAddClick && index !== undefined && <ContractMethodArrayButton index={ index } onClick={ onAddClick } type="add" ml={ 1 }/> }
+          { onRemoveClick && index !== undefined && <ArrayButton index={ index } onClick={ onRemoveClick } type="remove"/> }
+          { onAddClick && index !== undefined && <ArrayButton index={ index } onClick={ onAddClick } type="add" ml={ 1 }/> }
         </AccordionItemTrigger>
         <AccordionItemContent display="flex" flexDir="column" rowGap={ 1 } pl="18px" pr="6px">
           { children }

--- a/ui/address/contract/methods/form/ContractMethodFieldInputArray.tsx
+++ b/ui/address/contract/methods/form/ContractMethodFieldInputArray.tsx
@@ -4,7 +4,8 @@ import { useFormContext } from 'react-hook-form';
 
 import type { ContractAbiItemInput } from '../types';
 
-import ContractMethodArrayButton from './ContractMethodArrayButton';
+import ArrayButton from 'ui/shared/forms/ArrayButton';
+
 import type { Props as AccordionProps } from './ContractMethodFieldAccordion';
 import ContractMethodFieldAccordion from './ContractMethodFieldAccordion';
 import ContractMethodFieldInput from './ContractMethodFieldInput';
@@ -151,9 +152,9 @@ const ContractMethodFieldInputArray = ({
                 isOptional={ registeredIndices.length === 1 }
               />
               { !hasFixedSize && registeredIndices.length > 1 &&
-                <ContractMethodArrayButton index={ registeredIndex } onClick={ handleRemoveButtonClick } type="remove" my="6px"/> }
+                <ArrayButton index={ registeredIndex } onClick={ handleRemoveButtonClick } type="remove" my="6px"/> }
               { !hasFixedSize && index === registeredIndices.length - 1 &&
-                <ContractMethodArrayButton index={ registeredIndex } onClick={ handleAddButtonClick } type="add" my="6px"/> }
+                <ArrayButton index={ registeredIndex } onClick={ handleAddButtonClick } type="add" my="6px"/> }
             </Flex>
           );
         }) }

--- a/ui/shared/forms/ArrayButton.tsx
+++ b/ui/shared/forms/ArrayButton.tsx
@@ -9,7 +9,7 @@ interface Props extends Omit<IconButtonProps, 'type'> {
   type: 'add' | 'remove';
 }
 
-const ContractMethodArrayButton = ({ type, index, onClick, ...props }: Props) => {
+const ArrayButton = ({ type, index, onClick, ...props }: Props) => {
 
   const handleClick = React.useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -30,4 +30,4 @@ const ContractMethodArrayButton = ({ type, index, onClick, ...props }: Props) =>
   );
 };
 
-export default React.memo(ContractMethodArrayButton);
+export default React.memo(ArrayButton);


### PR DESCRIPTION
## Description and Related Issue(s)
Relocates ContractMethodArrayButton to ui/shared/forms/components/ArrayButton to allow reuse across the codebase, not just in contract method forms.
resolves #2462

@coderabbit review

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
