### PR TITLE
fix: add neutral selected border for multichain cards

### DIFF
--- a/ui/multichain/address/portfolio/MultichainAddressPortfolioCard.tsx
+++ b/ui/multichain/address/portfolio/MultichainAddressPortfolioCard.tsx
@@ -46,13 +46,13 @@ const MultichainAddressPortfolioCard = ({ chain, value, share, isLoading, isSele
       w={ cardWidth }
       borderRadius="base"
       border="1px solid"
-      borderColor={ isSelected ? 'transparent' : 'border.divider' }
+      borderColor={ isSelected ? { _light: 'blackAlpha.100', _dark: 'whiteAlpha.200' } : 'border.divider' }
       textStyle="xs"
-      bgColor={ isSelected ? 'selected.control.bg' : 'transparent' }
+      bgColor={ isSelected ? { _light: 'blackAlpha.50', _dark: 'whiteAlpha.100' } : 'transparent' }
       opacity={ !isSelected && !noneIsSelected ? 0.5 : 1 }
       _hover={ onClick ? {
-        borderColor: 'hover',
         opacity: 1,
+        ...(isSelected ? {} : { borderColor: 'hover' }),
       } : undefined }
       cursor={ onClick ? 'pointer' : 'default' }
       onClick={ handleClick }


### PR DESCRIPTION
Use light/dark alpha border and background tokens for selected portfolio chain cards and keep hover from applying the blue border when a card is already selected.

## Description and Related Issue(s)

Updates the multichain address portfolio chain selector cards so the selected chain uses a neutral border and fill in both light and dark mode, instead of a transparent border with the old selected.control.bg (blue-tinted in light mode). Hover no longer applies the theme blue border when a card is already selected.

### Proposed Changes

- MultichainAddressPortfolioCard
- Selected: border uses blackAlpha.100 (light) / whiteAlpha.200 (dark); background uses blackAlpha.50 (light) / whiteAlpha.100 (dark).
- Hover: only non-selected cards get borderColor: 'hover'; selected cards keep the neutral border.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, UI-only styling tweaks confined to the multichain portfolio selector card; no logic, data, or security-sensitive flows changed.
> 
> **Overview**
> Updates `MultichainAddressPortfolioCard` selected-state styling to use neutral light/dark alpha `borderColor` and `bgColor` instead of a transparent border and `selected.control.bg`.
> 
> Adjusts hover behavior so the theme `hover` border only applies to *non-selected* cards, keeping the selected card’s neutral border intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06845dc7ec11cce5256d0df783bd5771e33b0525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->