### PR TITLE
Improve toast messages in the Revoke dapp

### DIFF
--- a/ui/marketplace/essentialDapps/revoke/components/ApprovalsListItem.tsx
+++ b/ui/marketplace/essentialDapps/revoke/components/ApprovalsListItem.tsx
@@ -38,12 +38,12 @@ export default function ApprovalsListItem({
 
   const handleRevoke = useCallback(async() => {
     setIsPending(true);
-    const success = await revoke(approval, Number(selectedChain?.id));
+    const success = await revoke(approval, selectedChain);
     if (success) {
       hideApproval(approval);
     }
     setIsPending(false);
-  }, [ revoke, hideApproval, approval, selectedChain?.id ]);
+  }, [ revoke, hideApproval, approval, selectedChain ]);
 
   return (
     <ListItemMobileGrid.Container

--- a/ui/marketplace/essentialDapps/revoke/components/ApprovalsTableItem.tsx
+++ b/ui/marketplace/essentialDapps/revoke/components/ApprovalsTableItem.tsx
@@ -37,12 +37,12 @@ export default function ApprovalsTableItem({
 
   const handleRevoke = useCallback(async() => {
     setIsPending(true);
-    const success = await revoke(approval, Number(selectedChain?.id));
+    const success = await revoke(approval, selectedChain);
     if (success) {
       hideApproval(approval);
     }
     setIsPending(false);
-  }, [ revoke, hideApproval, approval, selectedChain?.id ]);
+  }, [ revoke, hideApproval, approval, selectedChain ]);
 
   return (
     <TableRow fontWeight="500">

--- a/ui/marketplace/essentialDapps/revoke/hooks/useRevoke.tsx
+++ b/ui/marketplace/essentialDapps/revoke/hooks/useRevoke.tsx
@@ -1,14 +1,17 @@
+import { Flex, Text } from '@chakra-ui/react';
 import ERC20Artifact from '@openzeppelin/contracts/build/contracts/ERC20.json';
 import NftArtifact from '@openzeppelin/contracts/build/contracts/ERC721.json';
 import { useCallback } from 'react';
 import { waitForTransactionReceipt } from 'viem/actions';
 import { useAccount, useWriteContract, useSwitchChain } from 'wagmi';
 
+import type { EssentialDappsChainConfig } from 'types/client/marketplace';
 import type { AllowanceType } from 'types/client/revoke';
 
 import useRewardsActivity from 'lib/hooks/useRewardsActivity';
 import * as mixpanel from 'lib/mixpanel/index';
 import { toaster } from 'toolkit/chakra/toaster';
+import TxEntity from 'ui/shared/entities/tx/TxEntity';
 
 import createPublicClient from '../lib/createPublicClient';
 
@@ -18,13 +21,13 @@ export default function useRevoke() {
   const { writeContractAsync } = useWriteContract();
   const { trackTransaction, trackTransactionConfirm } = useRewardsActivity();
 
-  return useCallback(async(approval: AllowanceType, chainId: number) => {
+  return useCallback(async(approval: AllowanceType, chain?: EssentialDappsChainConfig) => {
     try {
       if (!userAddress) return;
 
-      await switchChainAsync({ chainId });
+      await switchChainAsync({ chainId: Number(chain?.id) });
 
-      const activityResponse = await trackTransaction(userAddress, approval.address, String(chainId));
+      const activityResponse = await trackTransaction(userAddress, approval.address, chain?.id);
 
       const isErc20 = approval.type === 'ERC-20';
 
@@ -34,7 +37,7 @@ export default function useRevoke() {
         abi: isErc20 ? ERC20Artifact.abi : NftArtifact.abi,
         functionName: isErc20 ? 'approve' : 'setApprovalForAll',
         args: [ approval.spender, isErc20 ? 0 : false ],
-        chainId,
+        chainId: Number(chain?.id),
       });
 
       mixpanel.logEvent(mixpanel.EventTypes.WALLET_ACTION, {
@@ -42,14 +45,14 @@ export default function useRevoke() {
         Address: userAddress,
         AppId: 'revoke',
         Source: 'Essential dapps',
-        ChainId: String(chainId),
+        ChainId: chain?.id,
       });
 
       if (activityResponse?.token) {
         await trackTransactionConfirm(hash, activityResponse.token);
       }
 
-      const publicClient = createPublicClient(String(chainId));
+      const publicClient = createPublicClient(chain?.id);
       if (!publicClient) {
         throw new Error('Public client not found');
       }
@@ -62,7 +65,21 @@ export default function useRevoke() {
 
       toaster.success({
         title: 'Success',
-        description: 'Approval revoked successfully.',
+        meta: {
+          renderDescription: () => (
+            <Flex direction="column">
+              <Text>Approval revoked successfully.</Text>
+              <TxEntity
+                hash={ hash }
+                text="View transaction"
+                link={{ external: true }}
+                noCopy
+                noIcon
+                chain={ chain }
+              />
+            </Flex>
+          ),
+        },
       });
 
       return true;
@@ -70,7 +87,10 @@ export default function useRevoke() {
     } catch (error) {
       toaster.error({
         title: 'Error',
-        description: (error as Error)?.message || 'Something went wrong. Try again later.',
+        description:
+          (error as { shortMessage?: string })?.shortMessage ||
+          (error as Error)?.message ||
+          'Something went wrong. Try again later.',
       });
 
       return false;


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves https://github.com/blockscout/frontend/issues/3217

<img width="393" height="86" alt="image" src="https://github.com/user-attachments/assets/af9879c8-fb2b-4733-b460-85d865418640" />
<img width="390" height="106" alt="image" src="https://github.com/user-attachments/assets/4b88b6db-ac94-49e0-b8bd-bc27afc0d770" />


## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX-oriented changes around revocation feedback; the only functional adjustment is passing the full `selectedChain` config into `useRevoke`, which could affect chain-id wiring but remains a straightforward refactor.
> 
> **Overview**
> Improves the Revoke essential dapp’s user feedback after revoking an approval by upgrading the success toast to include a **direct transaction link** (via `TxEntity`) instead of a plain string message.
> 
> Refactors `useRevoke` and its callers to pass the full `selectedChain` config (rather than a numeric chain id), and enhances error toasts to prefer wallet/library `shortMessage` when available for clearer failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9df5a0ac6649481527b97def1856fe81dc503c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->