### PR TITLE
Add Content-Type header to /api/v2/key request

### DIFF
--- a/ui/shared/AppError/custom/AppErrorTooManyRequests.tsx
+++ b/ui/shared/AppError/custom/AppErrorTooManyRequests.tsx
@@ -47,6 +47,7 @@ const AppErrorTooManyRequests = ({ bypassOptions, reset }: Props) => {
         method: 'POST',
         body: JSON.stringify({ recaptcha_response: token }),
         headers: {
+          'Content-Type': 'application/json',
           'recaptcha-v2-response': token,
         },
       });


### PR DESCRIPTION
## Description and Related Issue(s)

Replaces text/plain with application/json for proper ingestion on the backend.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an explicit `Content-Type: application/json` header to an existing POST request, with minimal behavioral impact beyond backend request parsing.
> 
> **Overview**
> Fixes the rate-limit bypass flow in `AppErrorTooManyRequests` by explicitly setting `Content-Type: application/json` on the `POST` to `general:api_v2_key`, ensuring the backend correctly treats the payload as JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e942c6e5fce608b5a245c0aaef7fa58ce8deaed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->