### PR TITLE
Pass imageName: frontend-private to cleanup_docker workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,6 +17,7 @@ jobs:
     uses: blockscout/actions/.github/workflows/cleanup_helmfile.yaml@main
     with:
       appName: review-$GITHUB_REF_NAME_SLUG
+      namespace: review-$GITHUB_REF_NAME_SLUG
       globalEnv: review
       helmfileDir: deploy
       kubeConfigSecret: ci/data/dev/kubeconfig/k8s-dev
@@ -26,6 +27,7 @@ jobs:
     uses: blockscout/actions/.github/workflows/cleanup_helmfile.yaml@main
     with:
       appName: review-2-$GITHUB_REF_NAME_SLUG
+      namespace: review-2-$GITHUB_REF_NAME_SLUG
       globalEnv: review
       helmfileDir: deploy
       kubeConfigSecret: ci/data/dev/kubeconfig/k8s-dev

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -35,9 +35,11 @@ jobs:
     uses: blockscout/actions/.github/workflows/cleanup_docker.yaml@main
     with:
       dockerImage: review-$GITHUB_REF_NAME_SLUG
+      imageName: frontend-private
     secrets: inherit
   cleanup_docker_image_2:
     uses: blockscout/actions/.github/workflows/cleanup_docker.yaml@main
     with:
       dockerImage: review-2-$GITHUB_REF_NAME_SLUG
+      imageName: frontend-private
     secrets: inherit


### PR DESCRIPTION
## Summary

- Passes `imageName: frontend-private` to both `cleanup_docker_image` and `cleanup_docker_image_2` jobs in `.github/workflows/cleanup.yml`.

## Why

Since commit 13203efc8 (Sep 2025, "CI/CD: Change the default visibility of the package"), review images are published to `ghcr.io/blockscout/frontend-private`. The reusable `cleanup_docker.yaml` workflow was looking up the GHCR package by the calling repo name (`frontend`), so the tag never existed there and cleanup failed:

```
package with tag 'review-tom2drum-issue-3314' does not exits,
available tags: v2.3.5, latest, v2.3.5-alpha.1, ...
```

The fix on the reusable side (adding an optional `imageName` input) is in **blockscout/actions PR #4** — merge that first. This PR is safe to merge immediately after; `@main` will pick up the new input.

## Reference failed run
https://github.com/blockscout/frontend/actions/runs/24999835897

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-input changes only; low risk aside from potentially deleting the wrong namespace/image if variables are misconfigured.
> 
> **Overview**
> Fixes review environment cleanup by passing explicit targets to the reusable GitHub Actions workflows.
> 
> `.github/workflows/cleanup.yml` now supplies `namespace` to both Helmfile cleanup jobs and `imageName: frontend-private` to both Docker image cleanup jobs, ensuring the correct Kubernetes namespace and GHCR package are cleaned up for review deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e5a1bd3f0c4cc447f69e5bd9cb8df6129583a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->