### PR TITLE
Noves: unreadable tooltip in dark mode on `Asset Flows` tx tab

### DIFF
--- a/ui/tx/assetFlows/components/NovesActionSnippet.tsx
+++ b/ui/tx/assetFlows/components/NovesActionSnippet.tsx
@@ -90,7 +90,6 @@ const NovesActionSnippet: FC<Props> = ({ item, isLoaded }) => {
             jointSymbol
             noLink={ !validTokenAddress }
             fontWeight="500"
-            color="link.primary"
             w="fit-content"
           />
         </Box>

--- a/ui/tx/assetFlows/components/NovesTokenTooltipContent.tsx
+++ b/ui/tx/assetFlows/components/NovesTokenTooltipContent.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import type { NovesNft, NovesToken } from 'types/api/noves';
 
+import shortenString from 'client/shared/text/shorten-string';
 import { HEX_REGEXP } from 'toolkit/utils/regexp';
 import CopyToClipboard from 'ui/shared/CopyToClipboard';
 
@@ -21,7 +22,7 @@ const NovesTokenTooltipContent: FC<Props> = ({ token, amount }) => {
   const showTokenAddress = HEX_REGEXP.test(token.address);
 
   return (
-    <Box color={{ _light: 'white', _dark: 'blackAlpha.900' }} display="flex" flexDir="column" alignItems="center" gap={ 1 }>
+    <Box display="flex" flexDir="column" alignItems="center" gap={ 1 }>
       <Text as="p" color="inherit" fontWeight="semibold">
         <Text color="inherit" as="span">
           { amount }
@@ -40,9 +41,9 @@ const NovesTokenTooltipContent: FC<Props> = ({ token, amount }) => {
       { showTokenAddress && (
         <Box display="flex" alignItems="center">
           <Text color="inherit" fontWeight="normal">
-            { token.address }
+            { shortenString(token.address) }
           </Text>
-          <CopyToClipboard text={ token.address }/>
+          <CopyToClipboard text={ token.address } noTooltip/>
         </Box>
       ) }
 


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #2986

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
