### PR TITLE
Refactor search bar menu width to use Popover sameWidth

### DIFF
--- a/.agents/rules/code-quality.mdc
+++ b/.agents/rules/code-quality.mdc
@@ -128,7 +128,7 @@ Remove commented-out code blocks. The git history preserves anything that might 
 ### Links
 
 - Use `toolkit/chakra/link` instead of `next/link`. Never import `Link` from `next/link` directly.
-- When links to **application pages** are constructed, verify that `nextjs-routes` or `nextjs/routes` utilities are used instead of string concatenation or template literals. The full list of application routes is available in `nextjs/nextjs-routes.d.ts`.
+- When links to **application pages** are constructed, verify that `nextjs-routes` or `src/shared/router/routes` utilities are used instead of string concatenation or template literals. The full list of application routes is available in `src/shared/router/nextjs-routes.d.ts`.
 
 ### Date and time
 

--- a/src/slices/search/components/search-bar/SearchBarDesktop.tsx
+++ b/src/slices/search/components/search-bar/SearchBarDesktop.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import { useClickAway } from '@uidotdev/usehooks';
-import { debounce } from 'es-toolkit';
 import { useRouter } from 'next/router';
 import type { Route } from 'nextjs-routes';
 import { route } from 'nextjs-routes';
@@ -30,7 +29,6 @@ type Props = {
 
 const SearchBarDesktop = ({ isHeroBanner }: Props) => {
   const inputRef = React.useRef<HTMLFormElement>(null);
-  const menuWidth = React.useRef<number>(0);
 
   const { open, onClose, onOpen } = useDisclosure();
   const isMobile = useIsMobile();
@@ -86,6 +84,11 @@ const SearchBarDesktop = ({ isHeroBanner }: Props) => {
     open && onOpen();
   }, [ onOpen ]);
 
+  const handleRecentKeywordsClick = React.useCallback((keyword: string) => {
+    handleSearchTermChange(keyword);
+    inputRef.current?.querySelector('input')?.focus();
+  }, [ handleSearchTermChange ]);
+
   const handleClear = React.useCallback(() => {
     handleSearchTermChange('');
     inputRef.current?.querySelector('input')?.focus();
@@ -110,34 +113,11 @@ const SearchBarDesktop = ({ isHeroBanner }: Props) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ onClose ]);
 
-  const menuPaddingX = isMobile && !isHeroBanner ? 24 : 0;
-  const calculateMenuWidth = React.useCallback(() => {
-    menuWidth.current = (inputRef.current?.getBoundingClientRect().width || 0) - menuPaddingX;
-  }, [ menuPaddingX ]);
-
   // clear input on page change
   React.useEffect(() => {
     handleSearchTermChange('');
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ router.asPath?.split('?')?.[0] ]);
-
-  React.useEffect(() => {
-    const inputEl = inputRef.current;
-    if (!inputEl) {
-      return;
-    }
-    calculateMenuWidth();
-
-    const resizeHandler = debounce(calculateMenuWidth, 200);
-    const resizeObserver = new ResizeObserver(resizeHandler);
-    if (inputRef.current) {
-      resizeObserver.observe(inputRef.current);
-    }
-
-    return function cleanup() {
-      resizeObserver.unobserve(inputEl);
-    };
-  }, [ calculateMenuWidth ]);
 
   const showAllResultsLink = searchTerm.trim().length > 0 && (
     (query.data && query.data.length >= 50) ||
@@ -150,11 +130,14 @@ const SearchBarDesktop = ({ isHeroBanner }: Props) => {
         open={ open && (searchTerm.trim().length > 0 || recentSearchKeywords.length > 0) }
         autoFocus={ false }
         onOpenChange={ handleOpenChange }
-        positioning={{ offset: isMobile && !isHeroBanner ? { mainAxis: 0, crossAxis: 12 } : { mainAxis: 8, crossAxis: 0 } }}
+        positioning={{
+          offset: isMobile && !isHeroBanner ? { mainAxis: 0, crossAxis: 12 } : { mainAxis: 8, crossAxis: 0 },
+          sameWidth: true,
+        }}
         lazyMount
         closeOnInteractOutside={ false }
       >
-        <PopoverTrigger asChild w="100%">
+        <PopoverTrigger asChild>
           <SearchBarInput
             ref={ inputRef }
             onChange={ handleSearchTermChange }
@@ -169,11 +152,11 @@ const SearchBarDesktop = ({ isHeroBanner }: Props) => {
           />
         </PopoverTrigger>
         <PopoverContent
-          maxW={{ base: 'calc(100vw - 8px)', lg: 'unset' }}
-          w={ `${ menuWidth.current }px` }
-          ref={ menuRef }
+          w="auto"
+          maxW="100%"
           overflow="hidden"
           zIndex="modal"
+          ref={ menuRef }
         >
           <PopoverBody
             px={ 4 }
@@ -184,7 +167,7 @@ const SearchBarDesktop = ({ isHeroBanner }: Props) => {
             overflowY="hidden"
           >
             { searchTerm.trim().length === 0 && recentSearchKeywords.length > 0 && (
-              <SearchBarRecentKeywords onClick={ handleSearchTermChange } onClear={ onClose }/>
+              <SearchBarRecentKeywords onClick={ handleRecentKeywordsClick } onClear={ onClose }/>
             ) }
             { searchTerm.trim().length > 0 && (
               <SearchBarSuggest

--- a/src/slices/search/pages/search-results/SearchResultsInput.tsx
+++ b/src/slices/search/pages/search-results/SearchResultsInput.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-import { debounce } from 'es-toolkit';
 import type { FormEvent, FocusEvent } from 'react';
 import React from 'react';
 
@@ -24,7 +23,6 @@ const SearchResultsInput = ({ searchTerm, handleSubmit, handleSearchTermChange }
   const { open, onClose, onOpen } = useDisclosure();
   const inputRef = React.useRef<HTMLFormElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const menuWidth = React.useRef<number>(0);
   const isMobile = useIsMobile();
 
   const recentSearchKeywords = getRecentSearchKeywords();
@@ -55,29 +53,6 @@ const SearchResultsInput = ({ searchTerm, handleSubmit, handleSearchTermChange }
     inputRef.current?.querySelector('input')?.focus();
   }, [ handleSearchTermChange ]);
 
-  const menuPaddingX = isMobile ? 24 : 0;
-  const calculateMenuWidth = React.useCallback(() => {
-    menuWidth.current = (inputRef.current?.getBoundingClientRect().width || 0) - menuPaddingX;
-  }, [ menuPaddingX ]);
-
-  React.useEffect(() => {
-    const inputEl = inputRef.current;
-    if (!inputEl) {
-      return;
-    }
-    calculateMenuWidth();
-
-    const resizeHandler = debounce(calculateMenuWidth, 200);
-    const resizeObserver = new ResizeObserver(resizeHandler);
-    if (inputRef.current) {
-      resizeObserver.observe(inputRef.current);
-    }
-
-    return function cleanup() {
-      resizeObserver.unobserve(inputEl);
-    };
-  }, [ calculateMenuWidth ]);
-
   const isSuggestOpen = open && recentSearchKeywords.length > 0 && searchTerm.trim().length === 0;
 
   return (
@@ -86,7 +61,10 @@ const SearchResultsInput = ({ searchTerm, handleSubmit, handleSearchTermChange }
         open={ isSuggestOpen }
         autoFocus={ false }
         onOpenChange={ handleOpenChange }
-        positioning={{ offset: { mainAxis: isMobile ? 0 : 8, crossAxis: isMobile ? 12 : 0 } }}
+        positioning={{
+          offset: { mainAxis: isMobile ? 0 : 8, crossAxis: isMobile ? 12 : 0 },
+          sameWidth: true,
+        }}
       >
         <PopoverTrigger>
           <SearchBarInput
@@ -101,7 +79,7 @@ const SearchResultsInput = ({ searchTerm, handleSubmit, handleSearchTermChange }
             isSuggestOpen={ isSuggestOpen }
           />
         </PopoverTrigger>
-        <PopoverContent w={ `${ menuWidth.current }px` } maxH={{ base: '300px', lg: '500px' }} overflowY="scroll" ref={ menuRef }>
+        <PopoverContent w="auto" maxW="100%" maxH={{ base: '300px', lg: '500px' }} overflowY="scroll" zIndex="modal" ref={ menuRef }>
           <PopoverBody py={ 6 }>
             <SearchBarRecentKeywords onClick={ handleSearchTermChange } onClear={ onClose }/>
           </PopoverBody>

--- a/src/toolkit/package/tsconfig.json
+++ b/src/toolkit/package/tsconfig.json
@@ -20,7 +20,7 @@
     "paths": {
       "src/*": ["../../../src/*"],
       "public/*": ["../../../public/*"],
-      "nextjs-routes": ["../../../src/server/nextjs-routes.d.ts"],
+      "nextjs-routes": ["../../../src/shared/router/nextjs-routes.d.ts"],
     },
     "types": ["vite/client", "node"],
     "allowJs": true,


### PR DESCRIPTION
## Description and Related Issue(s)

Refactors search bar dropdown positioning to use Chakra Popover's built-in `sameWidth` positioning instead of manually tracking input width with a ResizeObserver.

### Proposed Changes

- Remove manual `ResizeObserver` + debounced width calculation from `SearchBarDesktop` and `SearchResultsInput`
- Use Popover `positioning.sameWidth: true` so the suggest/recent-keywords menu matches the trigger width
- Simplify `PopoverContent` width styling (`w="auto"`, `maxW="100%"`) and drop the `menuWidth` ref
- Restore input focus when selecting a recent keyword in the desktop search bar (`handleRecentKeywordsClick`)

### Breaking or Incompatible Changes

None.

### Additional Information

Net reduction of ~40 lines of layout-sync logic. Behavior should be unchanged aside from the recent-keywords focus fix on desktop.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
