### PR TITLE
Add configurable URL validator with loose scheme support for FormFieldUrl

### DIFF
--- a/src/features/account/pages/verified-addresses/token-info/fields/TokenInfoFieldSupport.tsx
+++ b/src/features/account/pages/verified-addresses/token-info/fields/TokenInfoFieldSupport.tsx
@@ -20,7 +20,7 @@ const TokenInfoFieldSupport = (props: Props) => {
       return true;
     }
 
-    const urlValidationResult = urlValidator(newValue);
+    const urlValidationResult = urlValidator()(newValue);
     const emailValidationResult = emailValidator(newValue);
 
     if (urlValidationResult === true || emailValidationResult === true) {

--- a/src/slices/chain/config.ts
+++ b/src/slices/chain/config.ts
@@ -20,7 +20,7 @@ const verificationType: NetworkVerificationType = (() => {
 
 const rpcUrls = (() => {
   const envValue = getEnvValue('NEXT_PUBLIC_NETWORK_RPC_URL');
-  const isUrl = urlValidator(envValue);
+  const isUrl = urlValidator()(envValue);
 
   if (envValue && isUrl === true) {
     return [ envValue ];

--- a/src/toolkit/components/forms/fields/FormFieldUrl.tsx
+++ b/src/toolkit/components/forms/fields/FormFieldUrl.tsx
@@ -10,20 +10,20 @@ import { urlValidator } from '../validators/url';
 import { FormFieldText } from './FormFieldText';
 
 const FormFieldUrlContent = <FormFields extends FieldValues>(
-  props: FormFieldPropsBase<FormFields> & { urlValidatorParams?: UrlValidatorParams },
+  { urlValidatorParams, ...rest }: FormFieldPropsBase<FormFields> & { urlValidatorParams?: UrlValidatorParams },
 ) => {
   const rules = React.useMemo(
     () => ({
-      ...props.rules,
+      ...rest.rules,
       validate: {
-        ...props.rules?.validate,
-        url: urlValidator(props.urlValidatorParams),
+        ...rest.rules?.validate,
+        url: urlValidator(urlValidatorParams),
       },
     }),
-    [ props.rules, props.urlValidatorParams ],
+    [ rest.rules, urlValidatorParams ],
   );
 
-  return <FormFieldText { ...props } rules={ rules }/>;
+  return <FormFieldText { ...rest } rules={ rules }/>;
 };
 
 export const FormFieldUrl = React.memo(FormFieldUrlContent) as typeof FormFieldUrlContent;

--- a/src/toolkit/components/forms/fields/FormFieldUrl.tsx
+++ b/src/toolkit/components/forms/fields/FormFieldUrl.tsx
@@ -5,21 +5,22 @@ import type { FieldValues } from 'react-hook-form';
 
 import type { FormFieldPropsBase } from './types';
 
+import type { UrlValidatorParams } from '../validators/url';
 import { urlValidator } from '../validators/url';
 import { FormFieldText } from './FormFieldText';
 
 const FormFieldUrlContent = <FormFields extends FieldValues>(
-  props: FormFieldPropsBase<FormFields>,
+  props: FormFieldPropsBase<FormFields> & { urlValidatorParams?: UrlValidatorParams },
 ) => {
   const rules = React.useMemo(
     () => ({
       ...props.rules,
       validate: {
         ...props.rules?.validate,
-        url: urlValidator,
+        url: urlValidator(props.urlValidatorParams),
       },
     }),
-    [ props.rules ],
+    [ props.rules, props.urlValidatorParams ],
   );
 
   return <FormFieldText { ...props } rules={ rules }/>;

--- a/src/toolkit/components/forms/fields/image/useImageField.tsx
+++ b/src/toolkit/components/forms/fields/image/useImageField.tsx
@@ -70,7 +70,7 @@ export function useImageField<
       return;
     }
 
-    const isValidUrl = urlValidator(fieldValue);
+    const isValidUrl = urlValidator()(fieldValue);
     isValidUrl === true && setValue(fieldValue);
   }, [ fieldValue, isRequired, name, trigger ]);
 

--- a/src/toolkit/components/forms/validators/url.ts
+++ b/src/toolkit/components/forms/validators/url.ts
@@ -2,12 +2,14 @@
 
 export type UrlScheme = 'http' | 'https' | 'ws' | 'wss';
 
+export const URL_SCHEME_REGEXP = /^[a-z][a-z0-9+\-.]*:\/\//i;
+
 export interface UrlValidatorParams {
+  // If true, the URL will be validated as an URL without scheme (e.g. 'example.com')
   loose?: boolean;
-  schemes?: Array<UrlScheme>;
 }
 
-export function urlValidator({ loose, schemes = [ 'https', 'http' ] }: UrlValidatorParams = {}) {
+export function urlValidator({ loose }: UrlValidatorParams = {}) {
   return function(value: string | undefined) {
     if (!value) {
       return true;
@@ -19,12 +21,12 @@ export function urlValidator({ loose, schemes = [ 'https', 'http' ] }: UrlValida
           return value;
         }
 
-        const hasScheme = schemes.some(scheme => value.startsWith(`${ scheme }://`));
+        const hasScheme = URL_SCHEME_REGEXP.test(value);
         if (hasScheme) {
           return value;
         }
 
-        return `${ schemes[0] }://${ value }`;
+        return `https://${ value }`;
       })();
       new URL(valueToTest);
       return true;

--- a/src/toolkit/components/forms/validators/url.ts
+++ b/src/toolkit/components/forms/validators/url.ts
@@ -1,16 +1,37 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-export function urlValidator(value: string | undefined) {
-  if (!value) {
-    return true;
-  }
+export type UrlScheme = 'http' | 'https' | 'ws' | 'wss';
 
-  try {
-    new URL(value);
-    return true;
-  } catch (error) {
-    return 'Incorrect URL';
-  }
+export interface UrlValidatorParams {
+  loose?: boolean;
+  schemes?: Array<UrlScheme>;
+}
+
+export function urlValidator({ loose, schemes = [ 'https', 'http' ] }: UrlValidatorParams = {}) {
+  return function(value: string | undefined) {
+    if (!value) {
+      return true;
+    }
+
+    try {
+      const valueToTest = (() => {
+        if (!loose) {
+          return value;
+        }
+
+        const hasScheme = schemes.some(scheme => value.startsWith(`${ scheme }://`));
+        if (hasScheme) {
+          return value;
+        }
+
+        return `${ schemes[0] }://${ value }`;
+      })();
+      new URL(valueToTest);
+      return true;
+    } catch (error) {
+      return 'Incorrect URL';
+    }
+  };
 }
 
 export const DOMAIN_REGEXP =

--- a/src/toolkit/package/src/index.ts
+++ b/src/toolkit/package/src/index.ts
@@ -124,7 +124,7 @@ export * from '../../utils/isBrowser';
 
 // Export hooks
 export { useClipboard } from '../../hooks/useClipboard';
-export { useDisclosure } from '../../hooks/useDisclosure';
+export * from '../../hooks/useDisclosure';
 export { useUpdateEffect } from '../../hooks/useUpdateEffect';
 export { useFirstMountState } from '../../hooks/useFirstMountState';
 export { useIsSticky } from '../../hooks/useIsSticky';


### PR DESCRIPTION
## Description and Related Issue(s)

Refactors `urlValidator` into a factory that accepts optional parameters, enabling `FormFieldUrl` to validate URLs without requiring an explicit scheme (e.g. `example.com` instead of `https://example.com`).

### Proposed Changes

- Refactor `urlValidator` from a direct validator function to a factory (`urlValidator(params)`) that returns a react-hook-form-compatible validator.
- Add `UrlValidatorParams` with:
  - `loose` — when `true`, the URL will be validated as an URL without scheme (e.g. 'example.com').
- Add optional `urlValidatorParams` prop to `FormFieldUrl` and pass it through to the validator.
- Update existing call sites (`TokenInfoFieldSupport`, chain config RPC URL check, `useImageField`) to use `urlValidator()`.
- Export all symbols from `useDisclosure` in the UI toolkit package index (types included).

### Breaking or Incompatible Changes

`urlValidator` is no longer callable directly as `(value) => ...`. Call sites must use `urlValidator()` or `urlValidator({ loose: true, schemes: [...] })`. This is an internal toolkit API change; `FormFieldUrl` consumers are unaffected unless they opt into `urlValidatorParams`.

### Additional Information

No environment variable changes.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
