### PR TITLE
feat(sitemap): include individual chart pages when chain stats is enabled

### DIFF
--- a/deploy/tools/sitemap-generator/next-sitemap.config.js
+++ b/deploy/tools/sitemap-generator/next-sitemap.config.js
@@ -90,6 +90,30 @@ const apiUrl = (() => {
   return `${ baseUrl }${ basePath }/api/v2`;
 })();
 
+const statsApiUrl = (() => {
+  const baseUrl = process.env.NEXT_PUBLIC_STATS_API_HOST;
+  if (!baseUrl) {
+    return;
+  }
+
+  const basePath = stripTrailingSlash(process.env.NEXT_PUBLIC_STATS_API_BASE_PATH || '');
+
+  return `${ stripTrailingSlash(baseUrl) }${ basePath }/api/v1`;
+})();
+
+const fetchStatsCharts = async() => {
+  if (!statsApiUrl) {
+    return;
+  }
+
+  return fetchResource(
+    `${ statsApiUrl }/lines`,
+    (data) => (data.sections || []).flatMap(
+      (section) => (section.charts || []).map(({ id }) => ({ path: `/stats/${ id }` })),
+    ),
+  );
+}
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl,
@@ -289,6 +313,7 @@ module.exports = {
         })),
       );
     const dapps = fetchDapps();
+    const statsCharts = fetchStatsCharts();
 
     return Promise.all([
       ...(await addresses || []),
@@ -297,6 +322,7 @@ module.exports = {
       ...(await tokens || []),
       ...(await contracts || []),
       ...(await dapps || []),
+      ...(await statsCharts || []),
     ].map(({ path, lastmod }) => config.transform({ ...config, lastmod }, path)));
   },
 };


### PR DESCRIPTION
## Description and Related Issue(s)

The generated `sitemap.xml` did not include the individual chart pages (`/stats/[id]`) even when the chain stats feature was enabled — only the top-level `/stats` page was listed.

### Proposed Changes
- Added a `statsApiUrl` builder that resolves the stats API base from `NEXT_PUBLIC_STATS_API_HOST` and `NEXT_PUBLIC_STATS_API_BASE_PATH` (mirroring the existing `apiUrl` logic).
- Added `fetchStatsCharts()` which fetches the `/api/v1/lines` endpoint and flattens every section's charts into `/stats/{id}` paths.
- Wired the chart paths into `additionalPaths`. It returns nothing when `NEXT_PUBLIC_STATS_API_HOST` is unset, so the pages are only added when chain stats is enabled, and the existing multichain early-return still applies.

### Breaking or Incompatible Changes
None.

### Additional Information
No environment variable changes.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
