### PR TITLE
fix(proxy): prevent SSRF via x-endpoint header

### DIFF
--- a/src/pages/api/proxy.ts
+++ b/src/pages/api/proxy.ts
@@ -4,6 +4,7 @@ import { pick, pickBy } from 'es-toolkit';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import fetchFactory from 'src/server/utils/fetchProxy';
+import getAllowedApiOrigins from 'src/server/utils/getAllowedApiOrigins';
 
 import isNeedProxy from 'src/api/utils/is-need-proxy';
 
@@ -25,6 +26,15 @@ const handler = async(nextReq: NextApiRequest, nextRes: NextApiResponse) => {
     nextReq.url.replace(/^\/node-api\/proxy/, ''),
     nextReq.headers['x-endpoint']?.toString() || appConfig.apis.core?.endpoint,
   );
+
+  // Guard against server-side request forgery: the target host comes from the
+  // user-controlled "x-endpoint" header (or a protocol-relative path), so only
+  // forward to origins that are present in the server-side configuration.
+  if (!getAllowedApiOrigins().has(url.origin)) {
+    nextRes.status(403).json({ error: 'Requested endpoint is not allowed' });
+    return;
+  }
+
   const apiRes = await fetchFactory(nextReq)(
     url.toString(),
     pickBy(pick(nextReq, [ 'body', 'method' ]), Boolean),

--- a/src/server/utils/getAllowedApiOrigins.spec.ts
+++ b/src/server/utils/getAllowedApiOrigins.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import getAllowedApiOrigins from './getAllowedApiOrigins';
+
+vi.mock('src/config', () => ({
+  'default': {
+    apis: {
+      core: { endpoint: 'https://core.example.com' },
+      stats: { endpoint: 'https://stats.example.com:8443' },
+      // invalid endpoint should be ignored, not throw
+      broken: { endpoint: 'not-a-url' },
+      // undefined api should be ignored
+      admin: undefined,
+    },
+  },
+}));
+
+vi.mock('src/features/multichain/chains-config', () => ({
+  'default': () => ({
+    chains: [
+      { app_config: { apis: { core: { endpoint: 'https://chain-a.example.com' } } } },
+      { app_config: { apis: { core: { endpoint: 'https://chain-b.example.com' } } } },
+    ],
+  }),
+}));
+
+vi.mock('src/features/marketplace/chains-config/essential-dapps', () => ({
+  'default': () => ({
+    chains: [
+      { app_config: { apis: { core: { endpoint: 'https://dapp-chain.example.com' } } } },
+      // chain without app_config should be ignored
+      {},
+    ],
+  }),
+}));
+
+describe('getAllowedApiOrigins', () => {
+  it('collects origins from local, multichain and essential dapps config', () => {
+    const origins = getAllowedApiOrigins();
+
+    expect(origins.has('https://core.example.com')).toBe(true);
+    expect(origins.has('https://stats.example.com:8443')).toBe(true);
+    expect(origins.has('https://chain-a.example.com')).toBe(true);
+    expect(origins.has('https://chain-b.example.com')).toBe(true);
+    expect(origins.has('https://dapp-chain.example.com')).toBe(true);
+  });
+
+  it('ignores endpoints that are not valid URLs', () => {
+    const origins = getAllowedApiOrigins();
+
+    expect([ ...origins ].some((origin) => origin.includes('not-a-url'))).toBe(false);
+  });
+
+  it('rejects origins that are not present in the configuration', () => {
+    const origins = getAllowedApiOrigins();
+
+    expect(origins.has('http://169.254.169.254')).toBe(false);
+    expect(origins.has('http://localhost:3000')).toBe(false);
+    expect(origins.has('https://evil.example.com')).toBe(false);
+  });
+});

--- a/src/server/utils/getAllowedApiOrigins.ts
+++ b/src/server/utils/getAllowedApiOrigins.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import essentialDappsChains from 'src/features/marketplace/chains-config/essential-dapps';
+import multichainConfig from 'src/features/multichain/chains-config';
+
+import config from 'src/config';
+
+// Collects the set of origins (scheme + host + port) that the Next.js proxy
+// (src/pages/api/proxy.ts) is allowed to forward requests to.
+//
+// The proxy picks its target host from the user-controlled "x-endpoint" header,
+// which would otherwise allow server-side request forgery (CWE-918). To prevent
+// that, the resolved request origin is checked against this allow-list, which is
+// derived solely from server-side configuration:
+//   - the local instance API endpoints (config.apis)
+//   - every chain endpoint in the multichain cluster config
+//   - every chain core endpoint in the essential dapps config
+function toOrigin(endpoint: string | undefined): string | undefined {
+  if (!endpoint) {
+    return;
+  }
+
+  try {
+    return new URL(endpoint).origin;
+  } catch (error) {
+    return;
+  }
+}
+
+function collectApiEndpoints(apis: Record<string, { endpoint?: string } | undefined> | undefined): Array<string> {
+  if (!apis) {
+    return [];
+  }
+
+  return Object.values(apis)
+    .map((api) => api?.endpoint)
+    .filter((endpoint): endpoint is string => Boolean(endpoint));
+}
+
+let cache: Set<string> | undefined;
+
+export default function getAllowedApiOrigins(): Set<string> {
+  if (cache) {
+    return cache;
+  }
+
+  const endpoints: Array<string> = [
+    ...collectApiEndpoints(config.apis),
+    ...(multichainConfig()?.chains ?? []).flatMap((chain) => collectApiEndpoints(chain.app_config?.apis)),
+    ...(essentialDappsChains()?.chains ?? []).flatMap((chain) => collectApiEndpoints(chain.app_config?.apis)),
+  ];
+
+  cache = new Set(endpoints.map(toOrigin).filter((origin): origin is string => Boolean(origin)));
+
+  return cache;
+}


### PR DESCRIPTION
## Summary

Fixes server-side request forgery (CWE-918) flagged by code-scanning alert [#43](https://github.com/blockscout/frontend/security/code-scanning/43).

The Next.js proxy route (`src/pages/api/proxy.ts`) built its outgoing request URL from user-controlled input:
- the `x-endpoint` request header was used directly as the **target host**, and
- a protocol-relative request path (e.g. `/node-api/proxy//evil.com/...`) could override the host of the default base.

Because the proxy returns the upstream response body and headers to the caller, an attacker could point it at internal services or cloud metadata endpoints (e.g. `169.254.169.254`) and read the response.

## Fix

Restrict forwarding to an allow-list of origins (`scheme://host:port`) derived **solely from server-side configuration**:
- local instance API endpoints (`config.apis.*`)
- every chain endpoint in the multichain cluster config
- every chain `core` endpoint in the essential-dapps config

The resolved request `origin` is checked against this set; non-allowed origins get a `403` before any fetch happens. Legitimate clients (`useApiFetch`, `CsvExport`) only ever set `x-endpoint` to a configured endpoint, so normal traffic is unaffected.

## Changes
- `src/server/utils/getAllowedApiOrigins.ts` — new memoized allow-list helper
- `src/pages/api/proxy.ts` — guard the resolved origin against the allow-list
- `src/server/utils/getAllowedApiOrigins.spec.ts` — unit tests

## Testing
- `pnpm test:vitest src/server/utils/getAllowedApiOrigins.spec.ts` — 3 passing
- `tsc --noEmit` — 0 errors
- `eslint` — clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
