### PR TITLE
Сode editor: dispose all models when component unmount itself

### DIFF
--- a/src/shared/code-editor/CodeEditor.tsx
+++ b/src/shared/code-editor/CodeEditor.tsx
@@ -98,6 +98,15 @@ const CodeEditor = ({ data, remappings, libraries, language, mainFile, contractN
     instance?.editor.setTheme(colorMode === 'light' ? 'blockscout-light' : 'blockscout-dark');
   }, [ colorMode, instance?.editor ]);
 
+  React.useEffect(() => {
+    return () => {
+      const loadedModels = instance?.editor.getModels() ?? [];
+      loadedModels.forEach((model) => {
+        model.dispose();
+      });
+    };
+  }, [ instance?.editor ]);
+
   const handleEditorDidMount = React.useCallback((editor: monaco.editor.IStandaloneCodeEditor, monaco: Monaco) => {
     setInstance(monaco);
     setEditor(editor);


### PR DESCRIPTION
## Description and Related Issue(s)

Addresses the issue with SPA transition from one contract to another when models with the same URI were not refereshed.

Steps to reproduce:

- Open the verified implementation (https://filecoin.blockscout.com/address/0xaD5c7e49fb0407Ec607d8880431b705Ea292DA4c?tab=contract)
- Expand "2 Libraries" next to "Contract source code (Solidity)"
- Click into SignatureVerificationLib. Instead of loading the verified code for the contract at that address, it uses the code from the previous page (has TerminateService)!
- Refresh the page. Now the code is correct (does not have TerminateService)!

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
