### PR TITLE
Mixpanel: route data to EU servers

### DIFF
--- a/src/services/mixpanel/useMixpanelInit.tsx
+++ b/src/services/mixpanel/useMixpanelInit.tsx
@@ -31,6 +31,7 @@ export default function useMixpanelInit() {
     const mixpanelConfig: Partial<Config> = {
       debug: Boolean(debugFlagQuery.current || debugFlagCookie),
       persistence: 'localStorage',
+      api_host: 'https://api-eu.mixpanel.com',
       ...config.services.mixpanel.configOverrides,
     };
     const isAuth = Boolean(cookies.get(cookies.NAMES.API_TOKEN));


### PR DESCRIPTION
## Description and Related Issue(s)

Update Mixpanel API host to address the [deprecation notice](https://docs.mixpanel.com/changelogs/2026-02-20-eu-forwarding-deprecation)

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
