### PR TITLE
Run independent Checks workflow steps in parallel

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,20 +51,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run ESLint
-        run: pnpm lint:eslint
+      - parallel:
+          - name: Run ESLint
+            run: pnpm lint:eslint
 
-      - name: Compile TypeScript
-        run: pnpm lint:tsc
+          - name: Compile TypeScript
+            run: pnpm lint:tsc
 
-      - name: Check licenses
-        run: pnpm lint:license:check
+          - name: Check licenses
+            run: pnpm lint:license:check
 
-      - name: Check spelling
-        run: pnpm lint:cspell --no-progress
+          - name: Check spelling
+            run: pnpm lint:cspell --no-progress
 
-      - name: Check preset lists are in sync with registry
-        run: pnpm presets:lint
+          - name: Check preset lists are in sync with registry
+            run: pnpm presets:lint
 
   toolkit_build_check:
     name: Toolkit build check
@@ -89,11 +90,12 @@ jobs:
       - name: Install project dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Type check the package
-        run: pnpm --filter @blockscout/ui-toolkit typecheck
+      - parallel:
+          - name: Type check the package
+            run: pnpm --filter @blockscout/ui-toolkit typecheck
 
-      - name: Build the package
-        run: pnpm --filter @blockscout/ui-toolkit build
+          - name: Build the package
+            run: pnpm --filter @blockscout/ui-toolkit build
 
       - name: Verify build output
         run: |


### PR DESCRIPTION
## Description and Related Issue(s)

Adopts GitHub Actions' new `parallel` step syntax to run independent lint and toolkit build steps concurrently, reducing wall-clock time on the Checks workflow critical path.

Recent runs showed the five sequential lint steps in `code_quality` taking ~148–178s combined (ESLint ~85–97s, TSC ~54–65s, plus smaller checks). Running them in parallel should bring that down toward the slowest step (~90s). Toolkit `typecheck` + `build` (~40s sequential) are parallelized for an additional ~15s savings.

### Proposed Changes

- Wrap ESLint, TSC, license, cspell, and presets lint steps in a `parallel` block in the `code_quality` job
- Wrap toolkit `typecheck` and `build` in a `parallel` block in `toolkit_build_check` (verify step still runs after both complete)

### Breaking or Incompatible Changes

None. Requires GitHub-hosted runners with support for parallel steps (introduced June 2026).

### Additional Information

- [GitHub Changelog: Actions steps can now be run in parallel](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/)
- Compare `code_quality` and `toolkit_build_check` job durations against recent main-branch runs after merge

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request

Made with [Cursor](https://cursor.com)