### PR TITLE
Agent context and skills for the API layer

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -6,6 +6,7 @@ Some directories have a `CONTEXT.md` documenting non-obvious patterns specific t
 
 - `deploy/scripts/` — how the frontend container is built and starts up (Dockerfile stages, entrypoint).
 - `deploy/tools/envs-validator/` — startup validation of `NEXT_PUBLIC_*` envs against yup schemas.
+- `src/api/` — how a resource's real request URL is resolved (registry + `config.ts` env vars + a live instance's `/node-api/config`).
 - `src/slices/` — slice ownership model (who owns an entity's rendering).
 - `src/sprite/` — SVG sprite build pipeline and which outputs are tracked vs. generated.
 - `src/toolkit/` — the `@blockscout/ui-toolkit` workspace package structure.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -6,7 +6,7 @@ Some directories have a `CONTEXT.md` documenting non-obvious patterns specific t
 
 - `deploy/scripts/` — how the frontend container is built and starts up (Dockerfile stages, entrypoint).
 - `deploy/tools/envs-validator/` — startup validation of `NEXT_PUBLIC_*` envs against yup schemas.
-- `src/api/` — how a resource's real request URL is resolved (registry + `config.ts` env vars + a live instance's `/node-api/config`).
+- `src/api/` — how a request URL is assembled (resource registry, runtime config, `/node-api/config`) and where resource response types come from.
 - `src/slices/` — slice ownership model (who owns an entity's rendering).
 - `src/sprite/` — SVG sprite build pipeline and which outputs are tracked vs. generated.
 - `src/toolkit/` — the `@blockscout/ui-toolkit` workspace package structure.

--- a/.agents/rules/architecture.mdc
+++ b/.agents/rules/architecture.mdc
@@ -46,7 +46,7 @@ All application source lives under `/src`. Code is co-located by **slice** (core
 
 | Path | Role |
 |---|---|
-| `src/api/` | Transport, fetch utilities, query client, WebSocket, data-fetching hooks |
+| `src/api/` | Transport, fetch utilities, query client, WebSocket, data-fetching hooks, per-service resource registry (`resources/`) |
 | `src/shell/` | App chrome: layout, header, footer, navigation, top-bar, root contexts |
 | `src/slices/` | Core explorer entities — always present on any vanilla EVM chain |
 | `src/features/` | Optional / config-gated product areas |

--- a/.agents/skills/add-api-resource/SKILL.md
+++ b/.agents/skills/add-api-resource/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: add-api-resource
+description: Declare new API resource(s) in an existing API service — registry entry, payload typing, pagination. Use whenever the app needs to call an endpoint that has no `service:name` resource yet.
+---
+
+# Add an API resource (to an existing service)
+
+Every request the app makes goes through a **resource**: an entry in the per-service registry
+under `src/api/resources/services/**` that maps a `service:name` key (e.g. `core:token`,
+`stats:lines`) to a path template and, via a sibling conditional type, to its response type.
+This skill declares new resource(s) in an **existing** service.
+
+**Out of scope — brand-new service.** Adding a whole new API service also touches
+`src/api/resources/index.ts` (register it in `RESOURCES` and add a branch to each dispatch
+type: `ResourcePayload`, `PaginationFilters`, `PaginationSorting`) plus a config block in
+`src/api/config.ts`. That is not covered here.
+
+**Out of scope — consuming the resource.** Wiring it into UI (`useApiQuery` /
+`useQueryWithPages`, stubs) is the caller's job; this skill only makes the resource exist and
+be correctly typed.
+
+**Background reading:** `src/api/CONTEXT.md` — how a resource's real URL is resolved
+(*Resolving a resource's real request URL*) and where response types come from (*Where a
+resource's response types come from*). Both sections are used below; read them first.
+
+**Rule of thumb: never guess.** Whenever information is missing or required to proceed,
+**pause and ask the user, or confirm your findings**, before writing files.
+
+## Step 0 — Interview (REQUIRED before writing anything)
+
+Collect for **each** resource, and confirm with the user:
+
+1. **Service + endpoint path** — must come from the user or the task description. **Never
+   hunt for endpoints** in specs or type packages yourself; if the path (or the HTTP service
+   it belongs to) isn't given, ask. Then propose the `service:name` key — follow the naming
+   of the sibling entries in the service's registry file.
+2. **A live instance that has the endpoint deployed** — an alias from
+   `tools/dev-server/registry.json` or a full instance URL. A brand-new endpoint may exist
+   only on a staging instance; ask which. This powers Step 1.
+3. **Filters / sorting** — note only the filters/sorts the task description explicitly names
+   (see Step 4). Do not derive any from the API.
+
+## Step 1 — Fetch a real sample response
+
+Resolve the resource's real URL with the recipe in `src/api/CONTEXT.md` (path template +
+URL-relevant env-var names from `src/api/config.ts` + their values from the instance's
+`GET <host>/node-api/config`), then make **one GET per resource** and save each body to the
+scratchpad. This sample is load-bearing three times over:
+
+- it **proves the endpoint exists** on the chosen instance (a 404 here stops the task);
+- it **settles pagination deterministically** — the resource is paginated **iff** the body
+  has a `next_page_params` field (Step 2);
+- it is the **ground truth for typing** (Step 3) and later for stub values in the wiring
+  phase.
+
+If the endpoint needs auth or params you can't supply, show the user the resolved URL and ask
+them for a sample body instead.
+
+## Step 2 — Add the resource entry
+
+All edits for an existing service live in its registry file — Core API:
+`resources/services/core/<group>.ts` (e.g. `token.ts`); micro-service:
+`resources/services/<name>.ts`. Add the entry to the `*_API_RESOURCES` object — shape is
+`ApiResource` (`resources/types.ts`): `{ path, pathParams?, filterFields?, paginated?,
+headers? }`.
+
+- `path` uses `:param` placeholders; list each one in `pathParams`.
+- `paginated: true` **only** if the Step 1 sample has `next_page_params`.
+
+**No `resources/index.ts` edit is needed** — the `ResourceName` union and the dispatch types
+aggregate per-service keys automatically.
+
+## Step 3 — Add the payload-type branch
+
+Add a matching branch to the sibling `*ResourcePayload<R>` conditional type **in the same
+file**. Miss this and `ResourcePayload<'service:new'>` silently resolves to **`never`** — no
+error at the declaration, just untyped data downstream. Where the response type comes from
+depends on the API:
+
+- **Core API** — use the generated `@blockscout/api-types` package; its README *Usage*
+  section (`node_modules/@blockscout/api-types/README.md`) is the reference for how to name
+  a response type (`schemas[…]`, `operations[…]`, `paths[…]['get']`).
+- **Micro-service APIs** — the types package has **no path → response-type map**, so the
+  connection can't be derived mechanically. Pick the interface that looks right for the
+  endpoint, **check it field-by-field against the Step 1 sample body**, and **confirm the
+  choice with the user** before relying on it.
+- **Local types** — some payloads are hand-typed in a slice/feature `types/api.ts` rather
+  than generated; see *Where a resource's response types come from* in `src/api/CONTEXT.md`.
+
+## Step 4 — Filters / sorting (only when the task names them)
+
+Not every paginated resource has them. Add `filterFields` and branches to the service's
+`*PaginationFilters<R>` / `*PaginationSorting<R>` types **only** for the filters/sorts named
+in the task description or conversation — **never infer them** from the API. Define the
+filter/sort types themselves in the owning slice/feature `types/api.ts` (kept local by
+design).
+
+## Step 5 — Verify
+
+Run `pnpm run lint:tsc`. To catch a missed Step 3 branch (the silent `never`), use the inline
+type-assertion pattern already present in `resources/index.ts` (e.g. the
+`ResourcePayload<'core:api_keys'>` / `ResourcePathParams<'bens:address_domain'>` checks) as a
+temporary probe for your new key — or hover/`tsc`-check a `ResourcePayload<'service:new'>`
+usage and confirm it is not `never`.
+
+## Output
+
+Report back, per resource: the `service:name` key, the payload type (and its origin —
+package or local), whether it's paginated, and the scratchpad path of the sample body —
+everything a follow-up consumption task needs.

--- a/.agents/skills/add-api-resource/SKILL.md
+++ b/.agents/skills/add-api-resource/SKILL.md
@@ -37,7 +37,16 @@ Collect for **each** resource, and confirm with the user:
 2. **A live instance that has the endpoint deployed** — an alias from
    `tools/dev-server/registry.json` or a full instance URL. A brand-new endpoint may exist
    only on a staging instance; ask which. This powers Step 1.
-3. **Filters / sorting** — note only the filters/sorts the task description explicitly names
+3. **Types-package state** — ask whether the response interface is already available in a
+   **published** version of the service's types package. For a brand-new endpoint it often
+   isn't (stable versions are published only on API releases). If yes, the user should provide
+   the exact version of the package. If not — or the user is unsure — collect the 
+   `publish-beta-types` Step 0 inputs **now** (most importantly the API source-repo branch to 
+   publish from), so the publish can run later without another interview. If the user already
+   knows publishing is **impossible** (no repo access, broken workflow, no spec/types
+   generated for the endpoint yet), settle the fallback now too: temporary local type, or
+   defer the resource — see *Worst case* in Step 3.
+4. **Filters / sorting** — note only the filters/sorts the task description explicitly names
    (see Step 4). Do not derive any from the API.
 
 ## Step 1 — Fetch a real sample response
@@ -86,6 +95,28 @@ depends on the API:
   choice with the user** before relying on it.
 - **Local types** — some payloads are hand-typed in a slice/feature `types/api.ts` rather
   than generated; see *Where a resource's response types come from* in `src/api/CONTEXT.md`.
+
+**Type not published yet?** If Step 0 established the interface isn't in any published
+package version, don't hand-type a stopgap: **invoke the `publish-beta-types` skill** with
+the inputs already collected in Step 0, then continue with this step. Same move if you only
+discover the gap here (the interface missing from `node_modules` even at `latest` despite
+the interview answer) — in that case the publish inputs still need collecting.
+
+**Worst case — no published types *and* no publish possible** (no access to the API repo,
+publish workflow broken, or the API branch doesn't generate types for the endpoint yet, so
+there's nothing to publish). Confirm the blocker, then **the user picks** one of two paths —
+never pick silently:
+
+- **Temporary local type** — hand-type the payload in the owning slice/feature
+  `types/api.ts` (the usual home for local types — see *Where a resource's response types
+  come from* in `src/api/CONTEXT.md`; some `core:*` payloads already live this way), derived
+  from the Step 1 sample body, and reference it from the payload branch. Mark it
+  `// TODO (api-types): replace with the generated @blockscout/<pkg> type once published` so
+  the swap can be found with a grep later. Caveat: one sample can't reveal **optional/nullable** fields —
+  confirm optionality with the user instead of inferring it from a single body.
+- **Defer the resource** — stop here, leaving the resource undeclared until types can be
+  published. In a page flow this degrades to layout-only (the page's `TODO (api-data):`
+  markers stay in place).
 
 ## Step 4 — Filters / sorting (only when the task names them)
 

--- a/.agents/skills/add-api-resource/SKILL.md
+++ b/.agents/skills/add-api-resource/SKILL.md
@@ -17,9 +17,8 @@ This skill declares new resource(s) in an **existing** service.
 `useQueryWithPages`, stubs) is the caller's job; this skill only makes the resource exist and
 be correctly typed.
 
-**Background reading:** `src/api/CONTEXT.md` — how a resource's real URL is resolved
-(*Resolving a resource's real request URL*) and where response types come from (*Where a
-resource's response types come from*). Both sections are used below; read them first.
+**Background reading:** *Where a resource's response types come from* in
+`src/api/CONTEXT.md` — read it before Step 3.
 
 **Rule of thumb: never guess.** Whenever information is missing or required to proceed,
 **pause and ask the user, or confirm your findings**, before writing files.
@@ -48,10 +47,9 @@ Collect for **each** resource, and confirm with the user:
 
 ## Step 1 — Fetch a real sample response
 
-Resolve the resource's real URL with the recipe in `src/api/CONTEXT.md` (path template +
-URL-relevant env-var names from `src/api/config.ts` + their values from the instance's
-`GET <host>/node-api/config`), then make **one GET per resource** and save each body to the
-scratchpad. This sample is load-bearing three times over:
+Resolve each resource's real URL with the **`resolve-api-url` skill**, then make **one GET
+per resource** and save each body to the scratchpad. This sample is load-bearing three
+times over:
 
 - it **proves the endpoint exists** on the chosen instance (a 404 here stops the task);
 - it **settles pagination deterministically** — the resource is paginated **iff** the body

--- a/.agents/skills/add-api-resource/SKILL.md
+++ b/.agents/skills/add-api-resource/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-api-resource
-description: Declare new API resource(s) in an existing API service — registry entry, payload typing, pagination. Use whenever the app needs to call an endpoint that has no `service:name` resource yet.
+description: Declare new API resource(s) in an existing API service. Use whenever the app needs to call an endpoint that has no `service:name` resource yet.
 ---
 
 # Add an API resource (to an existing service)
@@ -10,10 +10,8 @@ under `src/api/resources/services/**` that maps a `service:name` key (e.g. `core
 `stats:lines`) to a path template and, via a sibling conditional type, to its response type.
 This skill declares new resource(s) in an **existing** service.
 
-**Out of scope — brand-new service.** Adding a whole new API service also touches
-`src/api/resources/index.ts` (register it in `RESOURCES` and add a branch to each dispatch
-type: `ResourcePayload`, `PaginationFilters`, `PaginationSorting`) plus a config block in
-`src/api/config.ts`. That is not covered here.
+**Out of scope — brand-new service.** That also touches `src/api/resources/index.ts`
+(registration + dispatch-type branches) and a `src/api/config.ts` block; not covered here.
 
 **Out of scope — consuming the resource.** Wiring it into UI (`useApiQuery` /
 `useQueryWithPages`, stubs) is the caller's job; this skill only makes the resource exist and
@@ -43,9 +41,8 @@ Collect for **each** resource, and confirm with the user:
    the exact version of the package. If not — or the user is unsure — collect the 
    `publish-beta-types` Step 0 inputs **now** (most importantly the API source-repo branch to 
    publish from), so the publish can run later without another interview. If the user already
-   knows publishing is **impossible** (no repo access, broken workflow, no spec/types
-   generated for the endpoint yet), settle the fallback now too: temporary local type, or
-   defer the resource — see *Worst case* in Step 3.
+   knows publishing is **impossible**, settle the fallback choice now too — see *Worst case*
+   in Step 3.
 4. **Filters / sorting** — note only the filters/sorts the task description explicitly names
    (see Step 4). Do not derive any from the API.
 

--- a/.agents/skills/add-api-resource/SKILL.md
+++ b/.agents/skills/add-api-resource/SKILL.md
@@ -63,15 +63,15 @@ them for a sample body instead.
 ## Step 2 — Add the resource entry
 
 All edits for an existing service live in its registry file — Core API:
-`resources/services/core/<group>.ts` (e.g. `token.ts`); micro-service:
-`resources/services/<name>.ts`. Add the entry to the `*_API_RESOURCES` object — shape is
-`ApiResource` (`resources/types.ts`): `{ path, pathParams?, filterFields?, paginated?,
+`src/api/resources/services/core/<group>.ts` (e.g. `token.ts`); micro-service:
+`src/api/resources/services/<name>.ts`. Add the entry to the `*_API_RESOURCES` object — shape is
+`ApiResource` (`src/api/resources/types.ts`): `{ path, pathParams?, filterFields?, paginated?,
 headers? }`.
 
 - `path` uses `:param` placeholders; list each one in `pathParams`.
 - `paginated: true` **only** if the Step 1 sample has `next_page_params`.
 
-**No `resources/index.ts` edit is needed** — the `ResourceName` union and the dispatch types
+**No `src/api/resources/index.ts` edit is needed** — the `ResourceName` union and the dispatch types
 aggregate per-service keys automatically.
 
 ## Step 3 — Add the payload-type branch
@@ -124,7 +124,7 @@ design).
 ## Step 5 — Verify
 
 Run `pnpm run lint:tsc`. To catch a missed Step 3 branch (the silent `never`), use the inline
-type-assertion pattern already present in `resources/index.ts` (e.g. the
+type-assertion pattern already present in `src/api/resources/index.ts` (e.g. the
 `ResourcePayload<'core:api_keys'>` / `ResourcePathParams<'bens:address_domain'>` checks) as a
 temporary probe for your new key — or hover/`tsc`-check a `ResourcePayload<'service:new'>`
 usage and confirm it is not `never`.

--- a/.agents/skills/add-new-page/SKILL.md
+++ b/.agents/skills/add-new-page/SKILL.md
@@ -109,7 +109,10 @@ obvious from the conversation or the codebase.
    the API **service + endpoint path** that feeds it — given by the user, **never hunted for** (the
    `service:name` key if the resource is already declared) — and the **live instance** to sample data from
    (a `tools/dev-server/registry.json` alias or a full URL; a new endpoint may exist only on staging). If
-   the endpoint isn't deployed anywhere yet, wiring is deferred — layout only.
+   the endpoint isn't deployed anywhere yet, wiring is deferred — layout only. For each resource that
+   doesn't exist yet, also run the **Step 0 interview of the `add-api-resource` skill** here (it adds the
+   types-package-state question, among others) — after this step, no question should remain for the middle
+   of the work.
 
 Proceed only once these are settled.
 

--- a/.agents/skills/add-new-page/SKILL.md
+++ b/.agents/skills/add-new-page/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-new-page
-description: Scaffold a new page (index / detail / general) and optionally wire it to API data. Use when adding any new route to the app.
+description: Scaffold a new page (index / detail / general) and optionally wire it to API data. Use when adding any new route to the app, or when wiring API data into an already-scaffolded page (one with `TODO (api-data):` markers).
 ---
 
 # Add a new page
@@ -15,11 +15,10 @@ sorting, search, socket live-updates, mocks, tests, and design polish are out of
 wiring is deferred, the freshly-scaffolded page keeps its intentional `TODO`s and will not fully pass
 `lint`/`tsc` until its data is wired — that is expected.
 
-**TODO tags.** Every deferred piece of work is marked with a stage-tagged TODO so later stages can find their
-worklist mechanically: **`TODO (api-data):`** — resolved by the data-wiring phase (`wiring.md`); grep for the
-tag to find every spot. **`TODO (design):`** — content/representation decisions left for the design stage
-(icons, field hints, uncertain value formatting); the wiring phase leaves these behind, never resolves them.
-Keep the tags when scaffolding, and use them for any new deferred work you mark.
+**TODO tags.** Every deferred piece of work is marked with a stage-tagged TODO, so each later stage can find
+its worklist with a grep: **`TODO (api-data):`** — resolved by the data-wiring phase (`wiring.md`);
+**`TODO (design):`** — content/representation decisions left for the design stage (icons, field hints,
+uncertain value formatting). Keep the tags when scaffolding, and use them for any new deferred work you mark.
 
 **Rule of thumb: never guess.** Whenever information is missing or required to proceed, **pause and ask the
 user, or confirm your findings**, before writing files.
@@ -110,9 +109,8 @@ obvious from the conversation or the codebase.
    `service:name` key if the resource is already declared) — and the **live instance** to sample data from
    (a `tools/dev-server/registry.json` alias or a full URL; a new endpoint may exist only on staging). If
    the endpoint isn't deployed anywhere yet, wiring is deferred — layout only. For each resource that
-   doesn't exist yet, also run the **Step 0 interview of the `add-api-resource` skill** here (it adds the
-   types-package-state question, among others) — after this step, no question should remain for the middle
-   of the work.
+   doesn't exist yet, also run the **Step 0 interview of the `add-api-resource` skill** here — after this
+   step, no question should remain for the middle of the work.
 
 Proceed only once these are settled.
 
@@ -268,10 +266,8 @@ is wired (Step 10, or deferred follow-up work) — don't gate on it at this stag
 
 ## Step 10 — Wire data (if agreed in Step 0)
 
-If Step 0 settled on wiring data now, read **`wiring.md`** (next to this file) and follow it: it declares the
-resources via the `add-api-resource` skill, adds minimal loading stubs, wires `useApiQuery` /
-`useQueryWithPages` (+ pagination controls for paginated lists), and renders every payload field plainly.
-After it, both `tsc` and ESLint must pass.
+If Step 0 settled on wiring data now, read **`wiring.md`** (next to this file) and follow it. This step is
+done when its verify step (W5) passes.
 
 **Direct entry** — for a page scaffolded earlier (its `TODO (api-data):` markers are still in place), skip
 Steps 1–9: run only the *Data* item of the Step 0 interview, then start at `wiring.md`.

--- a/.agents/skills/add-new-page/SKILL.md
+++ b/.agents/skills/add-new-page/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-new-page
-description: Scaffold and wire up a new page (index / detail / general). Use when adding any new route to the app.
+description: Scaffold a new page (index / detail / general) and optionally wire it to API data. Use when adding any new route to the app.
 ---
 
 # Add a new page
@@ -8,10 +8,18 @@ description: Scaffold and wire up a new page (index / detail / general). Use whe
 This skill scaffolds the **page layout** from a per-type template and wires the page into every system that
 must know about it (navigation, metadata, server guard, route types, analytics, sitemap).
 
-**Scope — layout only.** The scaffold produces layout skeletons with clearly-marked `TODO`s. **Wiring up API
-data, pagination, filtering, sorting, and action bars is out of scope** and left to follow-up work. No stubs,
-mocks, or tests are produced here. As a consequence, a freshly-scaffolded page contains intentional `TODO`s
-and will not fully pass `lint`/`tsc` until its data is wired — that is expected.
+**Two phases.** The **scaffold** phase (Steps 0–9) produces layout skeletons with clearly-marked `TODO`s. The
+optional **data-wiring** phase (Step 10, procedure in `wiring.md`) then connects those skeletons to real API
+resources and renders the data plainly — Step 0 decides whether it runs now or is deferred. Filtering,
+sorting, search, socket live-updates, mocks, tests, and design polish are out of scope in both phases. If
+wiring is deferred, the freshly-scaffolded page keeps its intentional `TODO`s and will not fully pass
+`lint`/`tsc` until its data is wired — that is expected.
+
+**TODO tags.** Every deferred piece of work is marked with a stage-tagged TODO so later stages can find their
+worklist mechanically: **`TODO (api-data):`** — resolved by the data-wiring phase (`wiring.md`); grep for the
+tag to find every spot. **`TODO (design):`** — content/representation decisions left for the design stage
+(icons, field hints, uncertain value formatting); the wiring phase leaves these behind, never resolves them.
+Keep the tags when scaffolding, and use them for any new deferred work you mark.
 
 **Rule of thumb: never guess.** Whenever information is missing or required to proceed, **pause and ask the
 user, or confirm your findings**, before writing files.
@@ -97,6 +105,11 @@ obvious from the conversation or the codebase.
    belongs to.
 5. **Metadata** — **suggest** a default page title and description; let the user confirm or refine. Default
    only — do **not** add `enhanced` variants.
+6. **Data — wire data now, or layout only?** If now, collect for **each content body** (per tab if tabbed):
+   the API **service + endpoint path** that feeds it — given by the user, **never hunted for** (the
+   `service:name` key if the resource is already declared) — and the **live instance** to sample data from
+   (a `tools/dev-server/registry.json` alias or a full URL; a new endpoint may exist only on staging). If
+   the endpoint isn't deployed anywhere yet, wiring is deferred — layout only.
 
 Proceed only once these are settled.
 
@@ -157,7 +170,7 @@ Use the single page shell that embeds its one content body directly:
    `GeneralInfo`), **named after the tab** (`__PageName__<TabName>`, see the folders & naming rule above).
    Wire the renamed components into the shell's `tabs` array and imports.
 
-Leave the `// TODO: wire up data …` markers in place — data fetching is out of scope.
+Leave the `// TODO (api-data): …` markers in place — data fetching belongs to the wiring phase (Step 10).
 
 ## Step 3 — Route file + server guard
 
@@ -195,12 +208,12 @@ In `src/shell/navigation/useNavItems.tsx` add a `NavItem` to the group agreed in
 const __featureName__: NavItem | null = config.features.__featureName__.isEnabled ? {
   text: '__title__',
   nextRoute: { pathname: '__route__' as const },
-  // TODO: set nav icon
+  // TODO (design): set nav icon
   isActive: pathname.startsWith('__route__'),
 } : null;
 ```
 For a core slice page drop the `config.features.*` guard (or gate on `config.slices.*`). **Do not invent an
-icon** — leave the `// TODO: set nav icon` comment and omit the `icon` field so the user assigns the correct
+icon** — leave the `// TODO (design): set nav icon` comment and omit the `icon` field so the user assigns the correct
 sprite later. Then insert the item into the appropriate group array.
 
 ## Step 6 — Metadata
@@ -248,4 +261,14 @@ case '__route__':
 Run `pnpm run lint:tsc` (`tsc -p ./tsconfig.json`) to confirm the new files type-check. The scaffold uses the
 `unknown` item type and never reads properties off it, so TypeScript should pass as-is. **ESLint is expected
 to fail** on the scaffold's intentional `TODO`s (unused `item` props, single-value `const`s) until the data
-is wired — don't gate on it at this stage.
+is wired (Step 10, or deferred follow-up work) — don't gate on it at this stage.
+
+## Step 10 — Wire data (if agreed in Step 0)
+
+If Step 0 settled on wiring data now, read **`wiring.md`** (next to this file) and follow it: it declares the
+resources via the `add-api-resource` skill, adds minimal loading stubs, wires `useApiQuery` /
+`useQueryWithPages` (+ pagination controls for paginated lists), and renders every payload field plainly.
+After it, both `tsc` and ESLint must pass.
+
+**Direct entry** — for a page scaffolded earlier (its `TODO (api-data):` markers are still in place), skip
+Steps 1–9: run only the *Data* item of the Step 0 interview, then start at `wiring.md`.

--- a/.agents/skills/add-new-page/templates/detail/Details.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/detail/Details.tsx.tmpl
@@ -12,12 +12,12 @@ interface Props {
 }
 
 const __PageName__Details = ({ data, isLoading }: Props) => {
-  // TODO: replace placeholder rows with real fields from the fetched data.
+  // TODO (api-data): replace placeholder rows with real fields from the fetched data.
   // Each field is a label/value pair. Use DetailedInfo.ItemDivider to group sections.
 
   return (
     <DetailedInfo.Container>
-      <DetailedInfo.ItemLabel hint="TODO: describe this field" isLoading={ isLoading }>
+      <DetailedInfo.ItemLabel hint="TODO (design): describe this field" isLoading={ isLoading }>
         Label
       </DetailedInfo.ItemLabel>
       <DetailedInfo.ItemValue>
@@ -26,7 +26,7 @@ const __PageName__Details = ({ data, isLoading }: Props) => {
         </Skeleton>
       </DetailedInfo.ItemValue>
 
-      { /* TODO: add more DetailedInfo.ItemLabel / DetailedInfo.ItemValue rows */ }
+      { /* TODO (api-data): add more DetailedInfo.ItemLabel / DetailedInfo.ItemValue rows */ }
     </DetailedInfo.Container>
   );
 };

--- a/.agents/skills/add-new-page/templates/detail/Page.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/detail/Page.tsx.tmpl
@@ -13,7 +13,7 @@ const __PageName__ = () => {
   const router = useRouter();
   const __entityParam__ = getQueryParamString(router.query.__entityParam__);
 
-  // TODO: wire up data (useApiQuery keyed by __entityParam__) — out of scaffold scope.
+  // TODO (api-data): wire up data (useApiQuery keyed by __entityParam__) — see wiring.md in the add-new-page skill.
   // Drive `isLoading` from the query's `isPlaceholderData` once wired.
   const isLoading = false;
   const data: unknown = {};

--- a/.agents/skills/add-new-page/templates/general/GeneralInfo.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/general/GeneralInfo.tsx.tmpl
@@ -5,11 +5,11 @@ import React from 'react';
 
 // General-info body — usable as a tab panel (or extract for a non-tabbed general page).
 const __PageName__GeneralInfo = () => {
-  // TODO: wire up data (useApiQuery) — out of scaffold scope
+  // TODO (api-data): wire up data (useApiQuery) — see wiring.md in the add-new-page skill
 
   return (
     <Box>
-      { /* TODO: content */ }
+      { /* TODO (api-data): content */ }
     </Box>
   );
 };

--- a/.agents/skills/add-new-page/templates/general/Page.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/general/Page.tsx.tmpl
@@ -5,12 +5,12 @@ import React from 'react';
 import PageTitle from 'src/shell/page/title/PageTitle';
 
 const __PageName__ = () => {
-  // TODO: wire up data (useApiQuery) — out of scaffold scope
+  // TODO (api-data): wire up data (useApiQuery) — see wiring.md in the add-new-page skill
 
   return (
     <>
       <PageTitle title="__title__"/>
-      { /* TODO: page content */ }
+      { /* TODO (api-data): page content */ }
     </>
   );
 };

--- a/.agents/skills/add-new-page/templates/index/Content.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/index/Content.tsx.tmpl
@@ -9,7 +9,7 @@ import __PageName__Table from 'src/__area__/__featureName__/pages/index/__PageNa
 import DataList from 'src/shared/lists/DataList';
 
 const __PageName__Content = () => {
-  // TODO: wire up data (useQueryWithPages) — out of scaffold scope.
+  // TODO (api-data): wire up data (useQueryWithPages) — see wiring.md in the add-new-page skill.
   // Pagination, filtering, sorting and the action bar are intentionally omitted from
   // this scaffold. See src/slices/block/pages/index/BlocksContent.tsx for the full pattern.
   // Three placeholder items so the table/list render visible example rows — replace with fetched data.
@@ -18,7 +18,7 @@ const __PageName__Content = () => {
   const isLoading = false;
 
   return (
-    // TODO: replace the "items"/"item" placeholders below with this page's entity —
+    // TODO (api-data): replace the "items"/"item" placeholders below with this page's entity —
     // plural in `emptyText` ("There are no validators."), singular in `emptyStateProps.term` ("validator").
     <DataList
       isError={ isError }

--- a/.agents/skills/add-new-page/templates/index/List.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/index/List.tsx.tmpl
@@ -6,7 +6,7 @@ import React from 'react';
 import __PageName__ListItem from 'src/__area__/__featureName__/pages/index/__PageName__ListItem';
 
 interface Props {
-  // TODO: replace `unknown` with the real item type
+  // TODO (api-data): replace `unknown` with the real item type
   items: Array<unknown>;
   isLoading?: boolean;
 }

--- a/.agents/skills/add-new-page/templates/index/ListItem.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/index/ListItem.tsx.tmpl
@@ -7,7 +7,7 @@ import ListItemMobileGrid from 'src/shared/lists/ListItemMobileGrid';
 import { Skeleton } from 'src/toolkit/chakra/skeleton';
 
 interface Props {
-  // TODO: replace `unknown` with the real item type
+  // TODO (api-data): replace `unknown` with the real item type
   item: unknown;
   isLoading?: boolean;
 }
@@ -15,7 +15,7 @@ interface Props {
 const __PageName__ListItem = ({ item, isLoading }: Props) => {
   return (
     <ListItemMobileGrid.Container>
-      { /* TODO: one Label/Value pair per field; render values from `item` */ }
+      { /* TODO (api-data): one Label/Value pair per field; render values from `item` */ }
       <ListItemMobileGrid.Label isLoading={ isLoading }>Label 1</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
         <Skeleton loading={ isLoading }>Value 1</Skeleton>

--- a/.agents/skills/add-new-page/templates/index/Table.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/index/Table.tsx.tmpl
@@ -7,7 +7,7 @@ import __PageName__TableItem from 'src/__area__/__featureName__/pages/index/__Pa
 import { TableBody, TableColumnHeader, TableHeaderSticky, TableRoot, TableRow } from 'src/toolkit/chakra/table';
 
 interface Props {
-  // TODO: replace `unknown` with the real item type
+  // TODO (api-data): replace `unknown` with the real item type
   items: Array<unknown>;
   isLoading?: boolean;
 }
@@ -17,7 +17,7 @@ const __PageName__Table = ({ items, isLoading }: Props) => {
     <TableRoot>
       <TableHeaderSticky top={ 0 }>
         <TableRow>
-          { /* TODO: define columns */ }
+          { /* TODO (api-data): define columns */ }
           <TableColumnHeader>Column 1</TableColumnHeader>
           <TableColumnHeader>Column 2</TableColumnHeader>
           <TableColumnHeader>Column 3</TableColumnHeader>

--- a/.agents/skills/add-new-page/templates/index/TableItem.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/index/TableItem.tsx.tmpl
@@ -6,7 +6,7 @@ import { Skeleton } from 'src/toolkit/chakra/skeleton';
 import { TableCell, TableRow } from 'src/toolkit/chakra/table';
 
 interface Props {
-  // TODO: replace `unknown` with the real item type
+  // TODO (api-data): replace `unknown` with the real item type
   item: unknown;
   isLoading?: boolean;
 }
@@ -14,7 +14,7 @@ interface Props {
 const __PageName__TableItem = ({ item, isLoading }: Props) => {
   return (
     <TableRow>
-      { /* TODO: one TableCell per column in __PageName__Table; render values from `item` */ }
+      { /* TODO (api-data): one TableCell per column in __PageName__Table; render values from `item` */ }
       <TableCell>
         <Skeleton loading={ isLoading }>Value 1</Skeleton>
       </TableCell>

--- a/.agents/skills/add-new-page/templates/tabs/PageWithTabs.tsx.tmpl
+++ b/.agents/skills/add-new-page/templates/tabs/PageWithTabs.tsx.tmpl
@@ -18,7 +18,7 @@ const __PageName__ = () => {
   //   const router = useRouter();
   //   const __entityParam__ = getQueryParamString(router.query.__entityParam__);
 
-  // TODO: wire up data (useApiQuery / useQueryWithPages) — out of scaffold scope.
+  // TODO (api-data): wire up data (useApiQuery / useQueryWithPages) — see wiring.md in the add-new-page skill.
 
   const tabs: Array<TabItemRegular> = [
     { id: 'tab1', title: 'Tab 1', component: <__PageName__Tab1/> },

--- a/.agents/skills/add-new-page/wiring.md
+++ b/.agents/skills/add-new-page/wiring.md
@@ -24,9 +24,9 @@ For each content body's resource that doesn't exist yet in `src/api/resources/se
 page interview, so don't re-ask. It hands back the `service:name` key, payload type,
 paginated flag, and a sample response body.
 
-For resources that already exist, still fetch a sample body (recipe: *Resolving a resource's
-real request URL* in `src/api/CONTEXT.md`) if you don't have one — Steps W2 and W4 need it
-for stub values and the field inventory.
+For resources that already exist, still fetch a sample body (via the `resolve-api-url`
+skill) if you don't have one — Steps W2 and W4 need it for stub values and the field
+inventory.
 
 ## Step W2 — Loading stubs
 

--- a/.agents/skills/add-new-page/wiring.md
+++ b/.agents/skills/add-new-page/wiring.md
@@ -1,0 +1,94 @@
+# Data-wiring phase (Step 10 of `add-new-page`)
+
+Wires the scaffolded page components to real API data and displays it **plainly** — this is a
+data pass, not a design pass. Entered from Step 10 of `SKILL.md`, or directly for a page that
+was scaffolded earlier (its `TODO (api-data):` markers are still in place); on direct entry
+run the *Data* item of the Step 0 interview first.
+
+**The worklist is the tag.** Grep the page's directories for `TODO (api-data):` — every hit
+(page shell, `Content`, `Table`/`TableItem`, `List`/`ListItem`, `Details`, `GeneralInfo`) is
+a spot this phase must resolve, and the phase is done only when the grep comes back empty.
+`TODO (design):` markers are the next stage's worklist — leave them in place, and add new
+ones for any representation decision you defer (Step W4).
+
+**In scope:** resource declaration (via the `add-api-resource` skill), minimal loading stubs,
+`useApiQuery` / `useQueryWithPages` wiring, pagination controls, plain rendering of every
+payload field.
+**Out of scope:** filters, sorting, search, socket live-updates, mocks, tests, and design
+polish — unless the task explicitly names them.
+
+## Step W1 — Declare missing resources
+
+For each content body's resource that doesn't exist yet in `src/api/resources/services/**`,
+**invoke the `add-api-resource` skill** — all resource-level questions (endpoint path, live
+instance, pagination detection, payload typing) happen there, and it hands back the
+`service:name` key, payload type, paginated flag, and a sample response body.
+
+For resources that already exist, still fetch a sample body (recipe: *Resolving a resource's
+real request URL* in `src/api/CONTEXT.md`) if you don't have one — Steps W2 and W4 need it
+for stub values and the field inventory.
+
+## Step W2 — Loading stubs
+
+The loading UI renders skeleton rows over placeholder data (`isPlaceholderData` → the
+`isLoading` props the scaffold already threads through), so each resource needs a **minimal
+stub** in the owning slice/feature `stubs.ts` (or `stubs/`):
+
+- Type it with the payload type; for a paginated list, the stub is a **single item**
+  (exemplar: `BLOCK_ITEM: schemas['Block']` in `src/slices/block/stubs/list.ts`).
+- Copy/adapt realistic values from the sample body — don't invent shapes.
+- Reuse existing shared stub fragments where they fit (e.g. `ADDRESS_PARAMS`).
+
+Mocks and tests are **not** produced here.
+
+## Step W3 — Wire the queries (by content type)
+
+Replace the scaffold's placeholder `items` / `data` / `isLoading` / `isError` consts, and
+replace the `unknown` item/data types with the payload (item) type **everywhere it appears** —
+the page shell *and* the `Table`/`TableItem`/`List`/`ListItem` (or `Details`) components each
+carry their own `unknown` marker.
+
+- **index, paginated resource** — in the page shell, `useQueryWithPages({ resourceName,
+  options: { placeholderData: generateListStub<'service:name'>(ITEM_STUB, 50,
+  { next_page_params: { … } }) } })`; take the `next_page_params` keys from the sample body.
+  Thread the query down to the content body; pass `isPlaceholderData` as `isLoading` and
+  `query.pagination.page` where row indexes need it. Add an `ActionBar` with `Pagination`,
+  gated on `pagination.isVisible`. Exemplar: `src/slices/address/pages/index/Accounts.tsx`
+  (minimal, socket-free); for a tabbed page with one query per tab (each gated with
+  `enabled: tab === '…'`), see `src/slices/block/pages/index/Blocks.tsx`.
+- **index, non-paginated resource** — `useApiQuery('service:name', { queryOptions: {
+  placeholderData: <array-of-stub-items payload> } })`; no `ActionBar`/`Pagination`.
+- **detail** — in the page shell, `useApiQuery('service:name', { pathParams: { …: __entityParam__ },
+  queryOptions: { enabled: Boolean(__entityParam__), placeholderData: STUB } })`; pass
+  `data` and `isPlaceholderData` (as `isLoading`) into the `Details` body. The minimal
+  pattern is the `query` at the top of `src/slices/token/hooks/useTokenQuery.ts` — 
+  ignore `initialData`.
+- **general** — `useApiQuery` + stub, same shape as detail minus `pathParams`.
+
+## Step W4 — Render every field, plainly
+
+Inventory the payload fields from the type + sample body and render **all of them** in the
+scaffolded body — `DetailedInfo` rows in `Details` for detail pages; for index pages the
+columns in `Table`, the cells in `TableItem`, **and** the label/value pairs in `ListItem`
+(desktop and mobile views must show the same fields); free layout in `GeneralInfo` for
+general:
+
+- Use the obvious shared component **only when the field is unambiguous** — an address
+  object/hash → `AddressEntity`, a tx hash → `TxEntity`, a block → `BlockEntity`, a
+  timestamp → the shared time-format helpers.
+- Everything else is **plain text**: numbers/strings as-is; nested objects either split into
+  sub-fields or JSON-stringified. **Never invent formatting** (no rounding, units, or
+  truncation decisions). Add `// TODO (design): <field> representation` comment to it.
+- When unsure how a field should be represented, render it as plain text with a
+  `// TODO (design): <field> representation` comment — and **list all such fields to the
+  user at the end** so the design pass has a worklist.
+- Replace the scaffold's generic `DataList` placeholders with the real entity: plural
+  sentence in `emptyText`, singular `emptyStateProps.term`.
+
+## Step W5 — Verify
+
+No `TODO (api-data):` marker may remain in the page's directories (grep to confirm). 
+Both `pnpm run lint:tsc` **and** ESLint must now pass — the scaffold's intentional lint 
+failures are resolved by wiring; don't leave suppressions behind. Then suggest the user 
+run the dev server against the instance chosen in the interview (see `tools/dev-server/`) 
+to eyeball the page with real data.

--- a/.agents/skills/add-new-page/wiring.md
+++ b/.agents/skills/add-new-page/wiring.md
@@ -20,9 +20,11 @@ polish — unless the task explicitly names them.
 ## Step W1 — Declare missing resources
 
 For each content body's resource that doesn't exist yet in `src/api/resources/services/**`,
-**invoke the `add-api-resource` skill** — all resource-level questions (endpoint path, live
-instance, pagination detection, payload typing) happen there, and it hands back the
-`service:name` key, payload type, paginated flag, and a sample response body.
+**invoke the `add-api-resource` skill** — its Step 0 answers (endpoint path, live instance,
+types-package state, …) were already collected in the page interview, so don't re-ask; the
+skill does the work (sample fetch, pagination detection, payload typing — publishing beta
+types first if needed) and hands back the `service:name` key, payload type, paginated flag,
+and a sample response body.
 
 For resources that already exist, still fetch a sample body (recipe: *Resolving a resource's
 real request URL* in `src/api/CONTEXT.md`) if you don't have one — Steps W2 and W4 need it

--- a/.agents/skills/add-new-page/wiring.md
+++ b/.agents/skills/add-new-page/wiring.md
@@ -7,9 +7,9 @@ run the *Data* item of the Step 0 interview first.
 
 **The worklist is the tag.** Grep the page's directories for `TODO (api-data):` — every hit
 (page shell, `Content`, `Table`/`TableItem`, `List`/`ListItem`, `Details`, `GeneralInfo`) is
-a spot this phase must resolve, and the phase is done only when the grep comes back empty.
-`TODO (design):` markers are the next stage's worklist — leave them in place, and add new
-ones for any representation decision you defer (Step W4).
+a spot this phase must resolve (the done-condition is checked in Step W5). `TODO (design):`
+markers are the next stage's worklist — leave them in place, and add new ones for any
+representation decision you defer (Step W4).
 
 **In scope:** resource declaration (via the `add-api-resource` skill), minimal loading stubs,
 `useApiQuery` / `useQueryWithPages` wiring, pagination controls, plain rendering of every
@@ -20,11 +20,9 @@ polish — unless the task explicitly names them.
 ## Step W1 — Declare missing resources
 
 For each content body's resource that doesn't exist yet in `src/api/resources/services/**`,
-**invoke the `add-api-resource` skill** — its Step 0 answers (endpoint path, live instance,
-types-package state, …) were already collected in the page interview, so don't re-ask; the
-skill does the work (sample fetch, pagination detection, payload typing — publishing beta
-types first if needed) and hands back the `service:name` key, payload type, paginated flag,
-and a sample response body.
+**invoke the `add-api-resource` skill** — its Step 0 answers were already collected in the
+page interview, so don't re-ask. It hands back the `service:name` key, payload type,
+paginated flag, and a sample response body.
 
 For resources that already exist, still fetch a sample body (recipe: *Resolving a resource's
 real request URL* in `src/api/CONTEXT.md`) if you don't have one — Steps W2 and W4 need it
@@ -80,9 +78,8 @@ general:
   timestamp → the shared time-format helpers.
 - Everything else is **plain text**: numbers/strings as-is; nested objects either split into
   sub-fields or JSON-stringified. **Never invent formatting** (no rounding, units, or
-  truncation decisions). Add `// TODO (design): <field> representation` comment to it.
-- When unsure how a field should be represented, render it as plain text with a
-  `// TODO (design): <field> representation` comment — and **list all such fields to the
+  truncation decisions) — tag each plain-text field with
+  `// TODO (design): <field> representation` instead, and **list all tagged fields to the
   user at the end** so the design pass has a worklist.
 - Replace the scaffold's generic `DataList` placeholders with the real entity: plural
   sentence in `emptyText`, singular `emptyStateProps.term`.

--- a/.agents/skills/publish-beta-types/SKILL.md
+++ b/.agents/skills/publish-beta-types/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: publish-beta-types
+description: Publish a beta version of a `@blockscout/*-types` npm package from an API feature branch and pin it in this repo. Use when a needed response type isn't in any published package version yet.
+---
+
+# Publish a beta types package
+
+The `@blockscout/*-types` packages are generated from each API's OpenAPI spec or Protobuf **in the API's
+own source repo** and published to npm; this repo only pins versions in `package.json`.
+Stable versions are published automatically on API releases — so when work here depends on a
+**not-yet-released** API (e.g. one deployed only to staging), its types must be published as
+a **beta** first, manually, and pinned by exact version.
+
+**Background reading:** *Where a resource's response types come from* in `src/api/CONTEXT.md`
+(provenance, stable vs. beta channels, why `@beta` must never be used).
+
+**Rule of thumb: never guess.** Whenever information is missing or required to proceed,
+**pause and ask the user, or confirm your findings**, before acting.
+
+## Step 0 — Interview + prerequisites
+
+1. **Which API service** the types are for — maps to a package/repo/workflow in the table
+   below.
+2. **Which branch of the API source repo to publish from** — the beta is built from that
+   branch's HEAD, so this identifies the API version you'll get. It must come from the user
+   or the task (typically the API feature branch deployed to staging); **never assume** a
+   branch, and never publish from the default branch (that's what stable releases are for).
+3. **`gh` access** — invoke the `check-github-cli` skill: authenticated, `workflow` token
+   scope, access to the (possibly private) API repo.
+
+## Step 1 — Find the workflow
+
+| API service | npm package | Source repo | Publish workflow | Dispatch inputs (`-f …`) |
+|---|---|---|---|---|
+| `core` | `@blockscout/api-types` | `blockscout/blockscout` | publish-api-types-npm-dev.yml | - |
+| `stats`| `@blockscout/stats-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: stats |
+| `bens` | `@blockscout/bens-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: blockscout-ens |
+| `multichainAggregator` | `@blockscout/multichain-aggregator-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: multichain-aggregator |
+| `multichainStats` | `@blockscout/stats-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: stats |
+| `interchainIndexer` | `@blockscout/interchain-indexer-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: interchain-indexer |
+| `tac` | `@blockscout/tac-operation-lifecycle-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: tac-operation-lifecycle |
+| `visualize` | `@blockscout/visualizer-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: visualizer |
+| `contractInfo` | `@blockscout/contracts-info-types` | `blockscout/blockscout-admin` | publish-types-dev.yml | service: contracts-info |
+| `admin` | `@blockscout/admin-rs-types` | `blockscout/blockscout-admin` | publish-types-dev.yml | service: admin-rs |
+| `rewards` | `@blockscout/points-types` | `blockscout/points` | npm-publisher-dev.yml | - |
+| `zetachain` | `@blockscout/zetachain-cctx-types` | `blockscout/blockscout-rs` | manual / ad-hoc — not merged upstream, maintenance only | - |
+
+If a cell is unknown or stale, discover it with `gh workflow list --repo <repo>` and
+`gh workflow view <workflow> --repo <repo>` (shows the dispatch inputs); the authoritative
+package→repo pointer is the `repository` field in
+`node_modules/@blockscout/<pkg>/package.json`.
+
+## Step 2 — Trigger the publish
+
+```
+gh workflow run <workflow> --repo <repo> --ref <branch> [-f <input>=<value>]
+```
+
+## Step 3 — Watch the run, copy the exact version
+
+`gh run list --repo <repo> --workflow <workflow>` to find the run id, then
+`gh run watch <id> --repo <repo>` and `gh run view <id> --repo <repo> --log` to read the
+published version out of the logs (or check the package's versions on npm).
+
+**Copy the exact published version string — don't construct it.** The `0.0.1-beta.<hash>`
+template is workflow-defined and varies (the Core API workflow adds a `v` prefix; hash
+length has changed over time). And **never pin `@beta`**: multiple in-progress API branches
+publish under the same dist-tag, so it's ambiguous and can collide.
+
+## Step 4 — Pin and verify
+
+Set the exact version in `package.json`, reinstall (`pnpm install`), and run
+`pnpm run lint:tsc` — the typecheck surfaces what the new API version changed.

--- a/.agents/skills/publish-beta-types/SKILL.md
+++ b/.agents/skills/publish-beta-types/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publish-beta-types
-description: Publish a beta version of a `@blockscout/*-types` npm package from an API feature branch and pin it in this repo. Use when a needed response type isn't in any published package version yet.
+description: Publish a beta version of a `@blockscout/*-types` npm package and pin it here. Use when a needed response type isn't in any published package version yet.
 ---
 
 # Publish a beta types package
@@ -62,10 +62,9 @@ gh workflow run <workflow> --repo <repo> --ref <branch> [-f <input>=<value>]
 `gh run watch <id> --repo <repo>` and `gh run view <id> --repo <repo> --log` to read the
 published version out of the logs (or check the package's versions on npm).
 
-**Copy the exact published version string — don't construct it.** The `0.0.1-beta.<hash>`
-template is workflow-defined and varies (the Core API workflow adds a `v` prefix; hash
-length has changed over time). And **never pin `@beta`**: multiple in-progress API branches
-publish under the same dist-tag, so it's ambiguous and can collide.
+**Copy the exact published version string — don't construct it** (the `0.0.1-beta.<hash>`
+template varies per workflow), and **never pin `@beta`** (in-progress API branches collide
+on that dist-tag) — full rationale in the background reading.
 
 ## Step 4 — Pin and verify
 

--- a/.agents/skills/resolve-api-url/SKILL.md
+++ b/.agents/skills/resolve-api-url/SKILL.md
@@ -11,7 +11,7 @@ from the **target instance's** runtime config. So resolution means reading the r
 *which env vars* apply, then reading the instance's config to get their values. Background
 facts: *How a request URL is assembled* in `src/api/CONTEXT.md`.
 
-**Rule of thumb: never guess.** Don't guess hosts, and don't transcribe `config.ts` logic
+**Rule of thumb: never guess.** Don't guess hosts, and don't transcribe `src/api/config.ts` logic
 from memory — read the files each time (they change).
 
 ## Step 0 — Inputs
@@ -22,16 +22,16 @@ The **`service:name` resource key** and the **target instance** (a
 ## Step 1 — Repo → path template
 
 Find the resource in its service registry file under `src/api/resources/services/**`
-(see `resources/index.ts`); the entry gives the `path` template and its `:param`
+(see `src/api/resources/index.ts`); the entry gives the `path` template and its `:param`
 placeholders:
 
 ```ts
-// resources/services/core/token.ts
+// src/api/resources/services/core/token.ts
 token: { path: '/api/v2/tokens/:hash', pathParams: [ 'hash' ] }
 ```
 
 The `service:` prefix (`core:`, `contractInfo:`, `stats:`, …) selects which service config
-applies in the next step (`getResourceParams` in `utils/get-resource-params.ts` resolves it).
+applies in the next step (`getResourceParams` in `src/api/utils/get-resource-params.ts` resolves it).
 
 ## Step 2 — Repo → which env vars build the URL
 

--- a/.agents/skills/resolve-api-url/SKILL.md
+++ b/.agents/skills/resolve-api-url/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: resolve-api-url
+description: Resolve the real request URL of an API resource on a live Blockscout instance (`service:name` + instance → full URL). Use whenever a request must be made to, or a sample response fetched from, a deployed instance's API.
+---
+
+# Resolve a resource's real request URL
+
+A request URL is assembled as `<endpoint><basePath><resource.path>` (+ compiled path params,
++ query string): the `path` template lives in the repo, while `endpoint` / `basePath` come
+from the **target instance's** runtime config. So resolution means reading the repo to learn
+*which env vars* apply, then reading the instance's config to get their values. Background
+facts: *How a request URL is assembled* in `src/api/CONTEXT.md`.
+
+**Rule of thumb: never guess.** Don't guess hosts, and don't transcribe `config.ts` logic
+from memory — read the files each time (they change).
+
+## Step 0 — Inputs
+
+The **`service:name` resource key** and the **target instance** (a
+`tools/dev-server/registry.json` alias or a full URL). Ask if either is missing.
+
+## Step 1 — Repo → path template
+
+Find the resource in its service registry file under `src/api/resources/services/**`
+(see `resources/index.ts`); the entry gives the `path` template and its `:param`
+placeholders:
+
+```ts
+// resources/services/core/token.ts
+token: { path: '/api/v2/tokens/:hash', pathParams: [ 'hash' ] }
+```
+
+The `service:` prefix (`core:`, `contractInfo:`, `stats:`, …) selects which service config
+applies in the next step (`getResourceParams` in `utils/get-resource-params.ts` resolves it).
+
+## Step 2 — Repo → which env vars build the URL
+
+In `src/api/config.ts`, find the block for the service and read which env vars feed the
+URL-relevant fields:
+
+- **`endpoint`** — the origin. Sometimes a single host var; sometimes assembled from a
+  protocol/host/port trio. Read the block to see which.
+- **`basePath`** — an optional path prefix prepended before `resource.path`. Present on
+  some services, absent on others. Don't drop it when present.
+- **`instanceId`** — fills an `:instanceId` path param on services that have one. Note
+  the fallback chains expressed in the file (e.g. a service-specific id var falling back
+  to `NEXT_PUBLIC_NETWORK_ID`).
+
+Collect the exact `NEXT_PUBLIC_*` names the block references for these fields.
+
+## Step 3 — Instance → host + real values
+
+**Host** — map the instance alias to its base URL via `tools/dev-server/registry.json`.
+Use it rather than guessing: many instances don't follow the `<name>.blockscout.com`
+pattern (e.g. `explorer.immutable.com`, `www.shibariumscan.io`, `zetascan.com`). It lists
+~30 common instances, not all of them — if yours is absent, ask for the URL; don't assume
+the hostname.
+
+**Values** — fetch **`GET <host>/node-api/config`** and look up the env names from Step 2
+in its `envs` object. This is the canonical, deterministic source — always re-fetch it;
+never reuse values remembered from another instance or an earlier session.
+
+## Step 4 — Assemble
+
+Concatenate `<endpoint><basePath><resource.path>`, fill the `:param` placeholders, append
+the query string. **Always use this direct URL — never the `/node-api/proxy` form**: that
+rewrite exists only as a browser-CORS workaround in dev/review environments, and a
+Node/server-side request doesn't need it. Sanity check when feasible: a GET should return a
+2xx with valid JSON — on a 404, the most common miss is a dropped `basePath`.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@blockscout/admin-rs-types": "1.5.0",
-    "@blockscout/api-types": "0.0.1-beta.cf13c2de97",
+    "@blockscout/api-types": "0.0.1-beta.82839e44ce",
     "@blockscout/bens-types": "1.7.1",
     "@blockscout/contracts-info-types": "1.5.2",
     "@blockscout/interchain-indexer-types": "1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0
       '@blockscout/api-types':
-        specifier: 0.0.1-beta.cf13c2de97
-        version: 0.0.1-beta.cf13c2de97
+        specifier: 0.0.1-beta.82839e44ce
+        version: 0.0.1-beta.82839e44ce
       '@blockscout/bens-types':
         specifier: 1.7.1
         version: 1.7.1
@@ -1321,8 +1321,8 @@ packages:
   '@blockscout/admin-rs-types@1.5.0':
     resolution: {integrity: sha512-QE+dpUaQDvOAb/wUJ98J3CBqfohbiBW/+AEqEmSdOOZ0XxPRUrke08krBnflq3GMACRwB+nwzQrsfl7KCrC1Eg==}
 
-  '@blockscout/api-types@0.0.1-beta.cf13c2de97':
-    resolution: {integrity: sha512-Do7S5vBiZnBGQVg9Xk1uG3M0OA7G0OVccPbPDilsqcIkXTbVEAttvH26qWUq+tR4cudlgUolDbwp5Wcs95gNCQ==}
+  '@blockscout/api-types@0.0.1-beta.82839e44ce':
+    resolution: {integrity: sha512-DIyMKLqHqXmKCbf1eYCKbWsNY3VQ2NMXAlLyAgEkM7UYffEasUfAL0othyHfGyxvM4FMwU5tm9hlKHRFPmKYew==}
 
   '@blockscout/bens-types@1.7.1':
     resolution: {integrity: sha512-MNIvYbj1I2vcU2rb6otlRnVMIpFG2B1WDqC7HicNrt10DbM5yPZNfBcsNM+Mhk/965Aeg529Fd+BkV9zhINqjA==}
@@ -14466,7 +14466,7 @@ snapshots:
 
   '@blockscout/admin-rs-types@1.5.0': {}
 
-  '@blockscout/api-types@0.0.1-beta.cf13c2de97': {}
+  '@blockscout/api-types@0.0.1-beta.82839e44ce': {}
 
   '@blockscout/bens-types@1.7.1': {}
 

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -11,13 +11,13 @@ The frontend never hardcodes a full API URL. A request is assembled as:
 ```
 
 - **The `path` template lives in the repo.** Resources are registered per service under
-  `resources/services/**` (see `resources/index.ts`); each entry maps a `service:name` key
+  `src/api/resources/services/**` (see `src/api/resources/index.ts`); each entry maps a `service:name` key
   to a `path` template with `:param` placeholders. The matching `…ResourcePayload` type in
   the same file ties the resource to its response type (see *Where a resource's response
   types come from* below). The `service:` prefix (`core:`, `contractInfo:`, `stats:`, …)
   selects which service config applies; `getResourceParams`
-  (`utils/get-resource-params.ts`) resolves `service:name` → `{ api, resource }`.
-- **`endpoint` / `basePath` are per-service runtime config.** `config.ts` builds one config
+  (`src/api/utils/get-resource-params.ts`) resolves `service:name` → `{ api, resource }`.
+- **`endpoint` / `basePath` are per-service runtime config.** `src/api/config.ts` builds one config
   object per service from `NEXT_PUBLIC_*` env vars; the env-var → field mapping changes, so
   the file is the source of truth.
 - **Every deployed instance exposes its full public config** at
@@ -26,9 +26,9 @@ The frontend never hardcodes a full API URL. A request is assembled as:
   It also carries the "secret-ish" public keys (WalletConnect, reCAPTCHA, GA) by design;
   treat it as a config source, not secrets.
 - **The `/node-api/proxy` rewrite is a browser-CORS workaround only.** In local dev /
-  review environments (or with `NEXT_PUBLIC_USE_NEXT_JS_PROXY`), `build-url.ts` routes the
+  review environments (or with `NEXT_PUBLIC_USE_NEXT_JS_PROXY`), `src/api/utils/build-url.ts` routes the
   request through the app's own origin with the true upstream in the `x-endpoint` header
-  (`utils/is-need-proxy.ts`); server-side/Node requests never need this form.
+  (`src/api/utils/is-need-proxy.ts`); server-side/Node requests never need this form.
 
 **To resolve the concrete URL of a resource on a live instance, use the `resolve-api-url`
 skill** — it holds the step-by-step recipe (env-var lookup, instance host registry,
@@ -36,7 +36,7 @@ runtime-config fetch).
 
 ## Where a resource's response types come from
 
-Each service registry file (`resources/services/**`) declares a `…ResourcePayload` type
+Each service registry file (`src/api/resources/services/**`) declares a `…ResourcePayload` type
 mapping every `service:name` to its response type. Follow that type's import to learn its
 origin — there are two:
 

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -214,3 +214,45 @@ If any cell is unknown, discover it with `gh workflow list --repo <repo>` and
     SearchResultTacOperation |
     SearchResultDomain;
   ```
+
+## Declaring a new resource (in an existing API)
+
+Everything for an existing service lives in its registry file — for Core API,
+`resources/services/core/<group>.ts` (e.g. `token.ts`); for a micro-service,
+`resources/services/<name>.ts`. It's **two edits that must stay in sync**, and the second
+one fails silently:
+
+1. **Add the resource entry** to the `*_API_RESOURCES` object — shape is `ApiResource`
+   (`resources/types.ts`): `{ path, pathParams?, filterFields?, paginated?, headers? }`.
+   `path` uses `:param` placeholders; list each one in `pathParams`.
+
+2. **Add a matching branch** to the sibling `*ResourcePayload<R>` conditional type. Miss
+   this and `ResourcePayload<'service:new'>` resolves to **`never`** — no error at the
+   declaration, you just get untyped data downstream. Where the response type comes from
+   depends on the API:
+   - **Core API** — use the generated `@blockscout/api-types` package; its README *Usage*
+     section (`node_modules/@blockscout/api-types/README.md`) is the reference for how to
+     name a response type (`schemas[…]`, `operations[…]`, `paths[…]['get']`).
+   - **Micro-service APIs** — the types package has **no path → response-type map** like the
+     Core API's `paths`, so the connection can't be derived mechanically. Pick the interface
+     that looks right for the endpoint and **confirm the choice with the user** before
+     relying on it.
+   - **Local types** — some payloads are hand-typed in a slice/feature `types/api.ts` rather
+     than generated; see *Where a resource's response types come from*.
+
+3. **Pagination — only if the response is actually paginated.** A resource is paginated
+   **iff its response body has a `next_page_params` field** — set `paginated: true` only
+   then. If you can't tell whether a resource is paginated, **ask the user** rather than
+   assuming. Consume paginated resources with `useQueryWithPages`; everything else with
+   `useApiQuery('service:name', …)`.
+
+4. **Filters / sorting — only when the task says so.** Not every paginated resource has
+   them. Add `filterFields` and branches to the service's `*PaginationFilters<R>` /
+   `*PaginationSorting<R>` types **only** for the filters/sorts named in the feature task
+   description or conversation context — **never infer them** from the API. 
+   Define the filter/sort types themselves in the owning slice/feature `types/api.ts` 
+   (kept local by design).
+
+**No `resources/index.ts` edit is needed** for a new resource in an existing service.
+Only a brand-new *service* touches `index.ts`: register it in `RESOURCES`
+and add a branch to each of those dispatch types.

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -2,7 +2,7 @@
 
 Non-obvious patterns for the `src/api/` layer.
 
-## Resolving a resource's real request URL
+## How a request URL is assembled
 
 The frontend never hardcodes a full API URL. A request is assembled as:
 
@@ -10,97 +10,29 @@ The frontend never hardcodes a full API URL. A request is assembled as:
 <endpoint><basePath><resource.path>   (+ compiled path params, + query string)
 ```
 
-`endpoint` / `basePath` come from per-service **runtime config** (env vars), while the
-`path` template lives in the repo. So resolving the real URL means reading the repo to
-learn *which env vars* apply, then reading the *target instance's* runtime config to get
-their values. Don't guess hosts, and don't transcribe `config.ts` logic into your head —
-read it each time (it changes).
+- **The `path` template lives in the repo.** Resources are registered per service under
+  `resources/services/**` (see `resources/index.ts`); each entry maps a `service:name` key
+  to a `path` template with `:param` placeholders. The matching `…ResourcePayload` type in
+  the same file ties the resource to its response type (see *Where a resource's response
+  types come from* below). The `service:` prefix (`core:`, `contractInfo:`, `stats:`, …)
+  selects which service config applies; `getResourceParams`
+  (`utils/get-resource-params.ts`) resolves `service:name` → `{ api, resource }`.
+- **`endpoint` / `basePath` are per-service runtime config.** `config.ts` builds one config
+  object per service from `NEXT_PUBLIC_*` env vars; the env-var → field mapping changes, so
+  the file is the source of truth.
+- **Every deployed instance exposes its full public config** at
+  **`GET <host>/node-api/config`** (`{ envs: { …all NEXT_PUBLIC_* } }`; served by
+  `src/pages/api/config.ts`) — the canonical source for those values on a live instance.
+  It also carries the "secret-ish" public keys (WalletConnect, reCAPTCHA, GA) by design;
+  treat it as a config source, not secrets.
+- **The `/node-api/proxy` rewrite is a browser-CORS workaround only.** In local dev /
+  review environments (or with `NEXT_PUBLIC_USE_NEXT_JS_PROXY`), `build-url.ts` routes the
+  request through the app's own origin with the true upstream in the `x-endpoint` header
+  (`utils/is-need-proxy.ts`); server-side/Node requests never need this form.
 
-### 1. Repo → path template + which service the resource belongs to
-
-Resources are registered per service under `resources/services/**` (see
-`resources/index.ts`). Each entry maps a `service:name` key to a `path` template with
-`:param` placeholders:
-
-```ts
-// resources/services/core/token.ts
-token: { path: '/api/v2/tokens/:hash', pathParams: [ 'hash' ] }
-```
-
-The matching `…ResourcePayload` type in the same file ties the resource to its response
-type (see *Where a resource's response types come from* below). The
-`service:` prefix (`core:`, `contractInfo:`, `stats:`, …) selects which service config
-applies; `getResourceParams` (`utils/get-resource-params.ts`) resolves `service:name` →
-`{ api, resource }`.
-
-### 2. Repo → which env vars build the URL (`config.ts`)
-
-`config.ts` builds one config object per service. Find the block for your service and
-read which env vars feed the URL-relevant fields:
-
-- **`endpoint`** — the origin. Sometimes a single host var; sometimes assembled from a
-  protocol/host/port trio. Read the block to see which.
-- **`basePath`** — an optional path prefix prepended before `resource.path`. Present on
-  some services, absent on others. Don't drop it when present.
-- **`instanceId`** — fills an `:instanceId` path param on services that have one. Note
-  the fallback chains expressed in the file (e.g. a service-specific id var falling back
-  to `NEXT_PUBLIC_NETWORK_ID`).
-
-Collect the exact `NEXT_PUBLIC_*` names the block references for these fields.
-
-### 3. Find the instance host, then read its runtime config
-
-**Host** — the frontend host per instance is mapped in `tools/dev-server/registry.json`
-(alias → base URL, e.g. `immutable → https://explorer.immutable.com`). Use it rather than
-guessing: many instances don't follow the `<name>.blockscout.com` pattern (e.g.
-`explorer.immutable.com`, `www.shibariumscan.io`, `zetascan.com`, `explorer.zora.energy`).
-It lists ~30 common instances, not all of them — if yours is absent, find its explorer URL
-another way and don't assume the hostname.
-
-**Config** — every deployed instance exposes its full public config at
-**`GET <host>/node-api/config`** (`{ envs: { …all NEXT_PUBLIC_* } }`; served by
-`src/pages/api/config.ts`). Look up the env names from step 2 there to get their real
-values. This is the canonical, deterministic source. (It also carries the "secret-ish"
-public keys — WalletConnect, reCAPTCHA, GA — by design; treat it as a config source, not
-secrets.)
-
-### Worked examples
-
-Each shows one of the three service-config shapes. Values are from the named instance's
-`/node-api/config` at the time of writing — always re-fetch, don't copy these.
-
-- **Core API — assembled origin + base path.** `core:token` →
-  `path = /api/v2/tokens/:hash`. `config.ts` builds `endpoint` from
-  `NEXT_PUBLIC_API_PROTOCOL` (default `https`) + `NEXT_PUBLIC_API_HOST` +
-  optional `NEXT_PUBLIC_API_PORT`, and `basePath` from `NEXT_PUBLIC_API_BASE_PATH`.
-  Runtime: host `eth.blockscout.com`, protocol/port unset, base path `/` (→ empty) ⇒
-  `https://eth.blockscout.com/api/v2/tokens/0xdAC17…ec7`.
-
-- **Contract-info — single host + instanceId.** `contractInfo:token_verified_info` →
-  `path = /api/v1/chains/:instanceId/token-infos/:hash`. `endpoint =
-  NEXT_PUBLIC_CONTRACT_INFO_API_HOST`, `instanceId = NEXT_PUBLIC_CONTRACT_INFO_INSTANCE_ID`
-  falling back to `NEXT_PUBLIC_NETWORK_ID`. Runtime: host
-  `https://contracts-info.services.blockscout.com`, instance-id var unset so it uses
-  `NETWORK_ID = 1` ⇒
-  `https://contracts-info.services.blockscout.com/api/v1/chains/1/token-infos/0xdAC17…ec7`.
-
-- **Stats — single host + base path (host from the registry).** `stats:lines` →
-  `path = /api/v1/lines`; `endpoint = NEXT_PUBLIC_STATS_API_HOST`,
-  `basePath = NEXT_PUBLIC_STATS_API_BASE_PATH`. Registry maps the `immutable` instance to
-  host `explorer.immutable.com`; its `/node-api/config` gives
-  `STATS_API_HOST = https://explorer.immutable.com`, `STATS_API_BASE_PATH = /stats-service`
-  ⇒ `https://explorer.immutable.com/stats-service/api/v1/lines`. The stats service is
-  mounted on the main origin under a base path — drop it and the URL is wrong.
-
-### Note for agents: ignore the proxy — use the direct URL
-
-`build-url.ts` can rewrite the URL through the app's own origin (`config.app.baseUrl` +
-`/node-api/proxy…`, true upstream in the `x-endpoint` header). Per `utils/is-need-proxy.ts`
-this only happens in **local dev / review** environments, or when
-`NEXT_PUBLIC_USE_NEXT_JS_PROXY` is explicitly set — i.e. to let the *browser* make
-credentialed cross-origin requests. An agent hitting the API from a Node environment
-(server-side, no browser CORS) is unaffected: **always use the direct resolved URL from
-step 3**, never the `/node-api/proxy` form.
+**To resolve the concrete URL of a resource on a live instance, use the `resolve-api-url`
+skill** — it holds the step-by-step recipe (env-var lookup, instance host registry,
+runtime-config fetch).
 
 ## Where a resource's response types come from
 

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -36,8 +36,7 @@ applies; `getResourceParams` (`utils/get-resource-params.ts`) resolves `service:
 ### 2. Repo → which env vars build the URL (`config.ts`)
 
 `config.ts` builds one config object per service. Find the block for your service and
-read which env vars feed the URL-relevant fields — that's the whole point of reading the
-file rather than a table here (the mapping changes; the file is the source of truth):
+read which env vars feed the URL-relevant fields:
 
 - **`endpoint`** — the origin. Sometimes a single host var; sometimes assembled from a
   protocol/host/port trio. Read the block to see which.
@@ -124,42 +123,28 @@ Publishing is done by workflows **in the API source repo**, not here. Two channe
 - **Stable** — normal semver (e.g. `2.11.1`) under npm dist-tag `latest`, published
   automatically when a release is published in the API repo.
 - **Beta / dev** — published **manually** from an API *feature* branch, versioned from the
-  publish commit's short SHA (roughly `0.0.1-beta.<sha>`; the exact string is
-  workflow-defined and varies — e.g. the Core API workflow adds a `v` prefix, and hash
-  length has changed over time). **Copy the exact published version string** from the run
-  output / npm — don't construct it. Used to try a not-yet-released API (e.g. one deployed
-  to staging) before its final release.
+  publish commit's short SHA (roughly `0.0.1-beta.<sha>`). Used to try a not-yet-released
+  API (e.g. one deployed to staging) before its final release.
 
-**Pin the exact `0.0.1-beta.<hash>`, never `@beta`.** Multiple in-progress API feature
-branches publish under the same `beta` dist-tag, so `@beta` is ambiguous and can collide;
-the commit hash identifies the specific branch/build. The hash is the API
-**feature-branch commit the manual publish ran against** — get it from whoever published,
-the API branch, or the publish workflow run's logs. You **cannot** reliably derive it from
-a running/staging instance (not every commit is published as a beta, and micro-services
-don't expose it), so there's no `/node-api/config`-style shortcut here.
+**A beta build is identified only by its exact version string.** The `beta`
+dist-tag is shared by all in-progress feature branches, so `@beta` is ambiguous and can
+collide; the hash — the API **feature-branch commit the manual publish ran against** — is
+what identifies a specific build. A running/staging instance doesn't reveal its types
+version (not every commit is published as a beta, and micro-services don't expose the
+commit), so there's no `/node-api/config`-style shortcut.
 
 ### Publishing a beta yourself
 
 **Use the `publish-beta-types` skill** (`.agents/skills/publish-beta-types/`) — it holds the
-per-service package/repo/workflow mapping table and the `gh` procedure. Orientation: the
-publish is a manual (`workflow_dispatch`) workflow **in the API source repo**, run against an
-API feature branch; the run's logs give the exact `0.0.1-beta.<hash>` version to pin here.
-
-### APIs with typings in the repo
-
-| API service | Comment |
-|---|---|
-| `metadata` | Typed locally for now; npm package may be added later |
-| `userOps` | No resources registered / consumed by the app right now |
-| `clusters` | External API (tRPC), not maintained by Blockscout; typed locally |
-
+per-service package/repo/workflow mapping table and the `gh` dispatch procedure.
 
 ### The exceptions (types not from an npm package)
 
-- **Whole APIs typed locally** — e.g. the **Metadata API** (`metadata:*` →
-  `src/features/address-metadata/types/api`). Also, not every **Core API** resource has an
-  OpenAPI schema yet, so some `core:*` payloads are still hand-typed locally (to be
-  improved over time).
+- **Whole APIs typed locally** — `metadata:*` (`src/features/address-metadata/types/api`;
+  an npm package may be added later), `userOps` (no resources registered / consumed by the
+  app right now), and `clusters` (external tRPC API, not maintained by Blockscout). Also,
+  not every **Core API** resource has an OpenAPI schema yet, so some `core:*` payloads are
+  still hand-typed locally (to be improved over time).
 - **Kept local by design even when generated types exist:**
   - **Filter & sorting param types** (e.g. `TokensFilters`, `TokenTransferFilters` in
     `src/slices/**/types/api.ts`) — not cleanly derivable from the generated schemas, so

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -112,8 +112,8 @@ origin — there are two:
 - **Generated types from an `@blockscout/*` npm package** (the general case). These are
   generated from the API's OpenAPI spec **in the API's own source repo** and published to
   npm per API version; this repo only pins the version in `package.json`. Each service
-  maps to one package in one of **four** source repos — see the table under *Publishing a
-  beta yourself* below. Authoritative pointer for any package's repo: its `repository`
+  maps to one package in one of the source repos — see the mapping table in the
+  `publish-beta-types` skill. Authoritative pointer for any package's repo: its `repository`
   field in `node_modules/@blockscout/<pkg>/package.json`.
 - **Locally-defined types** in `src/**/types/api.ts` (the exceptions — see below).
 
@@ -138,37 +138,12 @@ the API branch, or the publish workflow run's logs. You **cannot** reliably deri
 a running/staging instance (not every commit is published as a beta, and micro-services
 don't expose it), so there's no `/node-api/config`-style shortcut here.
 
-### Publishing a beta yourself (cross-repo, via `gh`)
+### Publishing a beta yourself
 
-When staging has a new (unreleased) API version, you can publish its beta types package
-yourself and pin it here. The publish is a **manual (`workflow_dispatch`) workflow in the
-API source repo**. Requires `gh` authenticated with access to that repo (private is fine)
-and `workflow` token scope — see the `check-github-cli` skill.
-
-1. Find the package, repo, and workflow for your service in the table below.
-2. Trigger: `gh workflow run <workflow> --repo <repo> --ref <branch> <inputs>`.
-3. Read output: `gh run list --repo <repo> --workflow <workflow>`, then
-   `gh run watch <id> --repo <repo>` and `gh run view <id> --repo <repo> --log`.
-4. The run publishes `0.0.1-beta.<hash>`; set that exact version in `package.json`,
-   reinstall, and let the typecheck surface the diffs.
-
-If any cell is unknown, discover it with `gh workflow list --repo <repo>` and
-`gh workflow view <workflow> --repo <repo>` (shows the dispatch inputs).
-
-| API service | npm package | Source repo | Publish workflow | Dispatch inputs (`-f …`) |
-|---|---|---|---|---|
-| `core` | `@blockscout/api-types` | `blockscout/blockscout` | publish-api-types-npm-dev.yml | - |
-| `stats`| `@blockscout/stats-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: stats |
-| `bens` | `@blockscout/bens-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: blockscout-ens |
-| `multichainAggregator` | `@blockscout/multichain-aggregator-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: multichain-aggregator |
-| `multichainStats` | `@blockscout/stats-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: stats |
-| `interchainIndexer` | `@blockscout/interchain-indexer-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: interchain-indexer |
-| `tac` | `@blockscout/tac-operation-lifecycle-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: tac-operation-lifecycle |
-| `visualize` | `@blockscout/visualizer-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: visualizer |
-| `contractInfo` | `@blockscout/contracts-info-types` | `blockscout/blockscout-admin` | publish-types-dev.yml | service: contracts-info |
-| `admin` | `@blockscout/admin-rs-types` | `blockscout/blockscout-admin` | publish-types-dev.yml | service: admin-rs |
-| `rewards` | `@blockscout/points-types` | `blockscout/points` | npm-publisher-dev.yml | - |
-| `zetachain` | `@blockscout/zetachain-cctx-types` | `blockscout/blockscout-rs` | manual / ad-hoc — not merged upstream, maintenance only | - |
+**Use the `publish-beta-types` skill** (`.agents/skills/publish-beta-types/`) — it holds the
+per-service package/repo/workflow mapping table and the `gh` procedure. Orientation: the
+publish is a manual (`workflow_dispatch`) workflow **in the API source repo**, run against an
+API feature branch; the run's logs give the exact `0.0.1-beta.<hash>` version to pin here.
 
 ### APIs with typings in the repo
 

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -1,6 +1,6 @@
 # API layer — context
 
-Non-obvious patterns for the `src/api/` layer. Add new sections as the layer grows.
+Non-obvious patterns for the `src/api/` layer.
 
 ## Resolving a resource's real request URL
 
@@ -214,45 +214,3 @@ If any cell is unknown, discover it with `gh workflow list --repo <repo>` and
     SearchResultTacOperation |
     SearchResultDomain;
   ```
-
-## Declaring a new resource (in an existing API)
-
-Everything for an existing service lives in its registry file — for Core API,
-`resources/services/core/<group>.ts` (e.g. `token.ts`); for a micro-service,
-`resources/services/<name>.ts`. It's **two edits that must stay in sync**, and the second
-one fails silently:
-
-1. **Add the resource entry** to the `*_API_RESOURCES` object — shape is `ApiResource`
-   (`resources/types.ts`): `{ path, pathParams?, filterFields?, paginated?, headers? }`.
-   `path` uses `:param` placeholders; list each one in `pathParams`.
-
-2. **Add a matching branch** to the sibling `*ResourcePayload<R>` conditional type. Miss
-   this and `ResourcePayload<'service:new'>` resolves to **`never`** — no error at the
-   declaration, you just get untyped data downstream. Where the response type comes from
-   depends on the API:
-   - **Core API** — use the generated `@blockscout/api-types` package; its README *Usage*
-     section (`node_modules/@blockscout/api-types/README.md`) is the reference for how to
-     name a response type (`schemas[…]`, `operations[…]`, `paths[…]['get']`).
-   - **Micro-service APIs** — the types package has **no path → response-type map** like the
-     Core API's `paths`, so the connection can't be derived mechanically. Pick the interface
-     that looks right for the endpoint and **confirm the choice with the user** before
-     relying on it.
-   - **Local types** — some payloads are hand-typed in a slice/feature `types/api.ts` rather
-     than generated; see *Where a resource's response types come from*.
-
-3. **Pagination — only if the response is actually paginated.** A resource is paginated
-   **iff its response body has a `next_page_params` field** — set `paginated: true` only
-   then. If you can't tell whether a resource is paginated, **ask the user** rather than
-   assuming. Consume paginated resources with `useQueryWithPages`; everything else with
-   `useApiQuery('service:name', …)`.
-
-4. **Filters / sorting — only when the task says so.** Not every paginated resource has
-   them. Add `filterFields` and branches to the service's `*PaginationFilters<R>` /
-   `*PaginationSorting<R>` types **only** for the filters/sorts named in the feature task
-   description or conversation context — **never infer them** from the API. 
-   Define the filter/sort types themselves in the owning slice/feature `types/api.ts` 
-   (kept local by design).
-
-**No `resources/index.ts` edit is needed** for a new resource in an existing service.
-Only a brand-new *service* touches `index.ts`: register it in `RESOURCES`
-and add a branch to each of those dispatch types.

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -1,0 +1,216 @@
+# API layer — context
+
+Non-obvious patterns for the `src/api/` layer. Add new sections as the layer grows.
+
+## Resolving a resource's real request URL
+
+The frontend never hardcodes a full API URL. A request is assembled as:
+
+```
+<endpoint><basePath><resource.path>   (+ compiled path params, + query string)
+```
+
+`endpoint` / `basePath` come from per-service **runtime config** (env vars), while the
+`path` template lives in the repo. So resolving the real URL means reading the repo to
+learn *which env vars* apply, then reading the *target instance's* runtime config to get
+their values. Don't guess hosts, and don't transcribe `config.ts` logic into your head —
+read it each time (it changes).
+
+### 1. Repo → path template + which service the resource belongs to
+
+Resources are registered per service under `resources/services/**` (see
+`resources/index.ts`). Each entry maps a `service:name` key to a `path` template with
+`:param` placeholders:
+
+```ts
+// resources/services/core/token.ts
+token: { path: '/api/v2/tokens/:hash', pathParams: [ 'hash' ] }
+```
+
+The matching `…ResourcePayload` type in the same file ties the response to a
+`paths[...]` type from `@blockscout/api-types` — that's the response schema. The
+`service:` prefix (`core:`, `contractInfo:`, `stats:`, …) selects which service config
+applies; `getResourceParams` (`utils/build-url.ts`) resolves `service:name` →
+`{ api, resource }`.
+
+### 2. Repo → which env vars build the URL (`config.ts`)
+
+`config.ts` builds one config object per service. Find the block for your service and
+read which env vars feed the URL-relevant fields — that's the whole point of reading the
+file rather than a table here (the mapping changes; the file is the source of truth):
+
+- **`endpoint`** — the origin. Sometimes a single host var; sometimes assembled from a
+  protocol/host/port trio. Read the block to see which.
+- **`basePath`** — an optional path prefix prepended before `resource.path`. Present on
+  some services, absent on others. Don't drop it when present.
+- **`instanceId`** — fills an `:instanceId` path param on services that have one. Note
+  the fallback chains expressed in the file (e.g. a service-specific id var falling back
+  to `NEXT_PUBLIC_NETWORK_ID`).
+
+Collect the exact `NEXT_PUBLIC_*` names the block references for these fields.
+
+### 3. Find the instance host, then read its runtime config
+
+**Host** — the frontend host per instance is mapped in `tools/dev-server/registry.json`
+(alias → base URL, e.g. `immutable → https://explorer.immutable.com`). Use it rather than
+guessing: many instances don't follow the `<name>.blockscout.com` pattern (e.g.
+`explorer.immutable.com`, `www.shibariumscan.io`, `zetascan.com`, `explorer.zora.energy`).
+It lists ~30 common instances, not all of them — if yours is absent, find its explorer URL
+another way and don't assume the hostname.
+
+**Config** — every deployed instance exposes its full public config at
+**`GET <host>/node-api/config`** (`{ envs: { …all NEXT_PUBLIC_* } }`; served by
+`src/pages/api/config.ts`). Look up the env names from step 2 there to get their real
+values. This is the canonical, deterministic source. (It also carries the "secret-ish"
+public keys — WalletConnect, reCAPTCHA, GA — by design; treat it as a config source, not
+secrets.)
+
+### Worked examples
+
+Each shows one of the three service-config shapes. Values are from the named instance's
+`/node-api/config` at the time of writing — always re-fetch, don't copy these.
+
+- **Core API — assembled origin + base path.** `core:token` →
+  `path = /api/v2/tokens/:hash`. `config.ts` builds `endpoint` from
+  `NEXT_PUBLIC_API_PROTOCOL` (default `https`) + `NEXT_PUBLIC_API_HOST` +
+  optional `NEXT_PUBLIC_API_PORT`, and `basePath` from `NEXT_PUBLIC_API_BASE_PATH`.
+  Runtime: host `eth.blockscout.com`, protocol/port unset, base path `/` (→ empty) ⇒
+  `https://eth.blockscout.com/api/v2/tokens/0xdAC17…ec7`.
+
+- **Contract-info — single host + instanceId.** `contractInfo:token_verified_info` →
+  `path = /api/v1/chains/:instanceId/token-infos/:hash`. `endpoint =
+  NEXT_PUBLIC_CONTRACT_INFO_API_HOST`, `instanceId = NEXT_PUBLIC_CONTRACT_INFO_INSTANCE_ID`
+  falling back to `NEXT_PUBLIC_NETWORK_ID`. Runtime: host
+  `https://contracts-info.services.blockscout.com`, instance-id var unset so it uses
+  `NETWORK_ID = 1` ⇒
+  `https://contracts-info.services.blockscout.com/api/v1/chains/1/token-infos/0xdAC17…ec7`.
+
+- **Stats — single host + base path (host from the registry).** `stats:lines` →
+  `path = /api/v1/lines`; `endpoint = NEXT_PUBLIC_STATS_API_HOST`,
+  `basePath = NEXT_PUBLIC_STATS_API_BASE_PATH`. Registry maps the `immutable` instance to
+  host `explorer.immutable.com`; its `/node-api/config` gives
+  `STATS_API_HOST = https://explorer.immutable.com`, `STATS_API_BASE_PATH = /stats-service`
+  ⇒ `https://explorer.immutable.com/stats-service/api/v1/lines`. The stats service is
+  mounted on the main origin under a base path — drop it and the URL is wrong.
+
+### Note for agents: ignore the proxy — use the direct URL
+
+`build-url.ts` can rewrite the URL through the app's own origin (`config.app.baseUrl` +
+`/node-api/proxy…`, true upstream in the `x-endpoint` header). Per `utils/is-need-proxy.ts`
+this only happens in **local dev / review** environments, or when
+`NEXT_PUBLIC_USE_NEXT_JS_PROXY` is explicitly set — i.e. to let the *browser* make
+credentialed cross-origin requests. An agent hitting the API from a Node environment
+(server-side, no browser CORS) is unaffected: **always use the direct resolved URL from
+step 3**, never the `/node-api/proxy` form.
+
+## Where a resource's response types come from
+
+Each service registry file (`resources/services/**`) declares a `…ResourcePayload` type
+mapping every `service:name` to its response type. Follow that type's import to learn its
+origin — there are two:
+
+- **Generated types from an `@blockscout/*` npm package** (the general case). These are
+  generated from the API's OpenAPI spec **in the API's own source repo** and published to
+  npm per API version; this repo only pins the version in `package.json`. Each service
+  maps to one package in one of **four** source repos — see the table under *Publishing a
+  beta yourself* below. Authoritative pointer for any package's repo: its `repository`
+  field in `node_modules/@blockscout/<pkg>/package.json`.
+- **Locally-defined types** in `src/**/types/api.ts` (the exceptions — see below).
+
+### Stable vs. beta package versions
+
+Publishing is done by workflows **in the API source repo**, not here. Two channels:
+
+- **Stable** — normal semver (e.g. `2.11.1`) under npm dist-tag `latest`, published
+  automatically when a release is published in the API repo.
+- **Beta / dev** — published **manually** from an API *feature* branch, versioned from the
+  publish commit's short SHA (roughly `0.0.1-beta.<sha>`; the exact string is
+  workflow-defined and varies — e.g. the Core API workflow adds a `v` prefix, and hash
+  length has changed over time). **Copy the exact published version string** from the run
+  output / npm — don't construct it. Used to try a not-yet-released API (e.g. one deployed
+  to staging) before its final release.
+
+**Pin the exact `0.0.1-beta.<hash>`, never `@beta`.** Multiple in-progress API feature
+branches publish under the same `beta` dist-tag, so `@beta` is ambiguous and can collide;
+the commit hash identifies the specific branch/build. The hash is the API
+**feature-branch commit the manual publish ran against** — get it from whoever published,
+the API branch, or the publish workflow run's logs. You **cannot** reliably derive it from
+a running/staging instance (not every commit is published as a beta, and micro-services
+don't expose it), so there's no `/node-api/config`-style shortcut here.
+
+### Publishing a beta yourself (cross-repo, via `gh`)
+
+When staging has a new (unreleased) API version, you can publish its beta types package
+yourself and pin it here. The publish is a **manual (`workflow_dispatch`) workflow in the
+API source repo**. Requires `gh` authenticated with access to that repo (private is fine)
+and `workflow` token scope — see the `check-github-cli` skill.
+
+1. Find the package, repo, and workflow for your service in the table below.
+2. Trigger: `gh workflow run <workflow> --repo <repo> --ref <branch> <inputs>`.
+3. Read output: `gh run list --repo <repo> --workflow <workflow>`, then
+   `gh run watch <id> --repo <repo>` and `gh run view <id> --repo <repo> --log`.
+4. The run publishes `0.0.1-beta.<hash>`; set that exact version in `package.json`,
+   reinstall, and let the typecheck surface the diffs.
+
+If any cell is unknown, discover it with `gh workflow list --repo <repo>` and
+`gh workflow view <workflow> --repo <repo>` (shows the dispatch inputs).
+
+| API service | npm package | Source repo | Publish workflow | Dispatch inputs (`-f …`) |
+|---|---|---|---|---|
+| `core` | `@blockscout/api-types` | `blockscout/blockscout` | publish-api-types-npm-dev.yml | - |
+| `stats`| `@blockscout/stats-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: stats |
+| `bens` | `@blockscout/bens-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: blockscout-ens |
+| `multichainAggregator` | `@blockscout/multichain-aggregator-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: multichain-aggregator |
+| `multichainStats` | `@blockscout/stats-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: stats |
+| `interchainIndexer` | `@blockscout/interchain-indexer-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: interchain-indexer |
+| `tac` | `@blockscout/tac-operation-lifecycle-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: tac-operation-lifecycle |
+| `visualize` | `@blockscout/visualizer-types` | `blockscout/blockscout-rs` | npm-publisher-dev.yml | service: visualizer |
+| `contractInfo` | `@blockscout/contracts-info-types` | `blockscout/blockscout-admin` | publish-types-dev.yml | service: contracts-info |
+| `admin` | `@blockscout/admin-rs-types` | `blockscout/blockscout-admin` | publish-types-dev.yml | service: admin-rs |
+| `rewards` | `@blockscout/points-types` | `blockscout/points` | npm-publisher-dev.yml | - |
+| `zetachain` | `@blockscout/zetachain-cctx-types` | `blockscout/blockscout-rs` | manual / ad-hoc — not merged upstream, maintenance only | - |
+
+### APIs with typings in the repo
+
+| API service | Comment |
+|---|---|
+| `metadata` | Typed locally for now; npm package may be added later |
+| `userOps` | No resources registered / consumed by the app right now |
+| `clusters` | External API (tRPC), not maintained by Blockscout; typed locally |
+
+
+### The exceptions (types not from an npm package)
+
+- **Whole APIs typed locally** — e.g. the **Metadata API** (`metadata:*` →
+  `src/features/address-metadata/types/api`). Also, not every **Core API** resource has an
+  OpenAPI schema yet, so some `core:*` payloads are still hand-typed locally (to be
+  improved over time).
+- **Kept local by design even when generated types exist:**
+  - **Filter & sorting param types** (e.g. `TokensFilters`, `TokenTransferFilters` in
+    `src/slices/**/types/api.ts`) — not cleanly derivable from the generated schemas, so
+    they're shaped to be sensible in our code.
+  - **Socket message types** - cannot be typed with Open API spec.
+  - **Convenience type aliases** for deep-nested generated types (e.g. `ArbitrumBatchStatus`,
+    `AddressCeloAccount`).
+- **Feature-owned sub-types for data the Core API only proxies.** Some Core API responses
+  embed data the Core API merely proxies from a micro-service and doesn't fully describe in
+  its own OpenAPI spec — it doesn't know those shapes (e.g. the `tac_operation` field in search-result
+  variant with `type: 'tac_operaton'`). In the generated `@blockscout/api-types` schema such data
+  therefore shows up only as **optional properties** or **loose members of a type union**.
+  The precise shape is owned by the **feature** and must live under
+  `src/features/**/types/api.ts` (the feature owns the rendering, so it owns the type). A
+  slice may then **consolidate** these feature types with the generated schema — swapping a
+  generic union member / narrowing an optional field — but must not redefine them locally.
+  Example — `src/slices/search/types/api.ts` replaces two generic generated variants with the
+  feature-owned ones:
+
+  ```ts
+  import type { schemas } from '@blockscout/api-types';
+  import type { SearchResultTacOperation } from 'src/features/chain-variants/tac/types/api';
+  import type { SearchResultDomain }       from 'src/features/name-services/domains/types/api';
+
+  export type SearchResultItem =
+    Exclude<schemas['SearchResultItem'], { type: 'tac_operation' | 'ens_domain' }> |
+    SearchResultTacOperation |
+    SearchResultDomain;
+  ```

--- a/src/api/CONTEXT.md
+++ b/src/api/CONTEXT.md
@@ -27,10 +27,10 @@ Resources are registered per service under `resources/services/**` (see
 token: { path: '/api/v2/tokens/:hash', pathParams: [ 'hash' ] }
 ```
 
-The matching `…ResourcePayload` type in the same file ties the response to a
-`paths[...]` type from `@blockscout/api-types` — that's the response schema. The
+The matching `…ResourcePayload` type in the same file ties the resource to its response
+type (see *Where a resource's response types come from* below). The
 `service:` prefix (`core:`, `contractInfo:`, `stats:`, …) selects which service config
-applies; `getResourceParams` (`utils/build-url.ts`) resolves `service:name` →
+applies; `getResourceParams` (`utils/get-resource-params.ts`) resolves `service:name` →
 `{ api, resource }`.
 
 ### 2. Repo → which env vars build the URL (`config.ts`)
@@ -189,13 +189,13 @@ If any cell is unknown, discover it with `gh workflow list --repo <repo>` and
   - **Filter & sorting param types** (e.g. `TokensFilters`, `TokenTransferFilters` in
     `src/slices/**/types/api.ts`) — not cleanly derivable from the generated schemas, so
     they're shaped to be sensible in our code.
-  - **Socket message types** - cannot be typed with Open API spec.
+  - **Socket message types** — cannot be typed from an OpenAPI spec.
   - **Convenience type aliases** for deep-nested generated types (e.g. `ArbitrumBatchStatus`,
     `AddressCeloAccount`).
 - **Feature-owned sub-types for data the Core API only proxies.** Some Core API responses
   embed data the Core API merely proxies from a micro-service and doesn't fully describe in
-  its own OpenAPI spec — it doesn't know those shapes (e.g. the `tac_operation` field in search-result
-  variant with `type: 'tac_operaton'`). In the generated `@blockscout/api-types` schema such data
+  its own OpenAPI spec — it doesn't know those shapes (e.g. the `tac_operation` field in the
+  search-result variant with `type: 'tac_operation'`). In the generated `@blockscout/api-types` schema such data
   therefore shows up only as **optional properties** or **loose members of a type union**.
   The precise shape is owned by the **feature** and must live under
   `src/features/**/types/api.ts` (the feature owns the rendering, so it owns the type). A

--- a/src/slices/CONTEXT.md
+++ b/src/slices/CONTEXT.md
@@ -24,31 +24,6 @@ it must compose the child's components, never reimplement them. Example:
 receive parent data via props/hooks, never `import` from a parent slice.
 This keeps the dependency graph acyclic.
 
-## API contract mirror
-
-A slice's `types/api.ts` may `import type` feature- or chain-specific
-sub-types from `src/features/...`. This looks like a layering violation but
-is intentional: the backend response includes those fields unconditionally
-when the matching feature is enabled, so the frontend type must mirror the
-full contract.
-
-Canonical example — `src/slices/tx/types/api.ts`:
-
-```ts
-import type { TransactionArbitrum }   from 'src/features/rollup/arbitrum/types/api';
-import type { TransactionOptimistic } from 'src/features/rollup/optimism/types/api';
-import type { TransactionCelo }       from 'src/features/chain-variants/celo/types/api';
-import type { TransactionOpInterop }  from 'src/features/op-interop/types/api';
-
-export interface Transaction extends
-  TransactionArbitrum, TransactionOptimistic, TransactionCelo, TransactionOpInterop, /* … */ {
-  // base tx fields
-}
-```
-
-Do not "fix" this by moving sub-types into the slice — the feature owns the
-sub-type because the feature owns the rendering.
-
 ## Per-slice quirks
 
 - **`gas`** owns gas-price domain primitives (API types, `GasUnit`,


### PR DESCRIPTION
## Description and Related Issue(s)

Makes the API layer discoverable and operable for AI agents. The non-obvious *facts* about the layer now live in `src/api/CONTEXT.md`, and every *procedure* is extracted into an agent skill, so tasks like "add a page fed by a new endpoint" run end-to-end with all questions asked up front.

### Proposed Changes

- **`src/api/CONTEXT.md`** (new) — declarative reference: how a request URL is assembled (resource registry, per-service runtime config, `/node-api/config`, proxy semantics) and where resource response types come from (generated `@blockscout/*-types` packages, stable vs. beta versions, local-type exceptions).
- **Four skills own the procedures:**
  - `resolve-api-url` (new) — resolve a resource's real URL on a live instance (path template → env vars → instance host + runtime config).
  - `add-api-resource` (new) — declare resource(s) in an existing service: interview → live sample fetch → registry entry → payload typing → verify, with defined fallbacks when the types package isn't published (or can't be).
  - `publish-beta-types` (new) — publish a beta `@blockscout/*-types` package via `gh` workflow dispatch and pin the exact version; holds the per-service repo/workflow mapping table.
  - `add-new-page` (extended) — optional data-wiring phase (`wiring.md`): loading stubs, `useApiQuery` / `useQueryWithPages`, pagination controls, plain rendering of every payload field. The Step 0 interview now front-loads all data questions, so no user input is needed mid-work.
- **Stage-tagged TODO convention** in the page templates: `TODO (api-data):` markers are the wiring phase's worklist; `TODO (design):` markers are left for the design stage.
- **`@blockscout/api-types` bumped** (`0.0.1-beta.cf13c2de97` → `0.0.1-beta.82839e44ce`, + lockfile) — brings in the package README with the *Usage* section that the `add-api-resource` skill references for naming Core API response types. Types-only, no runtime impact.

No environment variables were added or changed.

### Breaking or Incompatible Changes

None — documentation, agent skills, and a types-only dependency bump; no application code changed.

### Additional Information

Skill references are one-directional (callers know callees, never the reverse): `add-new-page` → `wiring.md` → `add-api-resource` → `resolve-api-url` / `publish-beta-types`. The URL-resolution recipe was verified end-to-end against a live instance (`stats:lines` on the Immutable instance, HTTP 200). All skills were pruned per skill-writing guidance: descriptions carry triggers only, and each fact has a single source of truth between the skills and `CONTEXT.md`.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
