### PR TITLE
Add spec-driven product task workflow

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -56,6 +56,14 @@ Some directories have a `CONTEXT.md` documenting non-obvious patterns specific t
 
 If you encounter a `CONTEXT.md` not listed here, read it too (and consider adding it to this list).
 
+## Product task workflow
+
+Product tasks (GitHub issues) are worked through a spec-driven workflow: the `grill-the-task` skill
+interviews the developer to fill the issue's gaps, `to-spec` writes the spec into `.agents/tasks/` and
+routes open questions to their owners via Slack, and `implement-task` executes the spec one subtask at a
+time. See `.agents/tasks/README.md` for the lifecycle, `.agents/rules/delegation.mdc` for what agents may
+implement vs. what stays human, and `.agents/TEAM.md` for who answers open questions.
+
 ## Cursor Cloud specific instructions
 
 The Cursor Cloud VM refreshes deps on startup via its update script (`pnpm install`); there are no Cursor-only runtime steps. See "Running locally" above.

--- a/.agents/TEAM.md
+++ b/.agents/TEAM.md
@@ -1,0 +1,60 @@
+# Team roster for product tasks
+
+The teams involved in product tasks, with the members an agent may need to reach. Teams have several
+people — during a grilling session (`grill-the-task`) the developer picks **one contact per relevant team
+for the task**; the picks are recorded in the spec header and open questions are routed to those contacts.
+The member marked **default** is the fallback when the developer has no task-specific pick.
+
+Slack **member IDs** are stored deliberately so routing is deterministic (no runtime name lookup). They are
+workspace-scoped identifiers, not credentials — knowing one grants no access. To find yours in Slack:
+your profile → **⋯ More** → **Copy member ID**. Do not add emails to this file.
+
+## Product managers
+
+Own: product intent, scope, priorities, user stories, acceptance.
+
+| Name | GitHub | Slack member ID | Focus | |
+| --- | --- | --- | --- | --- |
+| Ulyana | @ulyanas | U024DUPJG3A | | default |
+| Nikita S. | @NikitaSavik | U05BR9QEYKB | |  |
+
+## Designers
+
+Own: mockups, missing screens/states, visual decisions.
+
+| Name | GitHub | Slack member ID | Focus | |
+| --- | --- | --- | --- | --- |
+| Tatyana | @tgladilina | U039P3QLP0A | | default |
+
+## Backend engineers
+
+Own: API endpoints, response models, field propagation across services, backend release schedule.
+
+| Name | GitHub | Slack member ID | Focus | |
+| --- | --- | --- | --- | --- |
+| Victor | @vbaranov | U8L403FEG | Core API | default |
+| Nikita P. | @nikitosing | U0218K3MTC5 | Core API |  |
+| Leonid | @lok52 | U01KDJWBCV7 | Microservices API | default |
+| Evgenii | @EvgenKor | U026N2LB01E | Microservices API: Intercahin Indexer, TAC | |
+
+## Frontend
+
+Own: architecture, the delegation boundary.
+
+| Name | GitHub | Slack member ID | Focus | |
+| --- | --- | --- | --- | --- |
+| tom | @tom2drum | U03MN1588AU | | default |
+| Max | @maxaleks | UKP0RR9K9 | | default |
+
+## Slack channels
+
+Product questions are asked **in a channel, not a DM**, so other teams (QA in particular) see the answers.
+The default is the frontend channel below; a large feature may have its own dedicated channel — recorded in
+the task's spec header — and then **all** of that task's questions go there. Channel posts always mention
+the addressee by member ID.
+
+| Purpose | Channel | Channel ID |
+| --- | --- | --- |
+| Default for product questions | blockscout-frontend | C03MMUTQDNU |
+| Multichain explorer | blockscout-multichain-explorer | C08R0UNBE3A |
+| Cross-chain transactions | dev-interchain | C0A7SALNLPL |

--- a/.agents/rules/delegation.mdc
+++ b/.agents/rules/delegation.mdc
@@ -1,0 +1,47 @@
+---
+description: Agent/human delegation boundary for product-task work — what agents may implement today vs. what stays human
+globs:
+alwaysApply: false
+---
+# Delegation boundary
+
+This is a **living document**. It records what work agents are trusted to do in this repo *today*, and what
+stays with a human developer for now. The `grill-the-task` / `to-spec` skills consult it when tagging spec
+subtasks `[agent]` or `[human]`; the `implement-task` skill obeys it when executing. As the repo becomes more
+agent-friendly, loosen the boundary here via a normal PR — don't renegotiate it per task.
+
+## Agents may do today
+
+- API resources and response types (`add-api-resource` skill), including sampling live responses (`resolve-api-url`).
+- Environment variables and feature configs (`add-env-var` / `deprecate-env-var` skills).
+- Page scaffolding and route plumbing — navigation, metadata, guards, route types, sitemap, page-type
+  analytics (`add-new-page` skill).
+- Data wiring: hooks, query integration, rendering fetched data plainly.
+- Component **scaffolds** (see the UI split below).
+- Unit tests (`*.spec.ts` / `*.spec.tsx`) and Playwright test **scaffolds** (`*.pw.tsx` files, fixtures, mock data).
+- Glossary and docs updates, demo deploys (`deploy-demo` skill).
+
+## Humans only, for now
+
+- Final markup and styling that must match the designer's Figma mockups; visual polish of any kind.
+- Choosing nav/sprite icons and other visual assets.
+- Generating and eyeballing Playwright screenshot baselines.
+- Design sign-off.
+
+## Default UI split: scaffold → style
+
+Every UI subtask in a spec is split into two linked subtasks by default:
+
+1. **`[agent]` scaffold** — file placement, props and types, data fetching, behavioral states
+   (loading / empty / error / pagination), semantic structure built from existing toolkit components,
+   placeholder presentation. Deferred visual decisions are marked `TODO (design):` (same convention as the
+   `add-new-page` templates).
+2. **`[human]` style** — take the scaffold to the mockup: layout, spacing, styling, icons. The spec links the
+   exact Figma node for this step.
+
+## Testing policy (standing — not asked per task)
+
+- Unit tests are written by the agent as part of whichever `[agent]` subtask they cover.
+- Playwright visual test files are scaffolded by the agent in the scaffold subtask.
+- Screenshot baselines are generated and reviewed by the human **after** the style subtask — a baseline is
+  only meaningful once the component matches the mockup.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: create-pr
 description: >-
-  Create or finalize a pull request. Three modes: open a placeholder draft PR at spec time (spec-first
-  workflow), finalize a draft PR into ready-for-review with the real description and labels, or create a
-  regular PR right away for work done outside the task workflow.
+  Create or finalize a pull request — three modes: placeholder draft PR at spec time, finalize a draft
+  into ready-for-review, or a regular PR right away for work done outside the task workflow.
 ---
 # Create PR
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: create-pr
-description: Create a well-structured pull request with proper description, labels, and reviewers
+description: >-
+  Create or finalize a pull request. Three modes: open a placeholder draft PR at spec time (spec-first
+  workflow), finalize a draft PR into ready-for-review with the real description and labels, or create a
+  regular PR right away for work done outside the task workflow.
 ---
 # Create PR
 
@@ -8,54 +11,83 @@ description: Create a well-structured pull request with proper description, labe
 
 This workflow uses `gh` to check for existing PRs, fetch issue details, and create the PR. **Follow the check-github-cli skill** first (ensure `gh auth status` succeeds; if not, guide the user to install/configure `gh` and do not proceed). The account needs read access to the repo and write access to create PRs and manage labels.
 
-## Overview
-
-Create a well-structured pull request with proper description, labels, and reviewers.
-
-## Steps
+## Pick the mode
 
 _Note:_ In the command output, format all URLs as clickable Markdown links: `[Link Text](URL)`.
 
-### 1. Check that a PR is not already open for this branch
+Check the current branch (`git branch --show-current`) and its open PR (`gh pr list --head <BRANCH> --state open`), then:
 
-- Get the current branch: `git branch --show-current`.
-- List open PRs for that branch: `gh pr list --head <BRANCH> --state open`.
-- If a PR exists, do **only** the PR summary (see step 3: write the description content as if for the PR, but do not create or update the PR). Skip steps 2, 3 (create/update), and 4. Tell the user the PR is already open and link to it.
+- **A. Draft placeholder** — no PR exists and the work is *not done yet*: the branch holds a freshly
+  written spec from the task workflow (typically invoked from the `to-spec` skill, or the branch's only
+  changes are under `.agents/tasks/`). The PR is a placeholder for work to come.
+- **B. Finalize draft** — a **draft** PR already exists for the branch and the work is done (spec's last
+  box checked, or the user asks to make it ready for review).
+- **C. Regular PR** — no PR exists and the work is already done (a task executed without the spec
+  workflow). This is the classic flow.
+- A non-draft PR already exists → don't create or update anything; write the description content as a
+  summary for the user (per Mode C step 2), tell them the PR is already open, and link to it.
 
-### 2. Prepare the branch
+If the signals conflict or are ambiguous, ask the user which mode they mean.
 
-- Ensure all changes are committed:
-  - `git status` to see uncommitted changes.
-  - If there are changes: `git add` (as appropriate), then `git commit -m "..."` with a clear message.
-- Push the branch: `git push -u origin <BRANCH>` (or `git push` if upstream is already set).
-- Verify the branch is up to date with main:
-  - `git fetch origin main` then compare: e.g. `git rev-list --left-right --count origin/main...HEAD` (expect `0	N` for “main has nothing we don’t have”) or merge/rebase if the user wants: `git merge origin/main`.
-- Resolve any merge conflicts before continuing.
+## Mode A — Draft placeholder (spec time)
 
-### 3. Write the PR description
+At this stage nothing is implemented, so **do not** describe changes, env vars, or checklists — the
+description is a placeholder pointing at the plan:
+
+1. **Prepare the branch** — commit the spec if needed (with the user's approval), push with `-u`.
+2. **Compose the placeholder body** (skip the PR template — it describes finished work):
+   - `Resolves #<ISSUE_NUMBER>` when the branch matches `issue-\d+` (ad-hoc spec branches have no issue —
+     omit).
+   - One short paragraph: the task's goal, taken from the spec's **Context & goal**.
+   - A link to the spec file on this branch (`.agents/tasks/<dir>/spec.md`).
+   - A note that this is a **spec-first draft**: the branch will receive the task's work subtask by
+     subtask, and the final description will be written when the PR is marked ready for review.
+3. **Confirm with the user**, then create as draft: `gh pr create --draft --title "..." --body-file ...`.
+   Title = the task title (not "spec for..."; the PR will become the task's PR).
+4. **Labels** — copy the issue's labels (`gh issue view <N> --json labels`). Skip ENVs/dependencies
+   labels — nothing is implemented yet; Mode B adds them from the real diff.
+5. Link the created PR in the output.
+
+## Mode B — Finalize a draft into ready-for-review
+
+1. **Prepare the branch** — ensure everything is committed and pushed; verify up-to-dateness with main
+   (`git fetch origin main`, `git rev-list --left-right --count origin/main...HEAD`), merge if the user
+   wants; resolve conflicts before continuing.
+2. **Rewrite the description** following "Writing the description" below — the placeholder body is
+   replaced wholesale: `gh pr edit <N> --body-file ...`.
+3. **Labels from the real diff** — ENVs label if `./docs/ENVS.md` changed; dependencies label only if the
+   **dependency sections** of `package.json` changed (`dependencies`, `devDependencies`,
+   `peerDependencies`, `pnpm`/`overrides`) — inspect `git diff origin/main -- package.json` and ignore
+   changes confined to `scripts` or other fields; plus the issue's labels if not already copied.
+4. **Confirm with the user**, then flip: `gh pr ready <N>`. (On flipping, the Checks workflow runs —
+   drafts skip it by design.)
+5. Link the PR in the output.
+
+## Mode C — Regular PR (work already done)
+
+1. **Prepare the branch** — as Mode B step 1, plus commit any outstanding changes (with the user's
+   approval, clear message).
+2. **Write the description** — see "Writing the description" below.
+3. **Confirm with the user**, then create: `gh pr create --title "..." --body-file ...` (add `--draft`
+   only if the user asked for it).
+4. **Labels** — as Mode B step 3.
+5. Link the created PR in the output.
+
+## Writing the description (Modes B and C)
 
 - Use the template from `./docs/PULL_REQUEST_TEMPLATE.md` as the base. Read it and fill in each section.
-- **Issue number from branch name:** If the branch name matches the pattern `issue-\d+` (e.g. `issue-123`), extract the number (e.g. `git branch --show-current | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+'`), then:
-  - Fetch the issue: `gh issue view <ISSUE_NUMBER>`.
-  - At the very beginning of the **"Description and Related Issue(s)"** section, include: `Resolves #<ISSUE_NUMBER>`.
-- **Summary of changes:** Summarize the changes clearly and concisely in no more than two paragraphs. Use bullet points if needed. Be precise; keep the description short.
-- **Environment variable changes:** If any env vars were added, changed, or documented:
-  - Compare or read `./docs/ENVS.md` (and the validator/ENVS docs if relevant) to list what changed.
-  - Add a separate section listing each variable change and the **purpose** of each (why it was added/changed).
-    - **Bad:** "Added `NEXT_PUBLIC_VIEWS_TX_GROUPED_FEES` environment variable to the documentation."
-    - **Good:** "Added `NEXT_PUBLIC_VIEWS_TX_GROUPED_FEES` to group transaction fees into one section on the transaction page."
-    - **Good:** "Extended possible values for `NEXT_PUBLIC_VIEWS_TX_ADDITIONAL_FIELDS` with set_max_gas_limit to display the maximum gas price set by the transaction sender."
-    - **Good:** "Introduced a new option, `"fee reception"`, for the `NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE` variable."
-- **Checklist:** Keep the "Checklist for PR Author" section from the template and check the items that apply (e.g. tested locally, tests added, ENVS/docs/validator updated if env vars changed).
-- When the description is ready, **ask the user for confirmation or changes** before creating the PR (step 4).
-
-### 4. Create the PR and set labels
-
-- Create the pull request with a descriptive title. Use draft mode if the user asked for it:
-  - `gh pr create --title "Your descriptive title" --body-file /path/to/body.md` (and add `--draft` if draft).
-  - Or paste the body inline if preferred; ensure the filled template is used.
-- Add labels:
-  - If anything was added or changed in `./docs/ENVS.md`, add the **"ENVs"** label: `gh pr edit <PR_NUMBER> --add-label "ENVs"` (or add labels during `gh pr create` if your `gh` version supports it).
-  - If `package.json` has changed (check with `git diff origin/main -- package.json`), add the **"dependencies"** label.
-  - If the branch name contained an issue number (pattern `issue-\d+`), copy all labels from that issue onto the PR: get labels with `gh issue view <ISSUE_NUMBER> --json labels -q '.labels[].name'`, then add each: `gh pr edit <PR_NUMBER> --add-label "<LABEL>"`.
-- Include a clickable link to the created PR in the command output (e.g. from `gh pr view --web` or the URL printed by `gh pr create`).
+- **Issue number from branch name:** If the branch name matches `issue-\d+`, extract the number, fetch the
+  issue (`gh issue view <N>`), and start the **"Description and Related Issue(s)"** section with
+  `Resolves #<ISSUE_NUMBER>`.
+- **Summary of changes:** clear and concise, at most two paragraphs; bullet points if needed. Be precise;
+  keep it short.
+- **Environment variable changes:** if any env vars were added, changed, or documented, compare or read
+  `./docs/ENVS.md` (and the validator/ENVS docs if relevant) and add a separate section listing each
+  variable change and its **purpose**:
+  - **Bad:** "Added `NEXT_PUBLIC_VIEWS_TX_GROUPED_FEES` environment variable to the documentation."
+  - **Good:** "Added `NEXT_PUBLIC_VIEWS_TX_GROUPED_FEES` to group transaction fees into one section on the transaction page."
+  - **Good:** "Extended possible values for `NEXT_PUBLIC_VIEWS_TX_ADDITIONAL_FIELDS` with set_max_gas_limit to display the maximum gas price set by the transaction sender."
+  - **Good:** "Introduced a new option, `"fee reception"`, for the `NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE` variable."
+- **Checklist:** keep the "Checklist for PR Author" section from the template and check the items that
+  apply (e.g. tested locally, tests added, ENVS/docs/validator updated if env vars changed).
+- Always **ask the user for confirmation or changes** before creating/updating the PR.

--- a/.agents/skills/grill-the-task/SKILL.md
+++ b/.agents/skills/grill-the-task/SKILL.md
@@ -1,25 +1,23 @@
 ---
 name: grill-the-task
 description: >-
-  Interview the developer about a poorly-specified product task (GitHub issue) until it becomes an
-  implementable spec. Researches the issue, codebase, live API, and Figma mockups first, then grills one
-  question at a time and hands off to the to-spec skill. Also elaborates sub-specs for big steps of large
-  tasks. Use before starting any product task.
+  Grill a product task (GitHub issue) into an implementable spec — research first, then a
+  one-question-at-a-time interview; also elaborates sub-specs for big steps of large tasks.
 disable-model-invocation: true
 ---
 
 # Grill the task
 
-Product task issues are often thin — a title and a couple of links. Passing such a task straight to an agent
-(or a developer) produces guesswork. This skill closes the gap: research everything researchable, then
-interview the developer about everything that is a *decision*, tracking what they can't answer as open
-questions for the responsible people. The output is a spec, written by the `to-spec` skill.
+Product task issues arrive thin — a title and a couple of links. This skill closes the gap: research
+everything researchable, then grill the developer about everything that is a *decision*, tracking what they
+can't answer as open questions for the responsible people. The output is a spec, written by the `to-spec`
+skill.
 
 **Two modes.**
 
 - **Task mode** (default): input is a GitHub issue URL; output is the task's main spec.
 - **Subtask mode**: input is an existing spec plus a step number (a big step of a `large` task); the session
-  scopes research and questions to that step and outputs its sub-spec (`subtasks/<NN>-<slug>.md>`). Run it
+  scopes research and questions to that step and outputs its sub-spec (`subtasks/<NN>-<slug>.md`). Run it
   just-in-time, right before the step starts, against the by-then-current code.
 
 ## Step 1 — Research
@@ -53,11 +51,14 @@ Then run two mechanical cross-checks; every mismatch becomes an open question fo
   that displays that piece of information and verify each backing resource carries the new field — including
   proxy paths (e.g. BENS microservice data proxied through the core API, search results carrying the same info).
 
+Research is complete when every linked source is read or flagged inaccessible, every named endpoint has a
+real sample response, and both cross-checks have run with each mismatch recorded as an open question.
+
 ## Step 2 — Classify the size
 
 Propose a size to the developer and confirm it:
 
-- **small** — one step; implementable by an agent or an user right after this session.
+- **small** — one step; implementable by an agent or a user right after this session.
 - **medium** — a flat list of small subtasks in one spec.
 - **large** — many steps; the main spec lists them, small steps fully specified now, big steps as one-liners
   each getting its own subtask-mode grilling session later.
@@ -66,13 +67,13 @@ Propose a size to the developer and confirm it:
 
 **Invoke the `grilling` skill** and run the interview under its discipline: one question at a time with a
 recommended answer, decisions put to the developer while facts are looked up, and no enactment (Step 4)
-until shared understanding is confirmed. Skip anything the research already answered. **Start by picking
-the task's contacts**: for each
-relevant team in `.agents/TEAM.md`, ask which member owns this task (recommending the roster's default) —
-these go into the spec header. Also ask whether the task has (or deserves) a **dedicated Slack channel** —
-large features often get one, and it changes where open questions are sent (see the `to-spec` skill); record
-it in the spec header. When the developer doesn't know an answer, don't press — record the question with the
-owning contact and move on.
+until shared understanding is confirmed. Skip anything the research already answered.
+
+**Start by picking the task's contacts**: for each relevant team in `.agents/TEAM.md`, ask which member
+owns this task (recommending the roster's default) — these go into the spec header. Also ask whether the
+task has (or deserves) a **dedicated Slack channel** — large features often get one, and it changes where
+open questions are sent (see the `to-spec` skill); record it in the spec header. When the developer doesn't
+know an answer, don't press — record the question with the owning contact and move on.
 
 Cover these domains:
 
@@ -99,6 +100,10 @@ current text — don't work from memory of its questions. The answers are record
 spec, so `implement-task` can later execute without stopping to ask. Do this in whichever session fully
 specifies the subtask: here for small/medium tasks and small steps, in the just-in-time subtask session for
 big steps.
+
+The interview is complete when every domain is covered or explicitly skipped as research-answered, the
+contacts and channel are settled, every unanswered question has an owner, and every fully-specified
+`[agent]` subtask has its executor skill's inputs collected.
 
 ## Step 4 — Hand off to `to-spec`
 

--- a/.agents/skills/grill-the-task/SKILL.md
+++ b/.agents/skills/grill-the-task/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: grill-the-task
+description: >-
+  Interview the developer about a poorly-specified product task (GitHub issue) until it becomes an
+  implementable spec. Researches the issue, codebase, live API, and Figma mockups first, then grills one
+  question at a time and hands off to the to-spec skill. Also elaborates sub-specs for big steps of large
+  tasks. Use before starting any product task.
+disable-model-invocation: true
+---
+
+# Grill the task
+
+Product task issues are often thin — a title and a couple of links. Passing such a task straight to an agent
+(or a developer) produces guesswork. This skill closes the gap: research everything researchable, then
+interview the developer about everything that is a *decision*, tracking what they can't answer as open
+questions for the responsible people. The output is a spec, written by the `to-spec` skill.
+
+**Two modes.**
+
+- **Task mode** (default): input is a GitHub issue URL; output is the task's main spec.
+- **Subtask mode**: input is an existing spec plus a step number (a big step of a `large` task); the session
+  scopes research and questions to that step and outputs its sub-spec (`subtasks/<NN>-<slug>.md>`). Run it
+  just-in-time, right before the step starts, against the by-then-current code.
+
+## Step 1 — Research
+
+Always investigate the question against **primary sources** — official docs, source code, specs, first-party APIs — 
+not a secondary write-up of them. **Never ask the developer something that can be looked up** — but do ask,
+immediately, when something **blocks the research itself**: the issue has no mockup link, it's unclear which
+instance an endpoint is deployed on (staging or production?), a linked doc is inaccessible, a named resource
+can't be found in the codebase. Ask to unblock the lookup rather than guessing or silently skipping a source.
+Gather, in roughly this order:
+
+1. **The issue** — `gh issue view <n> --repo blockscout/frontend --comments` (needs `gh`; follow the
+   `check-github-cli` skill if unsure). Read every linked resource that is accessible: other issues, docs
+   pages, Notion pages (via the Notion MCP tools, if connected).
+2. **The codebase** — what already exists: similar pages/features to mirror, relevant `service:name`
+   resources, feature configs, terms from `.agents/GLOSSARY.md`.
+3. **The API** — for every endpoint the issue names, fetch a real sample response (the `resolve-api-url`
+   skill resolves instance URLs; then `curl`). Note pagination/sorting/filtering params and whether the API
+   is production-deployed or staging-only.
+4. **Figma mockups** — via the Figma MCP tools, **enumerate-only**: list screens/frames, their elements,
+   columns, states, and record a node link per screen. Do **not** extract visual/styling details — appearance
+   stays with the mockups and the `[human]` style subtasks (see `.agents/rules/delegation.mdc`). If the Figma
+   MCP is not connected, have the developer describe the mockups instead.
+
+Then run two mechanical cross-checks; every mismatch becomes an open question for the backend owner or PM:
+
+- **Mockup ↔ API sufficiency** — for each element/column a mockup displays, confirm the sample API response
+  actually contains that data (e.g. the mockup shows a `receiver` column but the list item model has no
+  receiver hash → open question).
+- **Field propagation** — when the task adds a new field to an existing model, enumerate **every** UI surface
+  that displays that piece of information and verify each backing resource carries the new field — including
+  proxy paths (e.g. BENS microservice data proxied through the core API, search results carrying the same info).
+
+## Step 2 — Classify the size
+
+Propose a size to the developer and confirm it:
+
+- **small** — one step; implementable by an agent or an user right after this session.
+- **medium** — a flat list of small subtasks in one spec.
+- **large** — many steps; the main spec lists them, small steps fully specified now, big steps as one-liners
+  each getting its own subtask-mode grilling session later.
+
+## Step 3 — The interview
+
+**Invoke the `grilling` skill** and run the interview under its discipline: one question at a time with a
+recommended answer, decisions put to the developer while facts are looked up, and no enactment (Step 4)
+until shared understanding is confirmed. Skip anything the research already answered. **Start by picking
+the task's contacts**: for each
+relevant team in `.agents/TEAM.md`, ask which member owns this task (recommending the roster's default) —
+these go into the spec header. Also ask whether the task has (or deserves) a **dedicated Slack channel** —
+large features often get one, and it changes where open questions are sent (see the `to-spec` skill); record
+it in the spec header. When the developer doesn't know an answer, don't press — record the question with the
+owning contact and move on.
+
+Cover these domains:
+
+1. **Goal & users** — what problem, for whom.
+2. **Env gating** — does the feature sit behind a new `NEXT_PUBLIC_*` env var or not. (Just the decision —
+   the mechanics belong to the `add-env-var` skill at implementation time.)
+3. **Data & API** — anything Step 1 left open: readiness of staging-only endpoints, missing params, and
+   **which upcoming backend release ships the required API changes** (so the frontend release notes can
+   reference it) — usually a question for the backend owner.
+4. **UI inventory** — routes, navigation entry points (where do users find this?), cross-links to existing
+   entity pages. Behavioral states and mobile behavior are standard — don't ask.
+5. **Analytics & links** — custom Mixpanel events **only** if there's a new interactive element worth
+   tracking (page views are auto-wired); UTM query params on any hardcoded links to Blockscout or partner
+   products.
+6. **Delivery** — one question: deploy a demo after completion or not (executed via the `deploy-demo` skill
+   as a final subtask if yes).
+
+Testing is **not** an interview domain — the standing policy in `.agents/rules/delegation.mdc` applies.
+
+**Front-load the executor skills' inputs.** Once the task breakdown has taken shape, go through every
+`[agent]` subtask that will run a project skill (`add-new-page`, `add-api-resource`, `add-env-var`, …):
+**open that skill and run its user-facing interview now** (e.g. `add-new-page` Step 0), from the skill's
+current text — don't work from memory of its questions. The answers are recorded with the subtask in the
+spec, so `implement-task` can later execute without stopping to ask. Do this in whichever session fully
+specifies the subtask: here for small/medium tasks and small steps, in the just-in-time subtask session for
+big steps.
+
+## Step 4 — Hand off to `to-spec`
+
+Invoke the **`to-spec`** skill. It writes the spec (or sub-spec, in subtask mode), tags subtasks
+`[agent]`/`[human]` per the delegation boundary, and runs the open-question outreach (grouping by owner,
+drafting Slack messages for the developer's approval, recording thread permalinks).

--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a *fact* can be found by exploring the codebase, look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+
+Do not enact the plan until I confirm we have reached a shared understanding.

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -42,7 +42,8 @@ runs.
 first commit (feature branch → `main`; a big step's sub-branch → feature branch, with its sub-spec as the
 first commit) and flips to ready for review when its breakdown's last box is checked. Nudge accordingly: on
 a first run with no PR yet, suggest opening the draft; when checking off the final subtask (or a big step's
-final step), suggest marking it ready.
+final step), suggest finalizing it via the `create-pr` skill (finalize-draft mode: real description from the
+diff, labels, then ready for review).
 
 **Branch names carry the addressing.** The feature branch is `issue-<number>` (e.g. `issue-3219`); a big
 step's sub-branch adds a `-step-<N>` postfix (e.g. `issue-3219-step-2`). An **ad-hoc** spec's branch is its

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: implement-task
 description: >-
-  Execute the next subtask of a product-task spec from .agents/tasks/ — exactly one per run. Runs [agent]
-  subtasks by composing the project skills and verifying the result; hands [human] subtasks over to the
-  developer. Use when starting or continuing implementation of a task that has a spec.
+  Execute a product-task spec one leaf subtask per run — [agent] subtasks via the project skills,
+  [human] subtasks handed off to the developer.
 disable-model-invocation: true
 ---
 
@@ -16,9 +15,8 @@ task from the branch alone.
 
 ## Invocation
 
-- `/implement-task` — no arguments, the usual case: infer everything from the current branch. An
-  `issue-<number>` branch locates the task dir in `.agents/tasks/` by issue number; a `-step-<N>` postfix
-  narrows the run to big step N's sub-spec. Execute the next eligible subtask (Step 3 below).
+- `/implement-task` — no arguments, the usual case: infer the spec (and the current big step) from the
+  branch name, per the Branch model below. Execute the next eligible subtask (Step 3).
 - `/implement-task 4` — a **specific** subtask, out of order. Pending questions still refuse the run;
   unchecked dependencies are pointed out and need the developer's explicit confirmation to proceed.
 - `/implement-task 2.3` — large tasks address **leaf steps** with dotted numbers: step 3 inside big step 2's

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -38,11 +38,18 @@ subtask is a single commit directly on the feature branch. Remind the developer 
 starts, but **never commit, push, or open PRs yourself** — the developer reviews the diff and commits between
 runs.
 
+**PR timing (developer's action — prompt, don't do):** a draft PR opens as soon as the spec is the branch's
+first commit (feature branch → `main`; a big step's sub-branch → feature branch, with its sub-spec as the
+first commit) and flips to ready for review when its breakdown's last box is checked. Nudge accordingly: on
+a first run with no PR yet, suggest opening the draft; when checking off the final subtask (or a big step's
+final step), suggest marking it ready.
+
 **Branch names carry the addressing.** The feature branch is `issue-<number>` (e.g. `issue-3219`); a big
-step's sub-branch adds a `-step-<N>` postfix (e.g. `issue-3219-step-2`). A dash postfix, **not** a slash —
-git forbids `X` and `X/…` coexisting. The names are fully mechanical (no slug to invent), which is what
-lets the skill construct branches itself and infer the spec (and the current big step) with no arguments.
-Ad-hoc specs without an issue have no convention — for them, pass the task dir explicitly.
+step's sub-branch adds a `-step-<N>` postfix (e.g. `issue-3219-step-2`). An **ad-hoc** spec's branch is its
+task-dir slug (`.agents/tasks/<slug>/` → branch `<slug>`). Dash postfixes, **not** slashes — git forbids
+`X` and `X/…` coexisting. The names are fully mechanical, which is what lets the skill construct branches
+itself and infer the spec (and the current big step) with no arguments: `issue-<n>` matches the task dir by
+issue number, any other branch matches by exact dir name.
 
 ## Workflow
 

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: implement-task
+description: >-
+  Execute the next subtask of a product-task spec from .agents/tasks/ — exactly one per run. Runs [agent]
+  subtasks by composing the project skills and verifying the result; hands [human] subtasks over to the
+  developer. Use when starting or continuing implementation of a task that has a spec.
+disable-model-invocation: true
+---
+
+# Implement task
+
+Work through a spec produced by `grill-the-task` / `to-spec`, **one subtask per run**. The spec is the state
+machine: each run starts a fresh session, picks up where the spec says work stopped, executes a single
+subtask, updates the spec, and stops so the developer can verify and commit. Any colleague can resume the
+task from the branch alone.
+
+## Invocation
+
+- `/implement-task` — no arguments, the usual case: infer everything from the current branch. An
+  `issue-<number>` branch locates the task dir in `.agents/tasks/` by issue number; a `-step-<N>` postfix
+  narrows the run to big step N's sub-spec. Execute the next eligible subtask (Step 3 below).
+- `/implement-task 4` — a **specific** subtask, out of order. Pending questions still refuse the run;
+  unchecked dependencies are pointed out and need the developer's explicit confirmation to proceed.
+- `/implement-task 2.3` — large tasks address **leaf steps** with dotted numbers: step 3 inside big step 2's
+  sub-spec (`subtasks/02-<slug>.md`). The sub-spec's own breakdown is the checklist for that big step; its
+  header status is maintained like a spec's.
+- An explicit task dir as the first argument (e.g. `/implement-task 3219-cross-chain-views 4`) overrides
+  branch inference — needed when not on the feature branch yet.
+
+The unit of one run is always a **leaf**: in a large task, "next eligible subtask" descends — if the next
+subtask is a big step with a sub-spec, execute the next eligible step *inside* it (one step, then stop).
+
+## Branch model
+
+One **feature branch** holds the whole product task; it lands in `main` as one PR when the task is done.
+Within it: a big subtask (several commits) gets its own sub-branch and a PR into the feature branch; a simple
+subtask is a single commit directly on the feature branch. Remind the developer of this when a subtask
+starts, but **never commit, push, or open PRs yourself** — the developer reviews the diff and commits between
+runs.
+
+**Branch names carry the addressing.** The feature branch is `issue-<number>` (e.g. `issue-3219`); a big
+step's sub-branch adds a `-step-<N>` postfix (e.g. `issue-3219-step-2`). A dash postfix, **not** a slash —
+git forbids `X` and `X/…` coexisting. The names are fully mechanical (no slug to invent), which is what
+lets the skill construct branches itself and infer the spec (and the current big step) with no arguments.
+Ad-hoc specs without an issue have no convention — for them, pass the task dir explicitly.
+
+## Workflow
+
+### Step 1 — Load state
+
+Resolve the spec per the Invocation section (branch inference by default, explicit task dir wins); if
+neither yields a match in `.agents/tasks/`, ask. Read the spec — and the sub-spec, when a `-step-<N>`
+branch or a dotted target selects one — plus `.agents/rules/delegation.mdc`. If the header has no feature
+branch yet, construct it from the convention above (`issue-<number>`), confirm with the developer, create
+it, and record it in the header.
+
+### Step 2 — Reconcile the previous handoff
+
+If the previous subtask in the breakdown is `[human]` and still unchecked, ask the developer whether it's
+done before doing anything else — check it off if so, stop if it's still in progress (the order exists for a
+reason; don't leapfrog a pending style step unless the developer explicitly says the next subtask is
+independent).
+
+### Step 3 — Pick the next subtask
+
+If the invocation named a subtask or leaf step, that's the pick (with the guardrails from the Invocation
+section). Otherwise: the first unchecked subtask whose dependencies are all checked **and** whose listed
+questions are all `resolved` or `waived`, descending into sub-specs to a leaf step. Then:
+
+- **All remaining subtasks blocked by `pending` questions** → tell the developer which questions block what,
+  and suggest running `to-spec` to harvest Slack answers. Stop.
+- **Next subtask is `[human]`** → hand off: state what needs doing, link the Figma node, note that the
+  scaffold's `TODO (design):` markers are the worklist. Stop.
+- **Next subtask is a big step without its sub-spec yet** → tell the developer to run `grill-the-task` in
+  subtask mode for it. Stop.
+- **Next subtask is `[agent]`** → proceed.
+
+### Step 4 — Execute (one subtask only)
+
+Do the work, composing the project skills wherever one applies (`add-api-resource`, `add-env-var`,
+`add-new-page`, `deploy-demo`, …) and staying inside the delegation boundary — scaffolds get placeholder
+presentation and `TODO (design):` markers, never final styling. Follow the sub-spec if the subtask has one.
+
+The spec should already contain the executing skill's inputs — the grilling session runs each skill's
+interview up front, so **skip any of the skill's questions the spec answers** and run uninterrupted. If an
+input is genuinely missing, ask the developer and **backfill the answer into the spec** before proceeding.
+Write the unit tests and Playwright scaffolds the standing testing policy assigns to this subtask.
+
+### Step 5 — Verify
+
+Run the repo's checks for what was touched: `pnpm run lint:tsc`, ESLint on changed files, and the relevant
+unit tests (commands per `.agents/rules/code-quality.mdc`). Intentional scaffold `TODO`s may keep ESLint red
+in the same way the `add-new-page` skill documents — say so explicitly rather than chasing green.
+
+### Step 6 — Update the spec and stop
+
+Check the subtask off with a one-line note of what was done (files/skills involved). Set the header status to
+`in progress` on the first executed subtask, and to `done` when the last box is checked. Then summarize the
+result and end the run — verification of the diff, the commit, and the next `implement-task` invocation
+belong to the developer.

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -54,6 +54,9 @@ For every open question with status `pending` and a recorded Slack permalink:
 4. If a reply raises a follow-up: draft it (in Russian, like all outreach), get the user's approval, send it
    **into the same thread**, and keep the question `pending`.
 
+The harvest is complete when every `pending` question with a permalink has had its thread read and is now
+resolved, followed up, or confirmed still unanswered.
+
 ### Step 3 — Write or merge the spec
 
 Extract from the conversation: decisions, requirements, data/API facts, UI inventory, size classification,
@@ -88,6 +91,9 @@ For `pending` questions that have **no** Slack permalink yet:
 If the Slack MCP tools are unavailable, record the questions with owners anyway and tell the user to route
 them manually.
 
+Outreach is complete when every `pending` question has a recorded permalink — or an explicit note that the
+developer routes it manually.
+
 ### Step 5 — Branch and draft PR (first creation only)
 
 When this run **created** the spec (or sub-spec), bootstrap the workflow's draft-PR-first policy — each
@@ -99,10 +105,9 @@ action only with the developer's explicit approval, never unprompted:
    header.
 2. **Commit** — propose committing the spec as the branch's first commit; show what will be committed and
    wait for confirmation.
-3. **Draft PR** — suggest opening it right away (feature branch → `main`, or sub-branch → feature branch)
-   via the `create-pr` skill, **as a draft**: a spec-only draft is the cheap moment for someone to catch a
-   wrong split or missed requirement before implementation starts, and CI and demo deploys hang off it for
-   the rest of the task. It flips to ready for review when the breakdown's last box is checked (the
+3. **Draft PR** — suggest opening it right away via the `create-pr` skill (draft-placeholder mode; feature
+   branch → `main`, sub-branch → feature branch). Why drafts open this early is documented in
+   `.agents/tasks/README.md`; the PR flips to ready when the breakdown's last box is checked (the
    `implement-task` skill nudges at that moment).
 
 For ad-hoc specs the draft PR doubles as a **parking spot**: an idea captured as a spec today can sit in

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: to-spec
+description: >-
+  Convert the current conversation into a product-task spec in .agents/tasks/, or update an existing
+  spec — folding in new decisions, harvesting colleague replies from Slack threads, and sending open
+  questions to their owners. Use at the end of a grilling session, when the user wants to capture any
+  conversation as a spec, or to sync a spec's open questions with Slack.
+---
+
+# To spec
+
+Turn the current conversation into a spec file — or merge it into one that already exists. The spec is the
+single source of truth for a product task: `implement-task` executes from it, humans work from it, and its
+open questions drive the Slack round-trip with PMs, designers, and backend engineers.
+
+This skill is **conversation-agnostic**: it is normally invoked at the end of a `grill-the-task` session,
+but works from any conversation that contains decisions worth capturing — including an **empty** one. A
+fresh session invoking it on an existing spec (e.g. `/to-spec 3219-cross-chain-txs`) is the normal way to
+sync Slack replies: there is nothing to convert, so the run is just harvest (Step 2) plus outreach (Step 4).
+
+## Spec location and structure
+
+- With a GitHub issue: `.agents/tasks/<issue-number>-<slug>/spec.md` (e.g. `.agents/tasks/3219-cross-chain-txs/spec.md`).
+- Ad-hoc (no issue): `.agents/tasks/<slug>/spec.md`.
+- Large tasks: big steps get sub-specs at `subtasks/<NN>-<slug>.md` next to `spec.md`, written **just-in-time**
+  by a `grill-the-task` subtask session — when invoked from one, write the sub-spec, not the main spec.
+
+Use `spec-template.md` (next to this file) for every new spec and sub-spec. Structure by size:
+
+- **small** — one-step task breakdown; the whole task is implementable right after the session.
+- **medium** — a flat list of small subtasks in one spec.
+- **large** — main spec with the ordered step list; small steps fully specified inline, big steps as
+  one-liners pointing at their (future) sub-spec.
+
+Tag every subtask `[agent]` or `[human]` per `.agents/rules/delegation.mdc` (UI work defaults to the
+scaffold → style split). Specs merge with the task's PR and accumulate in `.agents/tasks/` as precedent.
+
+## Workflow
+
+### Step 1 — Locate the spec
+
+Derive the path from the issue (or ask for a slug). If the file already exists, this is an **update** run:
+read the spec first and treat it as hand-editable — developers edit specs directly between runs.
+
+### Step 2 — Harvest Slack answers (update runs only)
+
+For every open question with status `pending` and a recorded Slack permalink:
+
+1. Read the thread with the Slack MCP tools (`slack_read_thread`; parse `channel_id`/`message_ts` from the
+   permalink as in the `create-issue-from-slack-thread` skill).
+2. If there are replies, summarize them and propose a resolution to the user.
+3. On acceptance: fold the decision into the affected spec section(s), set the question's status to
+   `resolved`, and record the answer and date in its entry.
+4. If a reply raises a follow-up: draft it (in Russian, like all outreach), get the user's approval, send it
+   **into the same thread**, and keep the question `pending`.
+
+### Step 3 — Write or merge the spec
+
+Extract from the conversation: decisions, requirements, data/API facts, UI inventory, size classification,
+task breakdown, and unanswered questions with their owners — the per-team contacts picked during the
+session (defaults from `.agents/TEAM.md`), recorded in the header.
+
+**Merge surgically.** On update runs, never regenerate the file: preserve checked boxes, statuses, hand
+edits, and resolved-question records; only add or amend what the conversation actually changed. Show the
+user a summary of the changes and confirm before moving on.
+
+Status field: a new spec starts as `draft`; set it to `ready` once no `pending` question blocks the first
+subtask (per-subtask blocking — unblocked subtasks may proceed while unrelated questions are pending).
+
+### Step 4 — Send open questions (outreach)
+
+For `pending` questions that have **no** Slack permalink yet:
+
+1. Group them by owner.
+2. Pick each group's destination:
+   - Task has a **dedicated feature channel** (spec header) → **all** questions go there, API ones included.
+   - Otherwise, **product questions go to the frontend channel** (see `.agents/TEAM.md`) — never a DM — so
+     colleagues from other teams (QA in particular) build the same understanding of the feature.
+   - Other questions (API, design) default to a DM with the owner.
+   - When posting to a channel, **always mention the addressee** — `<@member ID>` from `.agents/TEAM.md`
+     (people missing from the roster: resolve by name via `slack_search_users` and suggest adding them).
+3. Draft one message per owner: brief task context (issue link), the questions, and why they block progress.
+   Write all Slack messages in **Russian** — the team's internal language (the spec itself stays in English).
+4. **Show every draft (with its destination) to the user and wait for explicit approval** — never send
+   unreviewed outreach.
+5. Send (`slack_send_message`), then record each thread's permalink in the question's entry.
+
+If the Slack MCP tools are unavailable, record the questions with owners anyway and tell the user to route
+them manually.

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -87,3 +87,24 @@ For `pending` questions that have **no** Slack permalink yet:
 
 If the Slack MCP tools are unavailable, record the questions with owners anyway and tell the user to route
 them manually.
+
+### Step 5 — Branch and draft PR (first creation only)
+
+When this run **created** the spec (or sub-spec), bootstrap the workflow's draft-PR-first policy — each
+action only with the developer's explicit approval, never unprompted:
+
+1. **Branch** — main spec: `issue-<number>` off `main`; sub-spec (subtask mode): `issue-<number>-step-<N>`
+   off the feature branch; **ad-hoc spec** (no issue): the task-dir slug itself (spec in
+   `.agents/tasks/<slug>/` → branch `<slug>`). Create/switch if needed and record the branch in the spec
+   header.
+2. **Commit** — propose committing the spec as the branch's first commit; show what will be committed and
+   wait for confirmation.
+3. **Draft PR** — suggest opening it right away (feature branch → `main`, or sub-branch → feature branch)
+   via the `create-pr` skill, **as a draft**: a spec-only draft is the cheap moment for someone to catch a
+   wrong split or missed requirement before implementation starts, and CI and demo deploys hang off it for
+   the rest of the task. It flips to ready for review when the breakdown's last box is checked (the
+   `implement-task` skill nudges at that moment).
+
+For ad-hoc specs the draft PR doubles as a **parking spot**: an idea captured as a spec today can sit in
+its draft PR and be picked up, refined, or implemented days later — visible on GitHub instead of only in a
+local working tree.

--- a/.agents/skills/to-spec/spec-template.md
+++ b/.agents/skills/to-spec/spec-template.md
@@ -1,0 +1,64 @@
+# <Task title>
+
+| | |
+| --- | --- |
+| Issue | <GitHub issue URL, or "—" for ad-hoc specs> |
+| Status | `draft` \| `ready` \| `in progress` \| `done` |
+| Size | `small` \| `medium` \| `large` |
+| Feature branch | `<branch name>` (set on first `implement-task` run) |
+| PM | <name> |
+| Designer | <name> |
+| Backend | <name> |
+| Slack channel | <#feature-channel if the task has one; otherwise "—" (default routing per `to-spec`)> |
+
+<!-- People default from `.agents/TEAM.md`; override here per task. -->
+
+## Context & goal
+
+<!-- The "why" and the user-facing outcome. A couple of paragraphs, no more. -->
+
+## Functional requirements
+
+<!-- User stories / testable statements. What the feature must do, not how it looks. -->
+
+## Data & API
+
+<!-- Endpoints with sample responses (curl-verified), which `service:name` resources exist vs. must be
+added, pagination/sorting/filtering params, env vars / feature flags, API readiness (deployed vs.
+staging-only) and the backend release version that ships the changes (for release-notes reference). -->
+
+## UI inventory
+
+<!-- Affected pages/tabs/components: routes, navigation entry points, cross-links to existing entity
+pages. One Figma node link per screen. Behavioral facts only — never visual/styling prose; appearance
+belongs to the mockups and the [human] style subtasks. -->
+
+## Out of scope
+
+<!-- Explicit non-goals, so agents don't wander. -->
+
+## Task breakdown
+
+<!-- Ordered. Tag each subtask `[agent]` or `[human]` per `.agents/rules/delegation.mdc`. Reference the
+executing skill where one applies. A subtask blocked by open questions lists their ids — it may not start
+while any of them is `pending`. In a large task, a big step gets a one-line entry here plus its own
+sub-spec (written just-in-time via a `grill-the-task` subtask session); a UI component is two linked
+subtasks (scaffold → style). Record the executing skill's interview answers (collected during grilling)
+as an indented `inputs:` list under the subtask, so `implement-task` never has to stop and ask. -->
+
+- [ ] 1 `[agent]` <title> — skill: `add-api-resource` — questions: Q2
+- [ ] 2 `[agent]` <big step title> — sub-spec: `subtasks/02-<slug>.md`
+- [ ] 3 `[human]` Style <component> to mockup — [Figma](<node URL>)
+
+## Open questions
+
+<!-- One entry per question. Status is the gate `implement-task` checks. The Slack permalink is recorded
+when the question is sent, so answers can be harvested later. When resolved, fold the decision into the
+section above that it affects AND record it here. -->
+
+### Q1 — <question>
+
+- Owner: <role> (<name>)
+- Status: `pending` \| `resolved` \| `waived`
+- Slack: <permalink, once sent>
+- Answer: <decision + date, once resolved>

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -1,0 +1,47 @@
+# Product task specs
+
+This directory holds one folder per product task, each with a `spec.md` (and, for large tasks, per-step
+sub-specs in `subtasks/`). Specs merge with their task's PR and **accumulate here as a permanent record** —
+consult past specs as precedent for how similar tasks were scoped and split.
+
+## Why
+
+Product issues often arrive thin (a title, a Figma link) — too thin to hand to an agent, and thin enough
+that a developer fills the gaps with guesswork. The spec workflow fixes the input: an interview fills the
+gaps, unanswerable questions get routed to the people who own the answers, and the resulting spec explicitly
+says which steps an agent does and which a developer does by hand.
+
+## Lifecycle
+
+1. **Grill** — run the `grill-the-task` skill with the issue URL. It researches first (issue, codebase, live
+   API samples, Figma mockups — enumerate-only), then interviews you one question at a time. What you can't
+   answer becomes an open question with an owner.
+2. **Spec** — the session ends in the `to-spec` skill: it writes `spec.md` here, sizes the task
+   (small / medium / large), tags every subtask `[agent]` or `[human]` per the delegation boundary, then
+   drafts the open questions as Slack messages grouped by owner — you approve, it sends, and each thread's
+   permalink lands in the spec. (`to-spec` also works standalone, from any conversation worth capturing.)
+3. **Answers** — when colleagues reply, run `to-spec` on the spec again: it harvests the Slack threads,
+   proposes resolutions, folds accepted decisions into the spec, and sends approved follow-ups.
+4. **Implement** — run the `implement-task` skill repeatedly, one subtask per run: it executes `[agent]`
+   subtasks (composing `add-api-resource`, `add-new-page`, `add-env-var`, …) and verifies them, or hands
+   `[human]` subtasks (styling to Figma mockups) over to you. You review the diff and commit between runs.
+   A subtask can't start while a question blocking it is `pending` — unrelated subtasks can.
+5. **Land** — the feature branch merges to `main` as one PR, spec included. Big subtasks may have had their
+   own sub-branch + PR into the feature branch along the way; simple ones are single commits on it. Branch
+   names carry the addressing — feature branch is `issue-<number>` (`issue-3219`), a big step's sub-branch
+   adds `-step-<N>` (`issue-3219-step-2`) — so `implement-task` needs no arguments on a task branch.
+
+## Task sizes
+
+- **small** — one step; an agent or an user can implement it right after the grilling session.
+- **medium** — one spec with a flat list of small subtasks.
+- **large** — main spec + sub-specs. Big steps get their sub-spec written **just-in-time** via a
+  `grill-the-task` subtask session right before they start; small steps are specified in the main session.
+
+## Supporting files
+
+- `.agents/rules/delegation.mdc` — the living agent/human boundary (incl. the scaffold → style split for UI
+  work and the standing testing policy). Loosen it via PR as the repo gets more agent-friendly.
+- `.agents/TEAM.md` — the team roster (members + Slack IDs); the grilling session picks one contact per
+  team for the task and records the picks in the spec header.
+- `.agents/skills/to-spec/spec-template.md` — the spec template.

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -20,14 +20,20 @@ says which steps an agent does and which a developer does by hand.
    (small / medium / large), tags every subtask `[agent]` or `[human]` per the delegation boundary, then
    drafts the open questions as Slack messages grouped by owner — you approve, it sends, and each thread's
    permalink lands in the spec. (`to-spec` also works standalone, from any conversation worth capturing.)
+   Commit the spec to the feature branch and **open a draft PR right away** (`to-spec` walks you through
+   branch, commit, and draft PR at the end of the run) — a spec-only draft is the cheap moment to catch a
+   wrong split or a missed requirement, it links the issue to the work, and CI and demo deploys hang off it
+   for the rest of the task.
 3. **Answers** — when colleagues reply, run `to-spec` on the spec again: it harvests the Slack threads,
    proposes resolutions, folds accepted decisions into the spec, and sends approved follow-ups.
 4. **Implement** — run the `implement-task` skill repeatedly, one subtask per run: it executes `[agent]`
    subtasks (composing `add-api-resource`, `add-new-page`, `add-env-var`, …) and verifies them, or hands
    `[human]` subtasks (styling to Figma mockups) over to you. You review the diff and commit between runs.
    A subtask can't start while a question blocking it is `pending` — unrelated subtasks can.
-5. **Land** — the feature branch merges to `main` as one PR, spec included. Big subtasks may have had their
-   own sub-branch + PR into the feature branch along the way; simple ones are single commits on it. Branch
+5. **Land** — flip the draft PR to **ready for review** when the spec's last box is checked; the feature
+   branch merges to `main` as one PR, spec included. Big subtasks may have had their own sub-branch + PR
+   into the feature branch along the way (same pattern: draft when the step starts with its sub-spec as the
+   first commit, ready when the step's boxes are checked); simple ones are single commits on it. Branch
    names carry the addressing — feature branch is `issue-<number>` (`issue-3219`), a big step's sub-branch
    adds `-step-<N>` (`issue-3219-step-2`) — so `implement-task` needs no arguments on a task branch.
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,15 +3,16 @@ on:
   workflow_call:
   workflow_dispatch:
   pull_request:
-    types: [ opened, synchronize, unlabeled ]
+    types: [ opened, synchronize, unlabeled, ready_for_review ]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
       - '.husky/**'
       - '.vscode/**'
+      - '.agents/**'
+      - '.cursor/**'
       - 'deploy/**'
       - 'docs/**'
       - 'public/**'
-      - 'stub/**'
       - 'tools/**'
 
 # concurrency:
@@ -31,7 +32,9 @@ jobs:
   code_quality:
     name: Code quality
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip checks') && !(github.event.action == 'unlabeled' && github.event.label.name != 'skip checks') }}
+    # Draft PRs are skipped (spec-first workflow opens PRs as drafts early); checks run on
+    # ready_for_review, and workflow_dispatch always allows a manual run on any PR.
+    if: ${{ github.event.pull_request.draft != true && !contains(github.event.pull_request.labels.*.name, 'skip checks') && !(github.event.action == 'unlabeled' && github.event.label.name != 'skip checks') }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -18,7 +18,8 @@
         "playwright/fixtures/rewards.ts",
         "public/static/capybara/index.js",
         "src/toolkit/pages/design-system/utils.ts",
-        "src/features/external-txs/components/TxExternalTxs.pw.tsx"
+        "src/features/external-txs/components/TxExternalTxs.pw.tsx",
+        ".agents/TEAM.md"
     ],
     "enableGlobDot": true,
     "ignoreRandomStrings": true,


### PR DESCRIPTION
## Description and Related Issue(s)

Introduces a spec-driven workflow for working product tasks whose GitHub issues arrive underspecified (a title and a couple of links — e.g. #3537, #2909). The workflow fills the task's gaps through a structured interview, routes unanswerable questions to the responsible people via Slack, and executes the resulting spec one subtask at a time — explicitly separating what an agent may implement from what stays with a developer (final markup/styling against Figma mockups).

Entry point for the team: [`.agents/tasks/README.md`](https://github.com/blockscout/frontend/blob/product-task-workflow/.agents/tasks/README.md).

### Proposed Changes

- **Three new skills**:
  - `grill-the-task` — research-first interview: fetches the issue, explores the codebase, curls live API samples, enumerates Figma mockups; runs mockup↔API sufficiency and field-propagation cross-checks; then grills the developer one question at a time and front-loads the executor skills' inputs into the spec.
  - `to-spec` — converts any conversation into a spec in `.agents/tasks/` (or merges into an existing one); sends open questions to their owners in Slack (channel-first for product questions, in Russian), harvests replies back into the spec, and bootstraps the branch + draft PR.
  - `implement-task` — executes the spec one leaf subtask per run, inferring the spec from the branch name (`issue-<number>` / `issue-<number>-step-<N>` / task-dir slug); hands `[human]` subtasks over to the developer.
- **Supporting files**: `.agents/rules/delegation.mdc` (living agent/human boundary, incl. the scaffold→style split and standing testing policy), `.agents/TEAM.md` (per-team contact roster + Slack routing channels), `.agents/tasks/README.md` (lifecycle doc), and the generic `grilling` interview skill promoted from a personal skill.
- **`create-pr` skill reworked** into three modes: placeholder draft PR at spec time, finalize-draft into ready-for-review, and the classic create-right-away flow. The dependencies label now requires changes in actual dependency sections of `package.json`, not `scripts`.
- **Checks workflow**: draft PRs are skipped (same gate as the `skip checks` label), checks run on `ready_for_review`, manual runs stay available via `workflow_dispatch`; `.agents/**` and `.cursor/**` added to `paths-ignore`.

No ENV variable changes.

### Breaking or Incompatible Changes

None for the application. One CI behavior change: the Checks workflow no longer runs automatically on **draft** PRs — it runs when the PR is marked ready for review, and can always be triggered manually via `workflow_dispatch`.

### Additional Information

Specs will accumulate in `.agents/tasks/` (they merge together with their task's PR) and serve as precedent for future tasks. `.agents/TEAM.md` stores Slack member IDs deliberately — they are workspace-scoped identifiers, not credentials — to make question routing deterministic.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
