### PR TITLE
Update token information tooltip copy

### DIFF
--- a/.agents/tasks/3572-token-info-tooltip-copy/spec.md
+++ b/.agents/tasks/3572-token-info-tooltip-copy/spec.md
@@ -1,0 +1,55 @@
+# Update token information tooltip copy
+
+| | |
+| --- | --- |
+| Issue | https://github.com/blockscout/frontend/issues/3572 |
+| Status | `ready` |
+| Size | `small` |
+| Feature branch | `issue-3572` |
+| PM | Ulyana (task author) |
+| Designer | — |
+| Backend | — |
+| Slack channel | — (default routing per `to-spec`) |
+
+## Context & goal
+
+The token details page shows a green "certified" checkmark next to the token name when verified token
+info exists. Its tooltip currently claims the info "has been verified by {chain name}", which oversells
+the provenance: the info may be added manually or come from an external data provider. The task replaces
+the tooltip copy with an accurate statement plus a link to the docs page explaining token info sources.
+
+## Functional requirements
+
+- The tooltip on the certified checkmark reads:
+  "Token information was added manually or sourced from an external data provider."
+  followed by a "More details" link.
+- "More details" links to `https://docs.blockscout.com/using-blockscout/overviews/token-info`, opening
+  externally. No UTM params (matches every other `docs.blockscout.com` link in the codebase).
+- The link inside the tooltip is clickable — the toolkit `Tooltip` gets the `interactive` prop
+  (see `src/slices/chain/indexing-status/IndexingStatusInternalTxs.tsx` for prior art).
+
+## Data & API
+
+None — no API, env var, or feature-flag changes.
+
+## UI inventory
+
+- Single surface: token details page title, [`src/slices/token/pages/details/TokenPageTitle.tsx:100`](../../../src/slices/token/pages/details/TokenPageTitle.tsx).
+  Codebase-wide search confirmed no other component renders this tooltip.
+- The tooltip content changes from a template string (interpolating `config.chain.name`) to JSX with a
+  `Link external` — chain name no longer appears in the copy.
+
+## Out of scope
+
+- The checkmark icon itself (name, color, placement) — text-only change.
+- Analytics: no Mixpanel event for the "More details" link.
+- Demo deploy.
+
+## Task breakdown
+
+- [ ] 1 `[agent]` Replace the tooltip copy in `TokenPageTitle.tsx` with the new text + "More details"
+  external link; make the tooltip `interactive`.
+
+## Open questions
+
+None.

--- a/.agents/tasks/3572-token-info-tooltip-copy/spec.md
+++ b/.agents/tasks/3572-token-info-tooltip-copy/spec.md
@@ -3,7 +3,7 @@
 | | |
 | --- | --- |
 | Issue | https://github.com/blockscout/frontend/issues/3572 |
-| Status | `ready` |
+| Status | `done` |
 | Size | `small` |
 | Feature branch | `issue-3572` |
 | PM | Ulyana (task author) |
@@ -47,8 +47,9 @@ None — no API, env var, or feature-flag changes.
 
 ## Task breakdown
 
-- [ ] 1 `[agent]` Replace the tooltip copy in `TokenPageTitle.tsx` with the new text + "More details"
-  external link; make the tooltip `interactive`.
+- [x] 1 `[agent]` Replace the tooltip copy in `TokenPageTitle.tsx` with the new text + "More details"
+  external link; make the tooltip `interactive`. — Done: JSX tooltip content with `Link external` in
+  `src/slices/token/pages/details/TokenPageTitle.tsx`; `tsc` and ESLint clean.
 
 ## Open questions
 

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -266,6 +266,7 @@
         "txns",
         "typegen",
         "uidotdev",
+        "Ulyana",
         "unfinalized",
         "UNKN",
         "unparse",

--- a/src/slices/token/pages/details/TokenPageTitle.tsx
+++ b/src/slices/token/pages/details/TokenPageTitle.tsx
@@ -31,6 +31,7 @@ import TokenAddToWallet from 'src/features/web3-wallet/components/TokenAddToWall
 import config from 'src/config';
 import SpriteIcon from 'src/sprite/SpriteIcon';
 
+import { Link } from 'src/toolkit/chakra/link';
 import { Tooltip } from 'src/toolkit/chakra/tooltip';
 
 const PREDEFINED_TAG_PRIORITY = 100;
@@ -97,7 +98,15 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, verifiedInfoQuery, hash }: P
     <>
       { tokenQuery.data && <TokenEntity.Reputation value={ tokenQuery.data.reputation } ml={ 0 }/> }
       { verifiedInfoQuery.data?.tokenAddress && (
-        <Tooltip content={ `Information on this token has been verified by ${ config.chain.name }` }>
+        <Tooltip
+          content={ (
+            <>
+              Token information was added manually or sourced from an external data provider.{ ' ' }
+              <Link href="https://docs.blockscout.com/using-blockscout/overviews/token-info" external>More details</Link>
+            </>
+          ) }
+          interactive
+        >
           <SpriteIcon name="certified" color="green.500" boxSize={ 6 } cursor="pointer"/>
         </Tooltip>
       ) }


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #3572

The tooltip on the token page's green "certified" checkmark claimed the token info "has been verified by {chain name}", overselling its provenance. It now accurately states the info was added manually or sourced from an external data provider, and links to the docs.

### Proposed Changes

- Replaced the tooltip copy in `TokenPageTitle.tsx` with "Token information was added manually or sourced from an external data provider." plus a "More details" external link to the [token info docs](https://docs.blockscout.com/using-blockscout/overviews/token-info).
- Made the tooltip `interactive` so the link is clickable.
- No ENV variable changes.

### Breaking or Incompatible Changes

None.

### Additional Information

Spec: `.agents/tasks/3572-token-info-tooltip-copy/spec.md`. Verified with `pnpm run lint:tsc` and ESLint.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests) *(copy-only change — no new functionality)*
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently. *(not a bug fix)*
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode. *(n/a)*
- [ ] If I have added, changed, renamed, or removed an environment variable *(n/a)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
