### PR TITLE
Fix gas estimation for Dynamic wallet contract writes

### DIFF
--- a/playwright/fixtures/mockContractReadResponse.ts
+++ b/playwright/fixtures/mockContractReadResponse.ts
@@ -32,7 +32,8 @@ const fixture: TestFixture<MockContractReadResponseFixture, { page: Page }> = as
         return;
       }
 
-      const json = route.request().postDataJSON();
+      const dataJson = route.request().postDataJSON();
+      const json = Array.isArray(dataJson) ? dataJson[0] : dataJson;
       const params = json?.params?.[0];
       const id = json?.id;
 
@@ -47,17 +48,20 @@ const fixture: TestFixture<MockContractReadResponseFixture, { page: Page }> = as
       };
 
       if (isEqual(params, callParams) && id !== undefined && json?.method === rpcMethod) {
+
+        const json = {
+          id,
+          jsonrpc: '2.0',
+          result: noResultEncoding ? result : encodeFunctionResult({
+            abi: [ abiItem ],
+            functionName: abiItem.name,
+            result: result as never,
+          }),
+        };
+
         return route.fulfill({
           status: 200,
-          json: {
-            id,
-            jsonrpc: '2.0',
-            result: noResultEncoding ? result : encodeFunctionResult({
-              abi: [ abiItem ],
-              functionName: abiItem.name,
-              result: result as never,
-            }),
-          },
+          json: Array.isArray(dataJson) ? [ json ] : json,
         });
       }
     }, { times });

--- a/src/slices/contract/pages/details/methods/ContractMethodsRegular.pw.tsx
+++ b/src/slices/contract/pages/details/methods/ContractMethodsRegular.pw.tsx
@@ -46,7 +46,7 @@ test('can simulate method', async({ render, mockContractReadResponse }) => {
     address: addressHash,
     args: [ ADDRESS, AMOUNT ],
     rpcMethod: 'eth_estimateGas',
-    result: 42000,
+    result: '0xA410',
     noResultEncoding: true,
   });
   await mockContractReadResponse({

--- a/src/slices/contract/pages/details/methods/useCallMethodPublicClient.ts
+++ b/src/slices/contract/pages/details/methods/useCallMethodPublicClient.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import React from 'react';
-import { encodeFunctionData, getAddress } from 'viem';
+import { getAddress } from 'viem';
 import { usePublicClient } from 'wagmi';
 
 import type { FormSubmitResult, MethodCallStrategy, SmartContractMethod } from './types';
@@ -11,7 +11,7 @@ import { useMultichainContext } from 'src/features/multichain/context';
 
 import config from 'src/config';
 
-import { getNativeCoinValue } from './utils';
+import { estimateTransactionGas, getNativeCoinValue } from './utils';
 
 interface Params {
   item: SmartContractMethod;
@@ -38,6 +38,8 @@ export default function useCallMethodPublicClient(): (params: Params) => Promise
     const _args = args.slice(0, inputs.length);
     const value = getNativeCoinValue(args[inputs.length]);
 
+    const estimateGas = () => estimateTransactionGas({ account, to: address, value, abiItem: item, args: _args, chainId });
+
     if (item.type === 'fallback') {
       // if the fallback method acts as a read method, it can only have one input of type bytes
       // so we pass the input value as data without encoding it
@@ -48,31 +50,18 @@ export default function useCallMethodPublicClient(): (params: Params) => Promise
         value,
         data,
       });
-      const estimatedGas = await publicClient.estimateGas({
-        account,
-        to: address,
-        value,
-        data,
-      });
-
       return {
         source: 'public_client' as const,
         data: result.data,
-        estimatedGas,
+        estimatedGas: await estimateGas(),
       };
     }
 
     if (item.type === 'receive') {
-      const estimatedGas = await publicClient.estimateGas({
-        account,
-        to: address,
-        value,
-      });
-
       return {
         source: 'public_client' as const,
         data: undefined,
-        estimatedGas,
+        estimatedGas: await estimateGas(),
       };
     }
 
@@ -84,25 +73,14 @@ export default function useCallMethodPublicClient(): (params: Params) => Promise
       account,
       value,
     };
-    const paramsForGasEstimate = {
-      account,
-      value,
-      to: address,
-      data: encodeFunctionData({
-        abi: [ item ],
-        functionName: item.name,
-        args: _args,
-      }),
-    };
 
     const result = strategy === 'read' ? await publicClient.readContract(params) : await publicClient.simulateContract(params);
-    const estimatedGas = strategy === 'simulate' ? await publicClient.estimateGas(paramsForGasEstimate) : undefined;
 
     return {
       source: 'public_client' as const,
       data: strategy === 'read' ? result : result.result,
-      estimatedGas,
+      estimatedGas: strategy === 'simulate' ? await estimateGas() : undefined,
     };
 
-  }, [ account, publicClient ]);
+  }, [ account, publicClient, chainId ]);
 }

--- a/src/slices/contract/pages/details/methods/useCallMethodWalletClient.ts
+++ b/src/slices/contract/pages/details/methods/useCallMethodWalletClient.ts
@@ -12,7 +12,7 @@ import useRewardsActivity from 'src/features/rewards/hooks/useRewardsActivity';
 
 import config from 'src/config';
 
-import { getNativeCoinValue } from './utils';
+import { estimateTransactionGas, getNativeCoinValue, withGasEstimateBuffer } from './utils';
 
 const feature = config.features.connectWallet;
 
@@ -32,7 +32,6 @@ export default function useCallMethodWalletClient(): (params: Params) => Promise
   const { trackTransaction, trackTransactionConfirm } = useRewardsActivity();
   const { writeContractAsync } = useWriteContract();
   const { sendTransactionAsync } = useSendTransaction();
-
   const { type: walletType } = useWallet({ source: 'Smart contracts' });
 
   return React.useCallback(async({ args, item, addressHash }) => {
@@ -52,15 +51,17 @@ export default function useCallMethodWalletClient(): (params: Params) => Promise
     const _args = args.slice(0, inputs.length);
     const value = getNativeCoinValue(args[inputs.length]);
 
+    // seems like Dynamic WaaS (assigned when user signed up with email) does not estimate gas for transactions
+    // so we do it manually here (with a buffer to avoid OOG between estimate and inclusion)
+    const estimatedGas = feature.isEnabled && feature.connectorType === 'dynamic' && walletType === 'dynamicwaas' ?
+      withGasEstimateBuffer(
+        await estimateTransactionGas({ account, to: address, value, abiItem: item, args: _args, chainId: targetChainId }),
+      ) : undefined;
+
     if (item.type === 'receive' || item.type === 'fallback') {
       // if the fallback method acts as a read method, it can only have one input of type bytes
       // so we pass the input value as data without encoding it
       const data = typeof _args[0] === 'string' && _args[0].startsWith('0x') ? _args[0] as `0x${ string }` : undefined;
-
-      // seems like Dynamic WaaS (assigned when user signed up with email) does not estimate gas for transactions
-      // so we pass 0 as gas here
-      const estimatedGas = feature.isEnabled && feature.connectorType === 'dynamic' && walletType === 'dynamicwaas' ?
-        BigInt(0) : undefined;
 
       const hash = await sendTransactionAsync({
         to: address,
@@ -82,11 +83,6 @@ export default function useCallMethodWalletClient(): (params: Params) => Promise
     if (!methodName) {
       throw new Error('Method name is not defined');
     }
-
-    // seems like Dynamic WaaS (assigned when user signed up with email) does not estimate gas for transactions
-    // so we pass 0 as gas here
-    const estimatedGas = feature.isEnabled && feature.connectorType === 'dynamic' && walletType === 'dynamicwaas' ?
-      BigInt(0) : undefined;
 
     const hash = await writeContractAsync({
       args: _args,

--- a/src/slices/contract/pages/details/methods/utils.ts
+++ b/src/slices/contract/pages/details/methods/utils.ts
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import type { Abi } from 'abitype';
-import { toFunctionSelector } from 'viem';
+import { encodeFunctionData, toFunctionSelector } from 'viem';
+import { estimateGas } from 'viem/actions';
 
 import type { MethodType, SmartContractMethod, SmartContractMethodRead, SmartContractMethodWrite } from './types';
 
+import wagmiConfig from 'src/features/connect-wallet/utils/wagmi-config';
+
 import { collator } from 'src/shared/texts/collator';
+
+// 20% headroom so the tx does not OOG between estimate and inclusion
+const GAS_ESTIMATE_BUFFER_NUMERATOR = BigInt(120);
+const GAS_ESTIMATE_BUFFER_DENOMINATOR = BigInt(100);
 
 export const getNativeCoinValue = (value: unknown) => {
   if (typeof value !== 'string') {
@@ -87,3 +94,46 @@ export const TYPE_FILTER_OPTIONS: Array<{ value: MethodType; title: string }> = 
   { value: 'read', title: 'Read' },
   { value: 'write', title: 'Write' },
 ];
+
+interface EstimateTransactionGasParams {
+  account: `0x${ string }` | undefined;
+  to: `0x${ string }`;
+  value: bigint;
+  abiItem: SmartContractMethod;
+  args: Array<unknown>;
+  chainId?: number;
+}
+
+export async function estimateTransactionGas(params: EstimateTransactionGasParams) {
+  const { account, to, value, abiItem, args, chainId } = params;
+
+  const data = (() => {
+    if (abiItem.type === 'fallback') {
+      return typeof args[0] === 'string' && args[0].startsWith('0x') ? args[0] as `0x${ string }` : undefined;
+    }
+
+    if (abiItem.type === 'receive') {
+      return;
+    }
+
+    return encodeFunctionData({
+      abi: [ abiItem ],
+      functionName: abiItem.name,
+      args,
+    });
+  })();
+
+  // Use viem estimateGas on the public client — wagmi/actions estimateGas falls back to
+  // getConnectorClient when account is undefined, which breaks disconnected reads/simulates.
+  const client = wagmiConfig.config.getClient({ chainId });
+  return estimateGas(client, {
+    account,
+    to,
+    value,
+    data,
+  });
+}
+
+export function withGasEstimateBuffer(estimatedGas: bigint) {
+  return estimatedGas * GAS_ESTIMATE_BUFFER_NUMERATOR / GAS_ESTIMATE_BUFFER_DENOMINATOR;
+}


### PR DESCRIPTION
## Description and Related Issue(s)

Dynamic WaaS wallets were sending contract write transactions with `gas: 0`, which broke writes. This PR estimates gas via the public client and passes a buffered limit instead.

### Proposed Changes
- Estimate gas for Dynamic WaaS writes (`dynamicwaas`) instead of hardcoding `0`
- Share encoding + estimation in `estimateTransactionGas` (viem public client, so disconnected read/simulate still work)
- Apply a 20% gas buffer on Dynamic writes to reduce OOG between estimate and inclusion
- Only run gas estimation on public-client paths that need it (simulate / fallback / receive), not plain reads

### Breaking or Incompatible Changes
None.

### Additional Information
N/A

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request

Made with [Cursor](https://cursor.com)