### PR TITLE
Refine the product-task workflow: per-subtask folders, self-contained PR titles, testing & comment rules

### DIFF
--- a/.agents/rules/code-quality.mdc
+++ b/.agents/rules/code-quality.mdc
@@ -137,6 +137,29 @@ const STREAK_IMAGES: Record<number, string> = {
 
 Before writing custom utility logic (clamping, deep cloning, grouping, etc.), check whether `es-toolkit` already provides it. Prefer the library function over a manual implementation. Documentation: https://es-toolkit.dev/llms-full.txt
 
+### Comments
+
+Comment the *why*, not the *what*. The code already shows what it does; a good comment explains what the
+code can't — the rationale, a non-obvious constraint, a gotcha, a link to the issue or spec that motivated
+it.
+
+Never write *diff-narration* comments — what the code replaces, what it used to do, what behavior it
+preserves. That belongs in the commit message and the PR, not in the source, where it goes stale the moment
+the next change lands.
+
+```ts
+// BAD — narrates the change and restates the obvious
+// Replaces the old useEffect approach; now we memoize the filtered list
+const active = useMemo(() => items.filter(isActive), [ items ]);
+
+// GOOD — explains the non-obvious why
+// Memoized because <VirtualList> bails out of re-rendering on referential equality of `items`.
+const active = useMemo(() => items.filter(isActive), [ items ]);
+```
+
+Quick test: if a comment would confuse a reader who never saw the previous version of the file, it is
+diff-narration — delete it. If it still helps that reader understand a decision, keep it.
+
 ### Commented-out code
 
 Remove commented-out code blocks. The git history preserves anything that might be needed later. TODOs are acceptable only when paired with a clear follow-up plan or issue reference.

--- a/.agents/rules/delegation.mdc
+++ b/.agents/rules/delegation.mdc
@@ -45,3 +45,6 @@ Every UI subtask in a spec is split into two linked subtasks by default:
 - Playwright visual test files are scaffolded by the agent in the scaffold subtask.
 - Screenshot baselines are generated and reviewed by the human **after** the style subtask — a baseline is
   only meaningful once the component matches the mockup.
+- Test the behavior that matters, not the obvious — follow the "What to test (and what not)" guidance in
+  `.agents/rules/tests-unit.mdc`. More tests are not better; a test that only asserts the framework or the
+  mock is noise.

--- a/.agents/rules/tests-unit.mdc
+++ b/.agents/rules/tests-unit.mdc
@@ -9,6 +9,28 @@ alwaysApply: false
 
 Unit tests cover logic that is independent of visual presentation: utility functions, custom hooks, and component behavior (state transitions, conditional rendering, event handling). If a change has no visual output to verify, prefer a Vitest test over a Playwright one — it is faster and cheaper.
 
+## What to test (and what not)
+
+More tests are not better. A test earns its place by pinning behavior that could plausibly break; a test
+that restates the implementation or the framework only adds maintenance cost and false confidence.
+
+**Worth testing:**
+- Branching and conditional logic — the non-obvious paths through a function.
+- State transitions, event handling, and the loading / empty / error / success states of a component.
+- Parsing, formatting, calculation, and data-shaping logic — especially edge cases (empty, zero, null,
+  boundary values, malformed input).
+- Regressions — a test that reproduces a fixed bug so it stays fixed.
+
+**Not worth testing:**
+- Framework or library behavior (that a Chakra prop renders, that `react-query` caches) — trust the deps.
+- Trivial pass-throughs: a getter that returns a field, a component that only forwards props with no logic.
+- Types — `tsc` already proves them; don't add a runtime test to check a type.
+- Tests whose assertions only echo the mock you set up, exercising no real code of your own.
+- Snapshotting large trees "for coverage" — a snapshot must capture something a human decision depends on.
+
+When in doubt, ask: *if I delete this test, what real defect could now ship unnoticed?* If the honest
+answer is "none", don't write it.
+
 ## File naming and location
 
 Test files must be named `*.spec.ts` or `*.spec.tsx` and placed alongside the code they test. Run all tests:

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -28,6 +28,18 @@ Check the current branch (`git branch --show-current`) and its open PR (`gh pr l
 
 If the signals conflict or are ambiguous, ask the user which mode they mean.
 
+## PR title (all modes)
+
+The title must stand on its own — a reader who has never heard of the parent task should understand what
+the PR does from the title alone:
+
+- Describe the change in plain language, scoped **accurately** — derive it from the spec's (or subtask
+  spec's) **Context & goal**, not from a breakdown shorthand (e.g. a primer that covers several pages is
+  not a "main page" change).
+- **No** issue numbers, "step N", or internal codenames/jargon (`lever 3`) in the title — those are
+  abstract to an outside reader. The parent-task relationship lives in the **description** (`Resolves #N` +
+  the spec link).
+
 ## Mode A — Draft placeholder (spec time)
 
 At this stage nothing is implemented, so **do not** describe changes, env vars, or checklists — the
@@ -42,7 +54,8 @@ description is a placeholder pointing at the plan:
    - A note that this is a **spec-first draft**: the branch will receive the task's work subtask by
      subtask, and the final description will be written when the PR is marked ready for review.
 3. **Confirm with the user**, then create as draft: `gh pr create --draft --title "..." --body-file ...`.
-   Title = the task title (not "spec for..."; the PR will become the task's PR).
+   Title per "PR title" above (not "spec for..."; the PR becomes the task's/subtask's PR) — a feature
+   branch's PR describes the whole task, a step sub-branch's PR describes just that subtask.
 4. **Labels** — copy the issue's labels (`gh issue view <N> --json labels`). Skip ENVs/dependencies
    labels — nothing is implemented yet; Mode B adds them from the real diff.
 5. Link the created PR in the output.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -50,7 +50,8 @@ description is a placeholder pointing at the plan:
    - `Resolves #<ISSUE_NUMBER>` when the branch matches `issue-\d+` (ad-hoc spec branches have no issue —
      omit).
    - One short paragraph: the task's goal, taken from the spec's **Context & goal**.
-   - A link to the spec file on this branch (`.agents/tasks/<dir>/spec.md`).
+   - A link to the spec file on this branch — the main `.agents/tasks/<dir>/spec.md`, or the subtask's
+     `.agents/tasks/<dir>/subtasks/<NN>-<slug>/spec.md` when this is a step sub-branch (`issue-N-step-M`).
    - A note that this is a **spec-first draft**: the branch will receive the task's work subtask by
      subtask, and the final description will be written when the PR is marked ready for review.
 3. **Confirm with the user**, then create as draft: `gh pr create --draft --title "..." --body-file ...`.

--- a/.agents/skills/grill-the-task/SKILL.md
+++ b/.agents/skills/grill-the-task/SKILL.md
@@ -16,9 +16,11 @@ skill.
 **Two modes.**
 
 - **Task mode** (default): input is a GitHub issue URL; output is the task's main spec.
-- **Subtask mode**: input is an existing spec plus a step number (a big step of a `large` task); the session
-  scopes research and questions to that step and outputs its sub-spec (`subtasks/<NN>-<slug>.md`). Run it
-  just-in-time, right before the step starts, against the by-then-current code.
+- **Subtask mode**: input is an existing spec plus a subtask number (one that has only a `brief.md`, no
+  `spec.md` yet); the session scopes research and questions to that subtask, reads its folder's `brief.md`
+  (plus any `research.md` / prototype notes gathered since) as the starting point, and writes its sub-spec
+  (`subtasks/<NN>-<slug>/spec.md`). Run it just-in-time, right before the subtask starts, against the
+  by-then-current code.
 
 ## Step 1 — Research
 
@@ -58,10 +60,18 @@ real sample response, and both cross-checks have run with each mismatch recorded
 
 Propose a size to the developer and confirm it:
 
-- **small** — one step; implementable by an agent or a user right after this session.
-- **medium** — a flat list of small subtasks in one spec.
-- **large** — many steps; the main spec lists them, small steps fully specified now, big steps as one-liners
-  each getting its own subtask-mode grilling session later.
+- **small** — one step; a single `spec.md`, no `subtasks/` folder. Implementable by an agent or a user
+  right after this session.
+- **medium** — a breakdown of subtasks, each in its own folder `subtasks/<NN>-<slug>/`. The main spec is a
+  slim index; every subtask is scoped now (its `spec.md` written up front).
+- **large** — same folder-per-subtask layout, but some subtasks are too big to specify up front. For
+  those, this session writes only a `brief.md` (the context it gathered + what still needs research,
+  prototyping, or decisions) into the folder — no `spec.md` — and each gets its own just-in-time
+  subtask-mode session later that writes the sub-spec.
+
+For medium and large tasks, decide each subtask's readiness with the developer as the breakdown takes
+shape — scoped now (write its `spec.md`) or deferred (write a `brief.md`, no `spec.md`). The presence of a
+`spec.md` is the signal that a subtask is scoped; the main spec's index carries only the done checkbox.
 
 ## Step 3 — The interview
 
@@ -99,10 +109,10 @@ Testing is **not** an interview domain — the standing policy in `.agents/rules
 **Front-load the executor skills' inputs.** Once the task breakdown has taken shape, go through every
 `[agent]` subtask that will run a project skill (`add-new-page`, `add-api-resource`, `add-env-var`, …):
 **open that skill and run its user-facing interview now** (e.g. `add-new-page` Step 0), from the skill's
-current text — don't work from memory of its questions. The answers are recorded with the subtask in the
-spec, so `implement-task` can later execute without stopping to ask. Do this in whichever session fully
-specifies the subtask: here for small/medium tasks and small steps, in the just-in-time subtask session for
-big steps.
+current text — don't work from memory of its questions. The answers are recorded with the subtask in its
+own `spec.md`, so `implement-task` can later execute without stopping to ask. Do this in whichever session
+scopes the subtask: here for a subtask specced now, in the just-in-time subtask session for a deferred one
+(the one that starts from a `brief.md`).
 
 The interview is complete when every domain is covered or explicitly skipped as research-answered, the
 contacts and channel are settled, every unanswered question has an owner, and every fully-specified

--- a/.agents/skills/grill-the-task/SKILL.md
+++ b/.agents/skills/grill-the-task/SKILL.md
@@ -2,7 +2,7 @@
 name: grill-the-task
 description: >-
   Grill a product task (GitHub issue) into an implementable spec — research first, then a
-  one-question-at-a-time interview; also elaborates sub-specs for big steps of large tasks.
+  one-question-at-a-time interview; also elaborates sub-specs for deferred subtasks of large tasks.
 disable-model-invocation: true
 ---
 
@@ -69,9 +69,10 @@ Propose a size to the developer and confirm it:
   prototyping, or decisions) into the folder — no `spec.md` — and each gets its own just-in-time
   subtask-mode session later that writes the sub-spec.
 
-For medium and large tasks, decide each subtask's readiness with the developer as the breakdown takes
-shape — scoped now (write its `spec.md`) or deferred (write a `brief.md`, no `spec.md`). The presence of a
-`spec.md` is the signal that a subtask is scoped; the main spec's index carries only the done checkbox.
+As the breakdown takes shape, decide each subtask's readiness with the developer — scoped now (write its
+`spec.md`) or deferred (write a `brief.md`, no `spec.md`). **A task with any deferred subtask is `large`; if
+every subtask is scoped now, it's `medium`.** The presence of a `spec.md` is the signal that a subtask is
+scoped; the main spec's index carries only the done checkbox.
 
 ## Step 3 — The interview
 

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -19,9 +19,9 @@ task from the branch alone.
   branch name, per the Branch model below. Execute the next eligible subtask (Step 3).
 - `/implement-task 4` — a **specific** subtask, out of order. Pending questions still refuse the run;
   unchecked dependencies are pointed out and need the developer's explicit confirmation to proceed.
-- `/implement-task 2.3` — large tasks address **leaf steps** with dotted numbers: step 3 inside big step 2's
-  sub-spec (`subtasks/02-<slug>.md`). The sub-spec's own breakdown is the checklist for that big step; its
-  header status is maintained like a spec's.
+- `/implement-task 2.3` — large tasks address **leaf steps** with dotted numbers: step 3 inside subtask 2's
+  sub-spec (`subtasks/02-<slug>/spec.md`). The sub-spec's own breakdown is the checklist for that subtask;
+  its header status is maintained like a spec's.
 - An explicit task dir as the first argument (e.g. `/implement-task 3219-cross-chain-views 4`) overrides
   branch inference — needed when not on the feature branch yet.
 
@@ -55,10 +55,10 @@ issue number, any other branch matches by exact dir name.
 ### Step 1 — Load state
 
 Resolve the spec per the Invocation section (branch inference by default, explicit task dir wins); if
-neither yields a match in `.agents/tasks/`, ask. Read the spec — and the sub-spec, when a `-step-<N>`
-branch or a dotted target selects one — plus `.agents/rules/delegation.mdc`. If the header has no feature
-branch yet, construct it from the convention above (`issue-<number>`), confirm with the developer, create
-it, and record it in the header.
+neither yields a match in `.agents/tasks/`, ask. Read the main spec — and the target subtask's
+`subtasks/<NN>-<slug>/spec.md`, when a `-step-<N>` branch or a dotted target selects one — plus
+`.agents/rules/delegation.mdc`. If the header has no feature branch yet, construct it from the convention
+above (`issue-<number>`), confirm with the developer, create it, and record it in the header.
 
 ### Step 2 — Reconcile the previous handoff
 
@@ -77,8 +77,8 @@ questions are all `resolved` or `waived`, descending into sub-specs to a leaf st
   and suggest running `to-spec` to harvest Slack answers. Stop.
 - **Next subtask is `[human]`** → hand off: state what needs doing, link the Figma node, note that the
   scaffold's `TODO (design):` markers are the worklist. Stop.
-- **Next subtask is a big step without its sub-spec yet** → tell the developer to run `grill-the-task` in
-  subtask mode for it. Stop.
+- **Next subtask has only a `brief.md`, no `spec.md` yet** → it isn't scoped; tell the developer to run
+  `grill-the-task` in subtask mode for it (it writes the folder's `spec.md` from its `brief.md`). Stop.
 - **Next subtask is `[agent]`** → proceed.
 
 ### Step 4 — Execute (one subtask only)
@@ -90,17 +90,20 @@ presentation and `TODO (design):` markers, never final styling. Follow the sub-s
 The spec should already contain the executing skill's inputs — the grilling session runs each skill's
 interview up front, so **skip any of the skill's questions the spec answers** and run uninterrupted. If an
 input is genuinely missing, ask the developer and **backfill the answer into the spec** before proceeding.
-Write the unit tests and Playwright scaffolds the standing testing policy assigns to this subtask.
+Write the unit tests and Playwright scaffolds the standing testing policy assigns to this subtask (test the
+behavior that matters, not the obvious — per `.agents/rules/tests-unit.mdc`).
 
 ### Step 5 — Verify
 
-Run the repo's checks for what was touched: `pnpm run lint:tsc`, ESLint on changed files, and the relevant
-unit tests (commands per `.agents/rules/code-quality.mdc`). Intentional scaffold `TODO`s may keep ESLint red
-in the same way the `add-new-page` skill documents — say so explicitly rather than chasing green.
+Run the repo's checks for what was touched (commands per `.agents/rules/code-quality.mdc`) and the relevant
+unit tests . Intentional scaffold `TODO`s may keep ESLint red in the same way the `add-new-page` skill 
+documents — say so explicitly rather than chasing green.
 
 ### Step 6 — Update the spec and stop
 
-Check the subtask off with a one-line note of what was done (files/skills involved). Set the header status to
+Check the subtask off with a **one-line** note of what was done (files/skills involved) — never a
+multi-line changelog; git and the PR carry the detail, and any durable decision (a new dependency, an
+architectural choice) is folded into the relevant spec section instead. Set the header status to
 `in progress` on the first executed subtask, and to `done` when the last box is checked. Then summarize the
 result and end the run — verification of the diff, the commit, and the next `implement-task` invocation
 belong to the developer.

--- a/.agents/skills/implement-task/SKILL.md
+++ b/.agents/skills/implement-task/SKILL.md
@@ -15,18 +15,19 @@ task from the branch alone.
 
 ## Invocation
 
-- `/implement-task` — no arguments, the usual case: infer the spec (and the current big step) from the
-  branch name, per the Branch model below. Execute the next eligible subtask (Step 3).
+- `/implement-task` — no arguments, the usual case: infer the spec (and the current subtask, from a
+  `-step-<N>` branch) from the branch name, per the Branch model below. Execute the next eligible subtask
+  (Step 3).
 - `/implement-task 4` — a **specific** subtask, out of order. Pending questions still refuse the run;
   unchecked dependencies are pointed out and need the developer's explicit confirmation to proceed.
-- `/implement-task 2.3` — large tasks address **leaf steps** with dotted numbers: step 3 inside subtask 2's
-  sub-spec (`subtasks/02-<slug>/spec.md`). The sub-spec's own breakdown is the checklist for that subtask;
-  its header status is maintained like a spec's.
+- `/implement-task 2.3` — when a subtask's own spec has a multi-step breakdown, address its **leaf steps**
+  with dotted numbers: step 3 inside subtask 2's sub-spec (`subtasks/02-<slug>/spec.md`). The sub-spec's own
+  breakdown is the checklist for that subtask; its header status is maintained like a spec's.
 - An explicit task dir as the first argument (e.g. `/implement-task 3219-cross-chain-views 4`) overrides
   branch inference — needed when not on the feature branch yet.
 
-The unit of one run is always a **leaf**: in a large task, "next eligible subtask" descends — if the next
-subtask is a big step with a sub-spec, execute the next eligible step *inside* it (one step, then stop).
+The unit of one run is always a **leaf**: "next eligible subtask" descends — if the next subtask has its
+own multi-step sub-spec, execute the next eligible leaf step *inside* it (one step, then stop).
 
 ## Branch model
 
@@ -37,17 +38,17 @@ starts, but **never commit, push, or open PRs yourself** — the developer revie
 runs.
 
 **PR timing (developer's action — prompt, don't do):** a draft PR opens as soon as the spec is the branch's
-first commit (feature branch → `main`; a big step's sub-branch → feature branch, with its sub-spec as the
-first commit) and flips to ready for review when its breakdown's last box is checked. Nudge accordingly: on
-a first run with no PR yet, suggest opening the draft; when checking off the final subtask (or a big step's
-final step), suggest finalizing it via the `create-pr` skill (finalize-draft mode: real description from the
-diff, labels, then ready for review).
+first commit (feature branch → `main`; a big subtask's sub-branch → feature branch, with its sub-spec as
+the first commit) and flips to ready for review when its breakdown's last box is checked. Nudge accordingly:
+on a first run with no PR yet, suggest opening the draft; when checking off the final subtask (or a big
+subtask's final leaf step), suggest finalizing it via the `create-pr` skill (finalize-draft mode: real
+description from the diff, labels, then ready for review).
 
 **Branch names carry the addressing.** The feature branch is `issue-<number>` (e.g. `issue-3219`); a big
-step's sub-branch adds a `-step-<N>` postfix (e.g. `issue-3219-step-2`). An **ad-hoc** spec's branch is its
+subtask's sub-branch adds a `-step-<N>` postfix (e.g. `issue-3219-step-2`). An **ad-hoc** spec's branch is its
 task-dir slug (`.agents/tasks/<slug>/` → branch `<slug>`). Dash postfixes, **not** slashes — git forbids
 `X` and `X/…` coexisting. The names are fully mechanical, which is what lets the skill construct branches
-itself and infer the spec (and the current big step) with no arguments: `issue-<n>` matches the task dir by
+itself and infer the spec (and the current subtask) with no arguments: `issue-<n>` matches the task dir by
 issue number, any other branch matches by exact dir name.
 
 ## Workflow
@@ -95,15 +96,24 @@ behavior that matters, not the obvious — per `.agents/rules/tests-unit.mdc`).
 
 ### Step 5 — Verify
 
-Run the repo's checks for what was touched (commands per `.agents/rules/code-quality.mdc`) and the relevant
-unit tests . Intentional scaffold `TODO`s may keep ESLint red in the same way the `add-new-page` skill 
-documents — say so explicitly rather than chasing green.
+Run every code-quality check the repo defines (per `.agents/rules/code-quality.mdc` — run all of them, not
+only the ones you remember) plus the relevant unit tests. Intentional scaffold `TODO`s may keep ESLint red
+in the same way the `add-new-page` skill documents — say so explicitly rather than chasing green.
 
 ### Step 6 — Update the spec and stop
 
-Check the subtask off with a **one-line** note of what was done (files/skills involved) — never a
-multi-line changelog; git and the PR carry the detail, and any durable decision (a new dependency, an
-architectural choice) is folded into the relevant spec section instead. Set the header status to
-`in progress` on the first executed subtask, and to `done` when the last box is checked. Then summarize the
-result and end the run — verification of the diff, the commit, and the next `implement-task` invocation
-belong to the developer.
+Check the box for what you did, with a **one-line** note (files/skills involved) — never a multi-line
+changelog; git and the PR carry the detail, and any durable decision (a new dependency, an architectural
+choice) is folded into the relevant spec section instead.
+
+Keep both checklist levels in sync when the subtask has its own sub-spec:
+
+- Check the **leaf step** in the sub-spec's breakdown; set the sub-spec's header `Status` to `in progress`
+  on its first step and `done` when its last box is checked.
+- When a sub-spec goes `done`, check its **subtask line in the main index** too.
+- Set the **main** header `Status` to `in progress` on the first executed subtask and `done` when the
+  index's last box is checked.
+
+The main index is what "done" and draft-PR finalization key off, so never leave it trailing a completed
+sub-spec. Then summarize the result and end the run — verification of the diff, the commit, and the next
+`implement-task` invocation belong to the developer.

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -22,18 +22,30 @@ sync Slack replies: there is nothing to convert, so the run is just harvest (Ste
 
 - With a GitHub issue: `.agents/tasks/<issue-number>-<slug>/spec.md` (e.g. `.agents/tasks/3219-cross-chain-txs/spec.md`).
 - Ad-hoc (no issue): `.agents/tasks/<slug>/spec.md`.
-- Large tasks: big steps get sub-specs at `subtasks/<NN>-<slug>.md` next to `spec.md`, written **just-in-time**
-  by a `grill-the-task` subtask session — when invoked from one, write the sub-spec, not the main spec.
+- Every subtask of a medium/large task gets its own folder `subtasks/<NN>-<slug>/`, holding:
+  - `brief.md` — the handoff from the initial grilling session for a subtask that isn't scoped yet:
+    context gathered so far + what still needs research, prototyping, or decisions. Its presence (with no
+    `spec.md`) marks the subtask as not-yet-scoped.
+  - `spec.md` — the subtask spec (same template), Status `draft | ready | in progress | done`. Written up
+    front for a scoped subtask, or by the just-in-time subtask session for a deferred one — filled from the
+    folder's `brief.md`.
+  - `research.md` — optional; real research findings or prototype notes produced before the subtask
+    session, feeding it alongside the brief.
+  - `review.md` — optional; where a local review agent drops findings and the implementer records
+    fix/reject responses (see `implement-task`).
 
-Use `spec-template.md` (next to this file) for every new spec and sub-spec. Structure by size:
+Use `spec-template.md` (next to this file) for every spec — main and subtask alike. Structure by size:
 
-- **small** — one-step task breakdown; the whole task is implementable right after the session.
-- **medium** — a flat list of small subtasks in one spec.
-- **large** — main spec with the ordered step list; small steps fully specified inline, big steps as
-  one-liners pointing at their (future) sub-spec.
+- **small** — one `spec.md`, no `subtasks/`; the whole task is a single leaf worklist.
+- **medium** — the main spec is a slim index; each subtask is a folder with a fully-specified `spec.md`.
+- **large** — same layout; big subtasks are deferred (a `brief.md` now, no `spec.md`; the sub-spec is
+  written just-in-time later).
 
-Tag every subtask `[agent]` or `[human]` per `.agents/rules/delegation.mdc` (UI work defaults to the
-scaffold → style split). Specs merge with the task's PR and accumulate in `.agents/tasks/` as precedent.
+**The main spec is an index, not a container.** Its Task breakdown is one line per subtask (checkbox +
+title + folder link) — never inline inputs, requirements, or changelogs; that detail belongs in the
+subtask's own `spec.md`. Tag every subtask `[agent]` or `[human]` per `.agents/rules/delegation.mdc` (UI
+work defaults to the scaffold → style split). Specs merge with the task's PR and accumulate in
+`.agents/tasks/` as precedent.
 
 ## Workflow
 
@@ -63,9 +75,18 @@ Extract from the conversation: decisions, requirements, data/API facts, UI inven
 task breakdown, and unanswered questions with their owners — the per-team contacts picked during the
 session (defaults from `.agents/TEAM.md`), recorded in the header.
 
+**Write to the right file.** Task-level facts (context, shared data/API, overall UI inventory, out-of-scope,
+the index breakdown) go in the main `spec.md`; a subtask's own requirements, data, UI, executor-skill
+`inputs:`, and leaf worklist go in `subtasks/<NN>-<slug>/spec.md`. A subtask that isn't scoped yet gets a
+`brief.md` instead of a `spec.md`.
+
 **Merge surgically.** On update runs, never regenerate the file: preserve checked boxes, statuses, hand
 edits, and resolved-question records; only add or amend what the conversation actually changed. Show the
 user a summary of the changes and confirm before moving on.
+
+**No changelogs.** Record a subtask's completion as a one-line note on its checkbox, nothing more — the
+commit and the PR are the record of what changed. Durable decisions taken during work (a new dependency, an
+architectural choice) are folded into the relevant spec section, not appended as a "done: …" block.
 
 Status field: a new spec starts as `draft`; set it to `ready` once no `pending` question blocks the first
 subtask (per-subtask blocking — unblocked subtasks may proceed while unrelated questions are pending).

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -23,16 +23,16 @@ sync Slack replies: there is nothing to convert, so the run is just harvest (Ste
 - With a GitHub issue: `.agents/tasks/<issue-number>-<slug>/spec.md` (e.g. `.agents/tasks/3219-cross-chain-txs/spec.md`).
 - Ad-hoc (no issue): `.agents/tasks/<slug>/spec.md`.
 - Every subtask of a medium/large task gets its own folder `subtasks/<NN>-<slug>/`, holding:
-  - `brief.md` — the handoff from the initial grilling session for a subtask that isn't scoped yet:
-    context gathered so far + what still needs research, prototyping, or decisions. Its presence (with no
-    `spec.md`) marks the subtask as not-yet-scoped.
+  - `brief.md` — the handoff from the initial grilling session for a subtask that isn't scoped yet. Its
+    presence (with no `spec.md`) marks the subtask as not-yet-scoped. It carries: the subtask's goal in a
+    sentence or two; the context already gathered (relevant code, endpoints, mockups); the specific unknowns
+    to resolve (what to research, prototype, or decide) and who owns each; and links (issue, Figma, related
+    specs) — enough for a `grill-the-task` subtask session to start without re-deriving it.
   - `spec.md` — the subtask spec (same template), Status `draft | ready | in progress | done`. Written up
     front for a scoped subtask, or by the just-in-time subtask session for a deferred one — filled from the
     folder's `brief.md`.
   - `research.md` — optional; real research findings or prototype notes produced before the subtask
     session, feeding it alongside the brief.
-  - `review.md` — optional; where a local review agent drops findings and the implementer records
-    fix/reject responses (see `implement-task`).
 
 Use `spec-template.md` (next to this file) for every spec — main and subtask alike. Structure by size:
 
@@ -56,7 +56,8 @@ read the spec first and treat it as hand-editable — developers edit specs dire
 
 ### Step 2 — Harvest Slack answers (update runs only)
 
-For every open question with status `pending` and a recorded Slack permalink:
+Open questions live in the main `spec.md` **and** in any subtask `spec.md` under `subtasks/*/` — gather
+them from all of these files. For every open question with status `pending` and a recorded Slack permalink:
 
 1. Read the thread with the Slack MCP tools (`slack_read_thread`; parse `channel_id`/`message_ts` from the
    permalink as in the `create-issue-from-slack-thread` skill).
@@ -66,8 +67,8 @@ For every open question with status `pending` and a recorded Slack permalink:
 4. If a reply raises a follow-up: draft it (in Russian, like all outreach), get the user's approval, send it
    **into the same thread**, and keep the question `pending`.
 
-The harvest is complete when every `pending` question with a permalink has had its thread read and is now
-resolved, followed up, or confirmed still unanswered.
+The harvest is complete when every `pending` question with a permalink — across the main spec and every
+subtask spec — has had its thread read and is now resolved, followed up, or confirmed still unanswered.
 
 ### Step 3 — Write or merge the spec
 

--- a/.agents/skills/to-spec/spec-template.md
+++ b/.agents/skills/to-spec/spec-template.md
@@ -13,6 +13,14 @@
 
 <!-- People default from `.agents/TEAM.md`; override here per task. -->
 
+<!-- SUBTASK SPECS reuse this same template, at `subtasks/<NN>-<slug>/spec.md`, with two header changes:
+swap the Issue row for `Parent spec | [../../spec.md](../../spec.md) — step <N> of #<issue>`, and add a
+`Sub-branch | issue-<N>-step-<N>` row. The Status vocabulary is the same as a main spec's
+(`draft | ready | in progress | done`). A subtask that hasn't been scoped yet has NO `spec.md` at all —
+only a `brief.md` in its folder (the handoff from the initial grilling session); the just-in-time subtask
+session reads that brief and writes this `spec.md`. People rows inherit from the parent unless a subtask
+overrides one. -->
+
 ## Context & goal
 
 <!-- The "why" and the user-facing outcome. A couple of paragraphs, no more. -->
@@ -39,16 +47,27 @@ belongs to the mockups and the [human] style subtasks. -->
 
 ## Task breakdown
 
-<!-- Ordered. Tag each subtask `[agent]` or `[human]` per `.agents/rules/delegation.mdc`. Reference the
-executing skill where one applies. A subtask blocked by open questions lists their ids — it may not start
-while any of them is `pending`. In a large task, a big step gets a one-line entry here plus its own
-sub-spec (written just-in-time via a `grill-the-task` subtask session); a UI component is two linked
-subtasks (scaffold → style). Record the executing skill's interview answers (collected during grilling)
-as an indented `inputs:` list under the subtask, so `implement-task` never has to stop and ask. -->
+<!-- Ordered checklist. The checkbox is the ONLY per-subtask state the spec tracks — done or not.
+Readiness is NOT recorded here; it lives in each subtask spec's Status and is inferred from there.
+
+MAIN spec of a medium/large task = a slim INDEX. One line per subtask, no inputs, no changelog — the
+detail lives in the subtask's own `subtasks/<NN>-<slug>/spec.md`:
+
+  - [ ] 1 `[agent]` <plain-language subtask title> → `subtasks/01-<slug>/`
+  - [ ] 2 `[human]` <plain-language subtask title> → `subtasks/02-<slug>/`
+
+LEAF worklist (a small task's single spec.md, or the breakdown inside a subtask spec) = the actual
+steps. Tag each `[agent]`/`[human]` per `.agents/rules/delegation.mdc`; reference the executing skill;
+list blocking question ids (the step may not start while any is `pending`); and record the executor
+skill's interview answers as an indented `inputs:` list, so `implement-task` never stops to ask. A UI
+component is two linked leaves (scaffold → style). Keep each completion note to ONE line — no changelog
+blocks; fold durable decisions into the sections above and let git and the PR be the record of what
+changed. -->
 
 - [ ] 1 `[agent]` <title> — skill: `add-api-resource` — questions: Q2
-- [ ] 2 `[agent]` <big step title> — sub-spec: `subtasks/02-<slug>.md`
-- [ ] 3 `[human]` Style <component> to mockup — [Figma](<node URL>)
+  - inputs:
+    - <executor-skill answer>
+- [ ] 2 `[human]` Style <component> to mockup — [Figma](<node URL>)
 
 ## Open questions
 

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -32,14 +32,12 @@ says which steps an agent does and which a developer does by hand.
 4. **Implement** — run the `implement-task` skill repeatedly, one subtask per run: it executes `[agent]`
    subtasks (composing `add-api-resource`, `add-new-page`, `add-env-var`, …) and verifies them, or hands
    `[human]` subtasks (styling to Figma mockups) over to you. You review the diff and commit between runs.
-   A subtask can't start while a question blocking it is `pending` — unrelated subtasks can. If you've
-   dropped a `review.md` in a subtask's folder (from a local review pass), the next `implement-task` run for
-   that subtask works through each finding and records a fix/reject response in it.
+   A subtask can't start while a question blocking it is `pending` — unrelated subtasks can.
 5. **Land** — flip the draft PR to **ready for review** when the spec's last box is checked; the feature
    branch merges to `main` as one PR, spec included. Big subtasks may have had their own sub-branch + PR
    into the feature branch along the way (same pattern: draft when the step starts with its sub-spec as the
    first commit, ready when the step's boxes are checked); simple ones are single commits on it. Branch
-   names carry the addressing — feature branch is `issue-<number>` (`issue-3219`), a big step's sub-branch
+   names carry the addressing — feature branch is `issue-<number>` (`issue-3219`), a big subtask's sub-branch
    adds `-step-<N>` (`issue-3219-step-2`) — so `implement-task` needs no arguments on a task branch.
 
 ## Task sizes
@@ -64,4 +62,4 @@ spec's breakdown carries only the done checkbox and a link to each subtask folde
 - `.agents/skills/to-spec/spec-template.md` — the spec template (used for both main and subtask specs).
 - Each `subtasks/NN-<slug>/` folder holds the subtask's `spec.md` (once scoped) or a `brief.md` (the
   handoff for a not-yet-scoped subtask), plus optional `research.md` (real research / prototype notes) and
-  `review.md` (local review-agent findings + the implementer's fix/reject responses).
+  `review.md` (a drop point for local review findings; the workflow that acts on them is a planned follow-up).

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -1,8 +1,9 @@
 # Product task specs
 
-This directory holds one folder per product task, each with a `spec.md` (and, for large tasks, per-step
-sub-specs in `subtasks/`). Specs merge with their task's PR and **accumulate here as a permanent record** —
-consult past specs as precedent for how similar tasks were scoped and split.
+This directory holds one folder per product task, each with a `spec.md`. A medium/large task also has a
+`subtasks/` folder with one sub-folder per subtask (`subtasks/NN-<slug>/`). Specs merge with their task's
+PR and **accumulate here as a permanent record** — consult past specs as precedent for how similar tasks
+were scoped and split.
 
 ## Why
 
@@ -16,8 +17,10 @@ says which steps an agent does and which a developer does by hand.
 1. **Grill** — run the `grill-the-task` skill with the issue URL. It researches first (issue, codebase, live
    API samples, Figma mockups — enumerate-only), then interviews you one question at a time. What you can't
    answer becomes an open question with an owner.
-2. **Spec** — the session ends in the `to-spec` skill: it writes `spec.md` here, sizes the task
-   (small / medium / large), tags every subtask `[agent]` or `[human]` per the delegation boundary, then
+2. **Spec** — the session ends in the `to-spec` skill: it writes a slim index `spec.md` here plus one
+   `subtasks/NN-<slug>/` folder per subtask (a `spec.md` if it's scoped now, or a `brief.md` if it's
+   deferred to its own later session), sizes the task (small / medium / large), tags every subtask
+   `[agent]` or `[human]` per the delegation boundary, then
    drafts the open questions as Slack messages grouped by owner — you approve, it sends, and each thread's
    permalink lands in the spec. (`to-spec` also works standalone, from any conversation worth capturing.)
    Commit the spec to the feature branch and **open a draft PR right away** (`to-spec` walks you through
@@ -29,7 +32,9 @@ says which steps an agent does and which a developer does by hand.
 4. **Implement** — run the `implement-task` skill repeatedly, one subtask per run: it executes `[agent]`
    subtasks (composing `add-api-resource`, `add-new-page`, `add-env-var`, …) and verifies them, or hands
    `[human]` subtasks (styling to Figma mockups) over to you. You review the diff and commit between runs.
-   A subtask can't start while a question blocking it is `pending` — unrelated subtasks can.
+   A subtask can't start while a question blocking it is `pending` — unrelated subtasks can. If you've
+   dropped a `review.md` in a subtask's folder (from a local review pass), the next `implement-task` run for
+   that subtask works through each finding and records a fix/reject response in it.
 5. **Land** — flip the draft PR to **ready for review** when the spec's last box is checked; the feature
    branch merges to `main` as one PR, spec included. Big subtasks may have had their own sub-branch + PR
    into the feature branch along the way (same pattern: draft when the step starts with its sub-spec as the
@@ -39,10 +44,16 @@ says which steps an agent does and which a developer does by hand.
 
 ## Task sizes
 
-- **small** — one step; an agent or an user can implement it right after the grilling session.
-- **medium** — one spec with a flat list of small subtasks.
-- **large** — main spec + sub-specs. Big steps get their sub-spec written **just-in-time** via a
-  `grill-the-task` subtask session right before they start; small steps are specified in the main session.
+- **small** — one step; a single `spec.md`, no `subtasks/` folder. An agent or a user can implement it
+  right after the grilling session.
+- **medium** — the main `spec.md` is a slim index; each subtask lives in its own
+  `subtasks/NN-<slug>/spec.md`, fully specified up front (`ready`).
+- **large** — same layout, but big subtasks are deferred: the grilling session drops a `brief.md` in the
+  folder now (no `spec.md`), and each gets its sub-spec written **just-in-time** via a `grill-the-task`
+  subtask session right before it starts.
+
+A subtask is "scoped" once its folder has a `spec.md`; until then it holds only a `brief.md`. The main
+spec's breakdown carries only the done checkbox and a link to each subtask folder.
 
 ## Supporting files
 
@@ -50,4 +61,7 @@ says which steps an agent does and which a developer does by hand.
   work and the standing testing policy). Loosen it via PR as the repo gets more agent-friendly.
 - `.agents/TEAM.md` — the team roster (members + Slack IDs); the grilling session picks one contact per
   team for the task and records the picks in the spec header.
-- `.agents/skills/to-spec/spec-template.md` — the spec template.
+- `.agents/skills/to-spec/spec-template.md` — the spec template (used for both main and subtask specs).
+- Each `subtasks/NN-<slug>/` folder holds the subtask's `spec.md` (once scoped) or a `brief.md` (the
+  handoff for a not-yet-scoped subtask), plus optional `research.md` (real research / prototype notes) and
+  `review.md` (local review-agent findings + the implementer's fix/reject responses).


### PR DESCRIPTION
## Description and Related Issue(s)

Refines the spec-driven product-task workflow (agent skills + rules under `.agents/`) after its first real
run. No application code — documentation and agent-workflow tooling only. Follow-up to #3561; motivated by
battle-testing on #3566 (PRs #3568 / #3570 / #3574).

### Proposed Changes

- **Folder per subtask.** Each subtask of a medium/large task now lives in `subtasks/NN-<slug>/`: `spec.md`
  once scoped, `brief.md` as the handoff for a not-yet-scoped subtask, plus optional `research.md`
  (research/prototype notes) and `review.md` (local review-agent findings + implementer responses). The main
  `spec.md` becomes a slim index — checkboxes + folder links, no inline subtask detail.
- **Dropped the `needs-research` status.** "Scoped" is signalled by the presence of `spec.md`; a `brief.md`
  alone means the subtask still needs its own just-in-time grilling session.
- **Self-contained PR titles** (`create-pr`): derive the title from the spec's Context & goal,
  scope-accurate, with no issue numbers / "step N" / internal codenames — the parent-task relationship
  stays in the description.
- **No changelog blocks in specs** (`to-spec`, `implement-task`): completion is a one-line note per
  checkbox; git and the PR are the record of what changed.
- **Repo rules**: "What to test (and what not)" added to `tests-unit.mdc`; "Comment the why, not the what"
  added to `code-quality.mdc`.

No ENV variable changes.

### Breaking or Incompatible Changes

None. Documentation and agent-workflow tooling only; no runtime, build, or config changes. (The Checks
workflow already ignores `.agents/**`, so CI does not run on this PR.)

### Additional Information

All changed skills were reviewed with the `writing-great-skills` principles (duplication, no-ops, leading
words) before commit.

## Checklist for PR author
- [x] I have tested these changes locally. *(docs/skills only — cspell passes; no code paths affected)*
- [ ] I added tests to cover any new functionality — N/A, no functionality changed.
- [ ] Whenever I fix a bug, I include a regression test — N/A.
- [ ] Privacy-compliant private-mode handling — N/A.
- [ ] Environment variable changes — none.
