### PR TITLE
Fix `api_temp_token` cookie TTL — use `api-v2-temp-token-ttl` instead of `x-ratelimit-reset`

### DIFF
--- a/src/pages/api/proxy.ts
+++ b/src/pages/api/proxy.ts
@@ -49,6 +49,7 @@ const handler = async(nextReq: NextApiRequest, nextRes: NextApiResponse) => {
     'x-ratelimit-remaining',
     'x-ratelimit-reset',
     'api-v2-temp-token',
+    'api-v2-temp-token-ttl',
   ];
 
   HEADERS_TO_PROXY.forEach((header) => {

--- a/src/shared/errors/custom/AppErrorTooManyRequests.tsx
+++ b/src/shared/errors/custom/AppErrorTooManyRequests.tsx
@@ -66,8 +66,11 @@ const AppErrorTooManyRequests = ({ bypassOptions, reset }: Props) => {
         throw new Error('API temp token is not found');
       }
 
+      // token TTL in seconds
+      const ttl = response.headers.get('api-v2-temp-token-ttl');
+
       cookies.set(cookies.NAMES.API_TEMP_TOKEN, apiTempToken, {
-        expires: reset ? Number(reset) / DAY : 1 / 24,
+        expires: ttl ? Number(ttl) * SECOND / DAY : 1 / 24,
       });
 
       window.location.reload();
@@ -79,7 +82,7 @@ const AppErrorTooManyRequests = ({ bypassOptions, reset }: Props) => {
         type: 'error',
       });
     }
-  }, [ recaptcha, reset ]);
+  }, [ recaptcha ]);
 
   React.useEffect(() => {
     if (reset === undefined) {


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #3582

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [x] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
