### PR TITLE
Build CSP policies with a nonce once at startup instead of on every page request

### DIFF
--- a/src/server/csp/index.spec.ts
+++ b/src/server/csp/index.spec.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import type { NextRequest } from 'next/server';
+
+import { describe, expect, it } from 'vitest';
+
+const NONCE = 'aabbccddeeff00112233445566778899';
+
+// the nonce only lands in the policy when an ads provider that needs it is configured;
+// the app config is frozen on first import, so it has to be set before anything pulls it in
+process.env.NEXT_PUBLIC_AD_BANNER_PROVIDER = 'sevio';
+
+const csp = await import('./index');
+const generateCspPolicy = (await import('./generateCspPolicy')).default;
+const primerScriptHashes = await (await import('src/server/primedRequests')).getPrimerScriptCspHashes();
+
+function makeRequest({ pathname = '/', appProfile }: { pathname?: string; appProfile?: string } = {}) {
+  return {
+    headers: new Headers(appProfile ? { 'x-app-profile': appProfile } : undefined),
+    nextUrl: { pathname, searchParams: new URLSearchParams() },
+    cookies: { get: () => undefined },
+  } as unknown as NextRequest;
+}
+
+describe('nonce policies', () => {
+  it('guards against a vacuous suite — the nonce must be part of the policy', async() => {
+    expect(await csp.get(makeRequest(), NONCE)).toContain(`'nonce-${ NONCE }'`);
+  });
+
+  it('matches a policy generated from scratch for the same nonce', async() => {
+    expect(await csp.get(makeRequest(), NONCE)).toBe(generateCspPolicy(false, NONCE, primerScriptHashes));
+  });
+
+  it('matches a policy generated from scratch in private mode', async() => {
+    expect(await csp.get(makeRequest({ appProfile: 'private' }), NONCE))
+      .toBe(generateCspPolicy(true, NONCE, primerScriptHashes));
+  });
+
+  it('does not leak a nonce between requests', async() => {
+    const otherNonce = '99887766554433221100ffeeddccbbaa';
+
+    await csp.get(makeRequest(), NONCE);
+    const policy = await csp.get(makeRequest(), otherNonce);
+
+    expect(policy).toContain(`'nonce-${ otherNonce }'`);
+    expect(policy).not.toContain(NONCE);
+  });
+
+  it('does not leak the placeholder', async() => {
+    expect(await csp.get(makeRequest(), NONCE)).not.toContain(csp.CSP_NONCE_PLACEHOLDER);
+  });
+});
+
+describe('nonceless policies', () => {
+  it('matches a policy generated from scratch', async() => {
+    expect(await csp.get(makeRequest())).toBe(generateCspPolicy(false, undefined, primerScriptHashes));
+    expect(await csp.get(makeRequest({ appProfile: 'private' }))).toBe(generateCspPolicy(true, undefined, primerScriptHashes));
+  });
+});

--- a/src/server/csp/index.ts
+++ b/src/server/csp/index.ts
@@ -9,20 +9,31 @@ import generateNftHtmlEmbedCspPolicy from './generateNftHtmlEmbedCspPolicy';
 
 const NFT_HTML_EMBED_PATH = '/nft-html-embed.html';
 
-let cspPolicies: { 'private': string; 'default': string } | undefined = undefined;
+// stands in for the per-request nonce so that policies with a nonce can be built once too:
+// a request only swaps this token for its own nonce instead of merging all descriptors again.
+// must be alphanumeric to be a valid nonce value, and distinctive enough to never occur elsewhere in a policy
+export const CSP_NONCE_PLACEHOLDER = 'blockscoutCspNoncePlaceholder';
+
+type CspPolicies = { 'private': string; 'default': string };
+
+let cspPolicies: CspPolicies | undefined = undefined;
+let cspPolicyTemplates: CspPolicies | undefined = undefined;
 let nftHtmlEmbedCsp: string | undefined = undefined;
-let primerScriptHashes: Array<string> = [];
 
 async function initializeCspPolicies() {
   if (!cspPolicies) {
     // the early-fetch primer scripts are deterministic per runtime config,
     // so their hashes are computed once and baked into the cached policies
-    primerScriptHashes = await getPrimerScriptCspHashes();
+    const primerScriptHashes = await getPrimerScriptCspHashes();
 
-    // Generate and cache both policies upfront
+    // Generate and cache all policy variants upfront
     cspPolicies = {
       'private': generateCspPolicy(true, undefined, primerScriptHashes),
       'default': generateCspPolicy(false, undefined, primerScriptHashes),
+    };
+    cspPolicyTemplates = {
+      'private': generateCspPolicy(true, CSP_NONCE_PLACEHOLDER, primerScriptHashes),
+      'default': generateCspPolicy(false, CSP_NONCE_PLACEHOLDER, primerScriptHashes),
     };
   }
 }
@@ -48,7 +59,8 @@ export async function get(req?: NextRequest, nonce?: string): Promise<string> {
   }
 
   if (nonce) {
-    return generateCspPolicy(isPrivateMode, nonce, primerScriptHashes);
+    const template = isPrivateMode ? cspPolicyTemplates?.private : cspPolicyTemplates?.default;
+    return template?.replaceAll(CSP_NONCE_PLACEHOLDER, nonce) || '';
   }
 
   return isPrivateMode ? cspPolicies?.private || '' : cspPolicies?.default || '';


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #3571

When an ads provider that requires a CSP nonce is configured (`sevio`), the proxy generates a nonce for every page request, and `csp.get()` had to rebuild the whole policy string from scratch each time — merging all ~20 descriptors and re-serializing them. Nonceless policies were already prebuilt and cached once.

The nonce is the only per-request part of the policy, so it can be templated: both variants (private / default) are now generated once at startup with a fixed alphanumeric placeholder in place of the nonce, and a request only string-replaces the placeholder with its own nonce. Per the benchmark in the issue that's ~20× cheaper per request (~0.5 µs vs ~10 µs mean) and removes the latency tail of the repeated merge.

### Proposed Changes

- `src/server/csp/index.ts`: cache `cspPolicyTemplates` (private/default, built with `CSP_NONCE_PLACEHOLDER`) alongside the existing `cspPolicies`, in the same startup initialization that computes the early-fetch primer script hashes, so the templates include them. The nonce path now returns `template.replaceAll(CSP_NONCE_PLACEHOLDER, nonce)`.
- Added `src/server/csp/index.spec.ts` covering the correctness guarantee: for a given nonce the output is byte-identical to a policy generated from scratch (default and private mode), the nonceless path is unchanged, no nonce leaks between requests, and the placeholder never reaches the header.

Output is identical because `mergeDescriptors` / `makePolicyString` preserve insertion order and don't sort — the placeholder and the real nonce occupy the same position in the policy string.

No env variable changes.

### Breaking or Incompatible Changes

None. The emitted `Content-Security-Policy` header is unchanged for every request.

### Additional Information

The ads-text provider defaults to `sevio`, so the nonce path is the default configuration rather than an edge case.

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
