### PR TITLE
Back the env-var deprecation branch choice with a check of the DevOps config repo

### DIFF
--- a/.agents/skills/deprecate-env-var/SKILL.md
+++ b/.agents/skills/deprecate-env-var/SKILL.md
@@ -38,8 +38,9 @@ release: grep `deploy/tools/envs-validator/index.ts` for a
   phase. Go straight to **Branch B → Phase 2**; do **not** ask the user which
   branch.
 
-- **Not yet deprecated** — **ask the user explicitly** which branch applies
-  (do not infer it):
+- **Not yet deprecated** — run the deployment-values check below; it names the
+  branch. Put that recommendation to the user and **have them confirm it** — do
+  not pick a branch silently:
 
   - **Immediate removal** — the variable is deleted in this release. Operators
     who still pass it get a startup failure. Right when the feature is gone
@@ -58,11 +59,42 @@ release: grep `deploy/tools/envs-validator/index.ts` for a
 Also settle: **is there a replacement variable?** This changes the grace-period
 recipe and the `Comment` you write in the docs.
 
+### Where is the variable actually set? (deployment-values check)
+
+What is safe is decided by where hosted instances get the variable from, not by
+how dead the feature looks — so read the DevOps config repo
+`blockscout/deployment-values` rather than reasoning about it (private repo;
+`gh` must be authenticated for it — see the `check-github-cli` skill):
+
+```bash
+gh api "search/code?q=repo:blockscout/deployment-values+NEXT_PUBLIC_FOO" --jq '.total_count, (.items[].path)'
+```
+
+Open every match — the count alone decides nothing:
+
+```bash
+gh api "repos/blockscout/deployment-values/contents/<path>" --jq '.content' | base64 -d
+```
+
+Read **where** it is set, and **to what**. The sampled values bound how much of
+the variable's behaviour is really in use: `NEXT_PUBLIC_ACCOUNT_API_KEYS_BUTTON`
+was only ever set to `'false'`, which is what made dropping its URL-string mode
+safe.
+
+- **Per-instance files only** (`common/values/blockscout/<instance>/values*.yaml*`)
+  → **Branch A**. DevOps drops the value instance by instance as they roll the
+  release out.
+- **The common template** (`common/values/blockscout/values.yaml.gotmpl`) →
+  **Branch B**. Immediate removal breaks **every** hosted instance's startup
+  until the DevOps cleanup merges.
+- **No matches** → **Branch A**, nothing to coordinate at all.
+
 ---
 
 ## Branch A — Immediate removal
 
-Do all of the following in one PR.
+Do all of the following in one PR. Requires the Step 0 check to have cleared it:
+set only in per-instance files, or nowhere.
 
 ### A1 — Move the docs row
 
@@ -141,6 +173,11 @@ clear "use X instead" message, add a guard to `checkDeprecatedEnvs()` in
    with a fallback to the old at the call site:
    `getEnvValue('NEXT_PUBLIC_FOO') || getEnvValue('NEXT_PUBLIC_OLD')`.
 
+   **Inert variant** — when the feature is already gone there is nothing left to
+   read, and the grace period exists only so the common template can keep setting
+   the variable: stop reading it now, and let the schema, the docs row and the
+   warning carry the rest of Phase 1. Phase 2 is then a pure cleanup.
+
 3. **Validator schema** — keep the old variable accepted in `schema.ts` /
    `schema_multichain.ts`. If it was **Required**, make it optional now (the new
    variable carries the requirement). Keep its test-preset entries valid.
@@ -169,6 +206,11 @@ the warning block you added to `printDeprecationWarning()` and the guard in
   to the shipping tag.
 - **Label the PR `ENVs`** so the change is picked up into the "Changes in ENV
   variables" section of the release notes.
+- **Name every removed variable in the PR description**, and say the removal is
+  breaking. `prepare-release` reads `ENVs`-labelled PR bodies to build both the
+  release notes and the roll-up request to DevOps, so this description is how
+  DevOps learns what to drop from deployment-values, and for which release. It is
+  the only place that list needs to live.
 - **Run the validator suite and check the negative path:**
   ```bash
   pnpm --filter envs-validator test


### PR DESCRIPTION
## Description and Related Issue(s)

Step 0 of the `deprecate-env-var` skill asked the developer to choose between immediate removal and a grace period, with nothing but intuition behind the answer. But the choice is decidable: since `.noUnknown(true)` plus the placeholder-congruity check turn a leftover value into a container startup failure, what matters is whether hosted instances still set the variable — and that is written down in the DevOps config repo `blockscout/deployment-values`.

### Proposed Changes

- Added a **deployment-values check** sub-step to Step 0: search `blockscout/deployment-values` for the variable, open every match, and read where it is set and to what. Three outcomes map to a branch — per-instance files only or no matches → immediate removal; the common `values.yaml.gotmpl` template → grace period, because immediate removal would break every hosted instance's startup until the DevOps cleanup merges. The check now produces the recommendation the user confirms.
- Noted that the sampled **values** matter, not just the match count (`NEXT_PUBLIC_ACCOUNT_API_KEYS_BUTTON` was only ever set to `'false'`, which is what made dropping its URL-string mode safe).
- Branch A now states its prerequisite: the Step 0 check must have cleared the variable.
- Documented the **inert variant** of a grace period under Branch B → Phase 1 (the app stops reading the variable immediately while the schema, docs row and warning keep it accepted) — needed when the feature is already gone and there is nothing left to read, which the existing "keep reading the variable" step could not express.
- Added a finishing-up rule: name every removed variable in the PR description and mark the removal breaking, since `prepare-release` builds both the release notes and the DevOps roll-up request from `ENVs`-labelled PR bodies. That description is how DevOps learns what to drop, so the list needs no other home.

### Breaking or Incompatible Changes

None — documentation for an agent skill only.

### Additional Information

The `gh api search/code` call needs a token with access to `blockscout/deployment-values`, which is private; the skill points at `check-github-cli` for that.

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
