### PR TITLE
Exclude agent worktrees from the linters and test runners

### DIFF
--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -8,6 +8,8 @@
         "**/*.svg",
         "**/*.sfd",
         ".git",
+        // agent worktrees are full checkouts of the repo — checking them duplicates every file
+        ".claude/worktrees",
         "pnpm-lock.yaml",
         "tools/dev-server/.env.localhost",
         "vitest/.env.vitest",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,8 @@ export default tseslint.config(
     'deploy/tools/',
     'public/',
     '.git/',
+    // agent worktrees are full checkouts of the repo; linting them doubles the work and can exhaust the heap
+    '.claude/worktrees/',
     'next.config.js',
   ] },
 

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -15,6 +15,9 @@ const config: PlaywrightTestConfig = defineConfig({
 
   testMatch: /.*\.pw\.tsx/,
 
+  // agent worktrees are full checkouts of the repo; their tests would run a second time
+  testIgnore: '.claude/worktrees/**',
+
   snapshotPathTemplate: '{testDir}/{testFileDir}/__screenshots__/{testFileName}_{projectName}_{arg}{ext}',
 
   /* Maximum time one test can run for. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,8 @@
   "exclude": [
     "node_modules",
     "node_modules_linux",
+    // agent worktrees are full checkouts of the repo, with no dependencies installed of their own
+    ".claude/worktrees",
     "./deploy/tools/envs-validator",
     "./deploy/tools/favicon-generator",
     "./deploy/tools/multichain-config-generator",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     globalSetup: [ './vitest/global-setup.ts' ],
     setupFiles: [ './vitest/setup.ts' ],
     include: [ '**/*.spec.ts', '**/*.spec.tsx' ],
-    exclude: [ '**/node_modules/**', '**/node_modules_linux/**' ],
+    // agent worktrees are full checkouts of the repo; their specs would run a second time
+    exclude: [ '**/node_modules/**', '**/node_modules_linux/**', '.claude/worktrees/**' ],
   },
 });


### PR DESCRIPTION
## Description and Related Issue(s)

Coding-agent tooling can create git worktrees under `.claude/worktrees/`, and each one is a full checkout of
the repository. Every tool that walks the tree from the project root therefore sees each file twice, which
ranges from wasteful to fatal: `pnpm lint:eslint` exhausted the Node heap and died, `tsc` type-checked a copy
that has no dependencies installed, and cspell, Vitest and Playwright silently duplicated their work — a
Vitest run would execute the whole suite a second time.

### Proposed Changes

Exclude `.claude/worktrees/` in each tool's own configuration:

- `eslint.config.mjs` — added to `ignores`
- `cspell.jsonc` — added to `ignorePaths`
- `tsconfig.json` — added to `exclude`
- `vitest.config.ts` — added to `test.exclude`
- `playwright-ct.config.ts` — new `testIgnore` (its `testDir` is the project root)

No ENV variable changes.

### Breaking or Incompatible Changes

None. The path is already git-ignored, so nothing that is committed to the repository is affected.

### Additional Information

Verified by creating a real worktree at `.claude/worktrees/` and re-running each tool: eslint reports no
files from it, the cspell file count is unchanged, `vitest list` and `playwright test --list` return no
entries from it, and `tsc` stays clean.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
