### PR TITLE
fix: add corepack retry + build cache write-back

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -107,8 +107,8 @@ jobs:
                     context: .
                     file: ./Dockerfile
                     push: true
-                    cache-from: type=gha
-                    cache-to: type=gha,mode=max,ignore-error=true
+                    cache-from: type=registry,ref=${{ steps.image-name.outputs.image-name }}:buildcache
+                    cache-to: type=registry,ref=${{ steps.image-name.outputs.image-name }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
                     tags: ${{ steps.meta.outputs.tags }}
                     platforms: ${{ inputs.platforms }}
                     labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -101,14 +101,27 @@ jobs:
                     docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
                     docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
 
+            # The registry cache exporter REPLACES the manifest at its tag rather than
+            # merging into it, so a single shared tag would let an amd64-only build
+            # (review/pre-release/main) wipe the arm64 records written by a release
+            # build. Scope the tag by platform set instead. Sorted + whitespace-stripped
+            # so the tag does not depend on how the input happens to be spelled.
+            -   name: Compute build cache tag
+                id: cache-tag
+                env:
+                    PLATFORMS: ${{ inputs.platforms }}
+                run: |
+                    slug=$(echo "$PLATFORMS" | tr -d '[:space:]' | tr ',' '\n' | grep -v '^$' | sort | tr '/' '-' | paste -sd '_' -)
+                    echo "tag=buildcache-${slug:-default}" >> "$GITHUB_OUTPUT"
+
             -   name: Build and push
                 uses: docker/build-push-action@v5
                 with:
                     context: .
                     file: ./Dockerfile
                     push: true
-                    cache-from: type=registry,ref=${{ steps.image-name.outputs.image-name }}:buildcache
-                    cache-to: type=registry,ref=${{ steps.image-name.outputs.image-name }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
+                    cache-from: type=registry,ref=${{ steps.image-name.outputs.image-name }}:${{ steps.cache-tag.outputs.tag }}
+                    cache-to: type=registry,ref=${{ steps.image-name.outputs.image-name }}:${{ steps.cache-tag.outputs.tag }},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
                     tags: ${{ steps.meta.outputs.tags }}
                     platforms: ${{ inputs.platforms }}
                     labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -106,13 +106,18 @@ jobs:
             # (review/pre-release/main) wipe the arm64 records written by a release
             # build. Scope the tag by platform set instead. Sorted + whitespace-stripped
             # so the tag does not depend on how the input happens to be spelled.
+            # Fails hard rather than falling back to a fixed tag: a shared fallback would
+            # silently reintroduce the very clobbering this step prevents, and
+            # `ignore-error=true` on the exporter would hide the symptom.
             -   name: Compute build cache tag
                 id: cache-tag
                 env:
                     PLATFORMS: ${{ inputs.platforms }}
                 run: |
-                    slug=$(echo "$PLATFORMS" | tr -d '[:space:]' | tr ',' '\n' | grep -v '^$' | sort | tr '/' '-' | paste -sd '_' -)
-                    echo "tag=buildcache-${slug:-default}" >> "$GITHUB_OUTPUT"
+                    set -euo pipefail
+                    slug=$(printf '%s' "$PLATFORMS" | tr -d '[:space:]' | tr ',' '\n' | awk 'NF' | LC_ALL=C sort | tr '/' '-' | paste -sd '_' -)
+                    [ -n "$slug" ] || { echo "platforms input resolved to no platforms" >&2; exit 1; }
+                    echo "tag=buildcache-$slug" >> "$GITHUB_OUTPUT"
 
             -   name: Build and push
                 uses: docker/build-push-action@v5
@@ -120,7 +125,12 @@ jobs:
                     context: .
                     file: ./Dockerfile
                     push: true
-                    cache-from: type=registry,ref=${{ steps.image-name.outputs.image-name }}:${{ steps.cache-tag.outputs.tag }}
+                    # Also read the amd64-only cache: it is warmed by every review /
+                    # pre-release / main build, so a multi-arch release gets its amd64
+                    # half for free. Redundant (same ref twice) for amd64-only callers.
+                    cache-from: |
+                        type=registry,ref=${{ steps.image-name.outputs.image-name }}:${{ steps.cache-tag.outputs.tag }}
+                        type=registry,ref=${{ steps.image-name.outputs.image-name }}:buildcache-linux-amd64
                     cache-to: type=registry,ref=${{ steps.image-name.outputs.image-name }}:${{ steps.cache-tag.outputs.tag }},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
                     tags: ${{ steps.meta.outputs.tags }}
                     platforms: ${{ inputs.platforms }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -108,6 +108,7 @@ jobs:
                     file: ./Dockerfile
                     push: true
                     cache-from: type=gha
+                    cache-to: type=gha,mode=max
                     tags: ${{ steps.meta.outputs.tags }}
                     platforms: ${{ inputs.platforms }}
                     labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -108,7 +108,7 @@ jobs:
                     file: ./Dockerfile
                     push: true
                     cache-from: type=gha
-                    cache-to: type=gha,mode=max
+                    cache-to: type=gha,mode=max,ignore-error=true
                     tags: ${{ steps.meta.outputs.tags }}
                     platforms: ${{ inputs.platforms }}
                     labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -102,9 +102,9 @@ jobs:
                     docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
 
             # The registry cache exporter REPLACES the manifest at its tag rather than
-            # merging into it, so a single shared tag would let an amd64-only build
-            # (review/pre-release/main) wipe the arm64 records written by a release
-            # build. Scope the tag by platform set instead. Sorted + whitespace-stripped
+            # merging into it, so a single shared tag would let any of the amd64-only
+            # callers wipe the arm64 records written by a release build (only releases
+            # build arm64). Scope the tag by platform set. Sorted + whitespace-stripped
             # so the tag does not depend on how the input happens to be spelled.
             # Fails hard rather than falling back to a fixed tag: a shared fallback would
             # silently reintroduce the very clobbering this step prevents, and
@@ -125,9 +125,9 @@ jobs:
                     context: .
                     file: ./Dockerfile
                     push: true
-                    # Also read the amd64-only cache: it is warmed by every review /
-                    # pre-release / main build, so a multi-arch release gets its amd64
-                    # half for free. Redundant (same ref twice) for amd64-only callers.
+                    # Also read the amd64-only cache, kept warm by the four amd64
+                    # callers, so a multi-arch release gets its amd64 half for free.
+                    # Redundant (same ref twice) for those amd64-only callers.
                     cache-from: |
                         type=registry,ref=${{ steps.image-name.outputs.image-name }}:${{ steps.cache-tag.outputs.tag }}
                         type=registry,ref=${{ steps.image-name.outputs.image-name }}:buildcache-linux-amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # *****************************
 FROM node:22.14.0-alpine AS base
 # corepack prepare makes a single network request to the npm registry and has no
-# built-in retry. Transient failures (HTTP 429 rate-limit, timeout) are common on
-# shared CI egress IPs, so retry with a linear backoff.
+# built-in retry. Transient registry failures (HTTP 429, timeout, DNS) are not
+# uncommon, so retry with a linear backoff.
 RUN set -eu; \
     corepack enable; \
     n=0; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,27 @@
 # *****************************
+# *** STAGE 0: Shared base ****
+# *****************************
+FROM node:22.14.0-alpine AS base
+# corepack prepare makes a single network request to the npm registry and has no
+# built-in retry. Transient failures (HTTP 429 rate-limit, timeout) are common on
+# shared CI egress IPs, so retry with a linear backoff.
+RUN set -eu; \
+    corepack enable; \
+    n=0; \
+    until corepack prepare pnpm@11.5.1 --activate; do \
+      n=$((n + 1)); \
+      if [ "$n" -ge 5 ]; then echo "corepack prepare failed after $n attempts" >&2; exit 1; fi; \
+      echo "corepack prepare attempt $n failed, retrying in $((n * 10))s..." >&2; \
+      sleep $((n * 10)); \
+    done
+
+# *****************************
 # *** STAGE 1: Dependencies ***
 # *****************************
-FROM node:22.14.0-alpine AS deps
+FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat python3 make g++
 RUN ln -sf /usr/bin/python3 /usr/bin/python
-RUN corepack enable && \
-    n=0; until corepack prepare pnpm@11.5.1 --activate; do \
-      n=$((n+1)); if [ "$n" -ge 5 ]; then echo "corepack prepare failed after $n attempts"; exit 1; fi; \
-      echo "corepack prepare attempt $n failed, retrying in 10s..."; sleep 10; \
-    done
 
 ### Install all workspace dependencies in one place
 WORKDIR /app
@@ -21,13 +33,8 @@ RUN pnpm install --frozen-lockfile
 # *****************************
 # ****** STAGE 2: Build *******
 # *****************************
-FROM node:22.14.0-alpine AS builder
+FROM base AS builder
 RUN apk add --no-cache --upgrade libc6-compat bash jq
-RUN corepack enable && \
-    n=0; until corepack prepare pnpm@11.5.1 --activate; do \
-      n=$((n+1)); if [ "$n" -ge 5 ]; then echo "corepack prepare failed after $n attempts"; exit 1; fi; \
-      echo "corepack prepare attempt $n failed, retrying in 10s..."; sleep 10; \
-    done
 
 # pass build args to env variables
 ARG GIT_COMMIT_SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ FROM node:22.14.0-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat python3 make g++
 RUN ln -sf /usr/bin/python3 /usr/bin/python
-RUN corepack enable && corepack prepare pnpm@11.5.1 --activate
+RUN corepack enable && \
+    n=0; until corepack prepare pnpm@11.5.1 --activate; do \
+      n=$((n+1)); if [ "$n" -ge 5 ]; then echo "corepack prepare failed after $n attempts"; exit 1; fi; \
+      echo "corepack prepare attempt $n failed, retrying in 10s..."; sleep 10; \
+    done
 
 ### Install all workspace dependencies in one place
 WORKDIR /app
@@ -19,7 +23,11 @@ RUN pnpm install --frozen-lockfile
 # *****************************
 FROM node:22.14.0-alpine AS builder
 RUN apk add --no-cache --upgrade libc6-compat bash jq
-RUN corepack enable && corepack prepare pnpm@11.5.1 --activate
+RUN corepack enable && \
+    n=0; until corepack prepare pnpm@11.5.1 --activate; do \
+      n=$((n+1)); if [ "$n" -ge 5 ]; then echo "corepack prepare failed after $n attempts"; exit 1; fi; \
+      echo "corepack prepare attempt $n failed, retrying in 10s..."; sleep 10; \
+    done
 
 # pass build args to env variables
 ARG GIT_COMMIT_SHA


### PR DESCRIPTION
## Problem

The **Deploy review environment** build (and all builds via `publish-image.yml`) regularly fails at:
```dockerfile
RUN corepack enable && corepack prepare pnpm@11.5.1 --activate
```
with `exit code: 1`.

Example: https://github.com/blockscout/frontend/actions/runs/30436913793/job/90526763300

`corepack prepare` downloads the pnpm binary from the npm registry. A single transient failure (timeout, HTTP 429) fails the entire build because the command has no retry logic. Combined with read-only Docker layer caching, the download ran on virtually every build — which is why this is a frequent, intermittent failure.

## Changes

### `Dockerfile` — shared base stage + retry loop

- **New `base` stage** holding the corepack setup, inherited by both `deps` and `builder`. Previously `corepack prepare` was duplicated verbatim in both stages (two downloads per build). Now it runs once.
- **Retry loop with linear backoff** (`n * 10s`, 5 attempts, `set -eu`) so transient registry failures self-heal. A naive `corepack enable && n=0; until...` would swallow the exit code of `corepack enable` if it fails — `set -eu` prevents that.
- The base stage is the first layer after the base image (`node:22.14.0-alpine`), so it invalidates less often than when it lived after `apk add`.
- The `runner` stage intentionally stays on `FROM node:22.14.0-alpine` — pnpm does not leak into the runtime image.

Moving corepack ahead of `apk add libc6-compat` is safe: corepack is plain JS, and node in the official alpine image is linked against musl natively — `libc6-compat` is only needed by native addons.

### `.github/workflows/publish-image.yml` — registry-backed layer cache

**The dominant root cause: there was no `cache-to` at all.** `main` carries `cache-from: type=gha` and nothing that ever writes it, so the cache was a guaranteed 100% miss on every build, on every branch — which is why `corepack prepare` ran essentially every time. Adding a one-line `cache-to: type=gha,mode=max` would have fixed the reported failure on its own.

The switch to **`type=registry`** on ghcr is therefore a preference, not the fix. The reasons below are still good reasons to prefer it — they are just not why the cache was cold:

| Concern | GHA cache (`type=gha`) | Registry cache (`type=registry`) |
|---|---|---|
| Branch scope | Isolated per ref. Since main has no automatic push trigger (commented out in `deploy-main.yml`), even *with* a `cache-to` there would be **no shared warm cache to inherit** — still a cold build on every new branch. | Branch-agnostic. One warm cache serves **all** branches immediately. |
| Quota | 10 GB per repo, LRU eviction. Competes with 7 pnpm caches from `checks.yml` (`actions/setup-node` + `cache: 'pnpm'`). `mode=max` exports the entire `deps` stage; with `amd64+arm64` that's doubled. Risk: cache eviction slows down every PR check. | GHCR storage, no Actions Cache quota impact. |
| Multi-node builder | `setup-multiarch-buildx` builds on two nodes (local amd64 + remote ARM host). GHA cache exports from multi-node builders can result in partially written caches. | `image-manifest=true` + `oci-mediatypes=true` produces a well-defined OCI image that works reliably across builder nodes. |
| Auth | Implicit via Actions token. | Already available: the workflow logs into ghcr with `packages: write` scope. |
| Failure mode | Cache write failures are background noise. | `ignore-error=true` keeps cache push failures non-fatal, same approach. |

#### The cache tag is scoped by platform set

The registry cache exporter **replaces** the manifest at its tag rather than merging into it. All five callers resolve to the same image name (none of them pass `private`, so all get `frontend-private`), but they do not build the same platforms:

| Workflow | `platforms` | Trigger |
|---|---|---|
| `deploy-review.yml` | `linux/amd64` | `workflow_dispatch` only |
| `pre-release.yml` | `linux/amd64` | `workflow_dispatch` only |
| `deploy-main.yml` | `linux/amd64` | `workflow_dispatch` (push trigger commented out) |
| `e2e-tests.yml` | `linux/amd64` | `workflow_dispatch` / `workflow_call` (currently uncalled) |
| `release.yml` | `linux/amd64,linux/arm64/v8` | release |

With one shared `:buildcache` tag, any amd64-only build would write an amd64-only cache and wipe the arm64 records, leaving releases cold on the remote ARM node — the slowest path, and exactly where `corepack prepare` hits the network again.

Note that **every caller is manually triggered**: no `push` or `pull_request` trigger reaches `publish-image.yml` today. So the clobbering rate — and the storage growth in #3602 — are far lower than build volume alone would suggest. It also means the shared mutable cache tag can only be written by someone who can dispatch a workflow: **no fork- or PR-triggered build can poison it**. That property is what makes a shared mutable cache tag acceptable here, and it stops holding the moment a `pull_request` trigger is added — whoever does that needs to revisit this.

So the tag is derived from the platform set: `buildcache-linux-amd64` and `buildcache-linux-amd64_linux-arm64-v8`. The slug is whitespace-stripped and sorted, so it does not depend on how the input happens to be spelled — `linux/amd64, linux/arm64/v8` (with a space, as a manual `workflow_dispatch` might well be typed) would otherwise produce a tag containing a space, which is not a valid Docker tag, and `ignore-error=true` would have made that failure silent. The step runs under `set -euo pipefail` and fails hard rather than falling back to a fixed tag, since a shared fallback would silently reintroduce exactly the clobbering it exists to prevent. `platforms` is passed via `env:` rather than interpolated into the script body, since it is a free-form string input.

`cache-from` reads two refs: the scoped tag, plus the amd64-only tag that the four amd64 callers keep warm. That gives a multi-arch release its amd64 half for free; for amd64-only callers the second ref is the same as the first and is simply redundant.

**What the scoping does and does not buy on ARM.** It stops arm64 records from being deleted, but they are only ever *written* by releases, and by the next release the source tree has moved on — so the expensive layers (`pnpm install`, `pnpm run build`) miss regardless. What survives across releases is the early, source-independent part: the base image, the `apk add` layers, and the `base` stage holding corepack. That last one is precisely what this PR is about, so the scoping is worth having — just not as a general speed-up for the ARM path.

## Why both changes are necessary

- **Registry cache eliminates most downloads** — a warm cache means `corepack prepare` doesn't even run. This is the main fix.
- **Retry is the safety net** for the case the cache cannot cover: a cold build, where the download happens for real.

This hardens the one failure mode that has an actual track record. It is not general resilience — the three `apk add` invocations are network calls with no retry either (one of them flaked during review, on the Alpine CDN), and `pnpm install --frozen-lockfile` relies on pnpm's own `fetch-retries`. Those are left alone deliberately: the write-back cache means these early layers stop re-running on most builds, so the right move is to measure that before adding more machinery.

## Follow-ups (deliberately not in this PR)

- **Cache storage is not garbage-collected** — tracked in #3602. `mode=max` exports the whole `builder` stage, and GHCR does not reclaim untagged manifests, so every overwrite of a cache tag leaves orphaned blobs behind. `cleanup.yml` only removes `review-<slug>` tags and does not touch these.
- **Verify the cache is actually working.** `ignore-error=true` makes a broken export indistinguishable from a working one. Half-confirmed: run 30473737168 shows `#65 exporting cache to registry ... DONE 150.8s`, so the manifest does get pushed. Still to check on the next build: that it reports `CACHED` steps.
- **The first build of each kind after merge will be cold**, since the new tags do not exist yet. One-off; the Dockerfile retry covers it.
- **The old `:buildcache` tag** in `ghcr.io/blockscout/frontend-private` is orphaned by this change and should be deleted manually.
