### PR TITLE
Fix Prometheus metrics recorded during page rendering never reaching `/api/metrics`

### DIFF
--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -1,19 +1,15 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import type { NextApiRequest, NextApiResponse } from 'next';
-import * as promClient from 'prom-client';
 
-const isEnabled = process.env.PROMETHEUS_METRICS_ENABLED === 'true';
-
-isEnabled && promClient.collectDefaultMetrics({ prefix: 'frontend_' });
+import { registry } from 'src/server/monitoring/metrics';
 
 export default async function metricsHandler(req: NextApiRequest, res: NextApiResponse) {
-  if (!isEnabled) {
+  if (!registry) {
     res.status(404).json({ error: 'Not found' });
     return;
   }
 
-  const metrics = await promClient.register.metrics();
-  res.setHeader('Content-type', promClient.register.contentType);
-  res.send(metrics);
+  res.setHeader('Content-type', registry.contentType);
+  res.send(await registry.metrics());
 }

--- a/src/server/monitoring/metrics.spec.ts
+++ b/src/server/monitoring/metrics.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Next.js instantiates this module once per server bundle; `vi.resetModules()` stands in for that
+// second instantiation, which is the only way the registry sharing can be exercised in a test.
+const importFreshModuleInstance = () => {
+  vi.resetModules();
+  return import('./metrics');
+};
+
+describe('server metrics', () => {
+  beforeEach(() => {
+    vi.stubEnv('PROMETHEUS_METRICS_ENABLED', 'true');
+    delete (globalThis as { __blockscoutMetricsStore?: unknown }).__blockscoutMetricsStore;
+  });
+
+  it('exposes samples recorded by another module instance', async() => {
+    const renderingBundle = await importFreshModuleInstance();
+    renderingBundle.default?.socialPreviewBotRequests.inc({ route: '/tx/[hash]', bot: 'twitter' });
+
+    const apiRouteBundle = await importFreshModuleInstance();
+
+    expect(apiRouteBundle.registry).toBe(renderingBundle.registry);
+    await expect(apiRouteBundle.registry?.metrics()).resolves.toContain(
+      'social_preview_bot_requests_total{route="/tx/[hash]",bot="twitter"} 1',
+    );
+  });
+
+  it('keeps the default process metrics registered', async() => {
+    const { registry } = await importFreshModuleInstance();
+
+    await expect(registry?.metrics()).resolves.toContain('frontend_nodejs_version_info');
+  });
+
+  it('records nothing when metrics are disabled', async() => {
+    vi.stubEnv('PROMETHEUS_METRICS_ENABLED', 'false');
+
+    const { 'default': metrics, registry } = await importFreshModuleInstance();
+
+    expect(metrics).toBeUndefined();
+    expect(registry).toBeUndefined();
+  });
+});

--- a/src/server/monitoring/metrics.ts
+++ b/src/server/monitoring/metrics.ts
@@ -2,30 +2,30 @@
 
 import * as promClient from 'prom-client';
 
-const metrics = (() => {
+const createStore = () => {
+  const registry = new promClient.Registry();
 
-  if (process.env.PROMETHEUS_METRICS_ENABLED !== 'true') {
-    return;
-  }
-
-  promClient.register.clear();
+  promClient.collectDefaultMetrics({ prefix: 'frontend_', register: registry });
 
   const invalidApiSchema = new promClient.Counter({
     name: 'invalid_api_schema',
     help: 'Number of invalid external API schema events',
     labelNames: [ 'resource', 'url' ] as const,
+    registers: [ registry ],
   });
 
   const socialPreviewBotRequests = new promClient.Counter({
     name: 'social_preview_bot_requests_total',
     help: 'Number of incoming requests from social preview bots',
     labelNames: [ 'route', 'bot' ] as const,
+    registers: [ registry ],
   });
 
   const searchEngineBotRequests = new promClient.Counter({
     name: 'search_engine_bot_requests_total',
     help: 'Number of incoming requests from search engine bots',
     labelNames: [ 'route', 'bot' ] as const,
+    registers: [ registry ],
   });
 
   const apiRequestDuration = new promClient.Histogram({
@@ -33,9 +33,34 @@ const metrics = (() => {
     help: 'Duration of requests to API in seconds',
     labelNames: [ 'route', 'code' ],
     buckets: [ 0.2, 0.5, 1, 3, 10 ],
+    registers: [ registry ],
   });
 
-  return { invalidApiSchema, socialPreviewBotRequests, searchEngineBotRequests, apiRequestDuration };
+  return {
+    registry,
+    metrics: { invalidApiSchema, socialPreviewBotRequests, searchEngineBotRequests, apiRequestDuration },
+  };
+};
+
+// Next.js compiles API routes and page rendering into separate server bundles, so this module is
+// instantiated more than once inside a single server process. Every instance has to end up with the
+// same metric objects: metrics created by one instance and not reachable from the instance behind
+// /api/metrics record samples that are never exported. globalThis is the only thing the instances
+// share, so the store is cached there and built at most once per process.
+const globalStore = globalThis as typeof globalThis & {
+  __blockscoutMetricsStore?: ReturnType<typeof createStore>;
+};
+
+const store = (() => {
+  if (process.env.PROMETHEUS_METRICS_ENABLED !== 'true') {
+    return;
+  }
+
+  globalStore.__blockscoutMetricsStore = globalStore.__blockscoutMetricsStore ?? createStore();
+
+  return globalStore.__blockscoutMetricsStore;
 })();
 
-export default metrics;
+export const registry = store?.registry;
+
+export default store?.metrics;


### PR DESCRIPTION
## Description and Related Issue(s)

Every metric recorded while rendering a page — `social_preview_bot_requests_total`, `search_engine_bot_requests_total` and the `api_request_duration_seconds` histogram written by `fetchApi` — was silently dropped: `/api/metrics` listed the definitions with zero samples on every deployment. Only what API routes recorded (`invalid_api_schema`) was ever exported, and the `frontend_*` default process metrics were missing entirely.

The cause is `promClient.register.clear()` at the top of `src/server/monitoring/metrics.ts`. Next.js compiles API routes and page rendering into separate server bundles, so that module is instantiated **twice** in one server process (`prom-client` itself stays a single instance — the registry was never split). The second instantiation cleared the registry again, unregistering the metric objects the first one had created. The page-rendering bundle kept incrementing those now-orphaned counters, and `/api/metrics` — which lives in the other bundle — could not see them. The same `clear()` also wiped `collectDefaultMetrics`.

`clear()` was what kept the second instantiation from throwing "already registered", so it masked the double-init while breaking it.

### Proposed Changes

- `src/server/monitoring/metrics.ts` — create an explicit `prom-client` `Registry` and register the metrics on it, caching both on `globalThis` so every module instance resolves the same objects. `register.clear()` is dropped (nothing re-registers now), and `collectDefaultMetrics({ prefix: 'frontend_' })` moves here so the defaults land in the same registry.
- `src/pages/api/metrics.ts` — serve that registry instead of `prom-client`'s default one.
- `src/server/monitoring/metrics.spec.ts` — regression test using `vi.resetModules()` to stand in for the second bundle's instantiation.

No env variable changes.

### Breaking or Incompatible Changes

None. The exported metric names, labels and buckets are unchanged; `/api/metrics` still returns 404 when `PROMETHEUS_METRICS_ENABLED` is not `true`.

### Additional Information

Verified against a local **production** build (`pnpm prod:preset staging` with `PROMETHEUS_METRICS_ENABLED=true`). Dev mode cannot reproduce the bug — Turbopack externalizes `node_modules` there, so only one `metrics.ts` instance ends up winning the registry.

Same request sequence before and after (`/api/metrics`, then bot requests to a tx page, an address page and a block page, then `/api/metrics` again):

| | before | after |
| --- | --- | --- |
| `frontend_*` defaults | 0 sample lines | 86 sample lines |
| `social_preview_bot_requests_total` | absent | `/tx/[hash]`, `/address/[hash]` (twitter) |
| `search_engine_bot_requests_total` | absent | `/block/[height_or_hash]` (google) |
| `api_request_duration_seconds` | no samples | full histogram, including `code="504"` on an aborted upstream call |
| `invalid_api_schema` | worked | still works |

The regression test fails on the pre-fix arrangement (`expected Registry to be Registry // Object.is equality`) once the `globalThis` cache is removed.

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
