### PR TITLE
fix: upgrade dotenv-cli so preset envs with a bare $ load

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "@typescript/native": "npm:typescript@7.0.2",
     "@vitejs/plugin-react": "^4.3.4",
     "css-loader": "^6.11.0",
-    "dotenv-cli": "^6.0.0",
+    "dotenv-cli": "10.0.0",
     "eslint": "9.39.2",
     "eslint-config-next": "16.2.6",
     "eslint-plugin-boundaries": "6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^6.11.0
         version: 6.11.0(webpack@5.107.2(esbuild@0.25.12)(postcss@8.5.15))
       dotenv-cli:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: 10.0.0
+        version: 10.0.0
       eslint:
         specifier: 9.39.2
         version: 9.39.2
@@ -8633,10 +8633,6 @@ packages:
     resolution: {integrity: sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==}
     hasBin: true
 
-  dotenv-cli@6.0.0:
-    resolution: {integrity: sha512-qXlCOi3UMDhCWFKe0yq5sg3X+pJAz+RQDiFN38AMSbUrnY3uZshSfDJUAge951OS7J9gwLZGfsBlWRSOYz/TRg==}
-    hasBin: true
-
   dotenv-cli@7.4.4:
     resolution: {integrity: sha512-XkBYCG0tPIes+YZr4SpfFv76SQrV/LeCE8CI7JSEMi3VR9MvTihCGTOtbIexD6i2mXF+6px7trb1imVCXSNMDw==}
     hasBin: true
@@ -8647,10 +8643,6 @@ packages:
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
-    engines: {node: '>=12'}
-
-  dotenv-expand@8.0.3:
-    resolution: {integrity: sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==}
     engines: {node: '>=12'}
 
   dotenv@16.6.1:
@@ -17127,7 +17119,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.16.7
+      '@types/node': 22.12.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -25760,7 +25752,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 20.16.7
+      '@types/node': 22.12.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -25771,7 +25763,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0:
     dependencies:
-      '@types/node': 20.16.7
+      '@types/node': 22.12.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -26625,13 +26617,6 @@ snapshots:
       dotenv-expand: 11.0.7
       minimist: 1.2.8
 
-  dotenv-cli@6.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      dotenv: 16.6.1
-      dotenv-expand: 8.0.3
-      minimist: 1.2.8
-
   dotenv-cli@7.4.4:
     dependencies:
       cross-spawn: 7.0.6
@@ -26644,8 +26629,6 @@ snapshots:
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.6.1
-
-  dotenv-expand@8.0.3: {}
 
   dotenv@16.6.1: {}
 
@@ -28671,7 +28654,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.16.7
+      '@types/node': 22.12.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -28688,13 +28671,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.16.7
+      '@types/node': 22.12.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.16.7
+      '@types/node': 22.12.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1

--- a/tools/dev-server/CONTEXT.md
+++ b/tools/dev-server/CONTEXT.md
@@ -59,6 +59,10 @@ lives here):
   newline doesn't silently drop its last variable (this bit us with `.env.extra`).
 - **dotenv-cli precedence: the FIRST `-e` file wins** (not the last). The run scripts therefore
   list env files **highest-priority-first**.
+- **`dotenv-cli` must stay on a release that bundles `dotenv-expand` ≥ 10.** Instance configs contain
+  values with a bare `$` (regex anchors in `NEXT_PUBLIC_ZETACHAIN_EXTERNAL_SEARCH_CONFIG`, say);
+  `dotenv-expand` 8 throws `Cannot read properties of undefined (reading 'split')` on them instead of
+  leaving the non-variable `$` alone, which kills every `dotenv` invocation in the run scripts.
 - **`--omit-local-envs` is the dev/container switch.** Dev mode applies `localEnvs` (so APP_HOST
   etc. point at `localhost`); the container passes `--omit-local-envs` so those keys are absent
   and the deployment's own APP_* values survive (this replaced the old entrypoint blacklist).


### PR DESCRIPTION
## Problem

`pnpm dev:preset zetachain` (and `zetachain_testnet`) never reaches `next dev` — every `dotenv` invocation in `tools/dev-server/dev.preset.sh` dies first:

```
TypeError: Cannot read properties of undefined (reading 'split')
    at node_modules/.pnpm/dotenv-expand@8.0.3/node_modules/dotenv-expand/lib/main.js:20:33
```

The trigger is a bare `$` in an env value. ZetaChain's `NEXT_PUBLIC_ZETACHAIN_EXTERNAL_SEARCH_CONFIG` holds regex anchors:

```
[{"regex":"^[A-F0-9]{64}$","template":"https://zetachain.exploreme.pro/transactions/{hash}",…}]
```

`dotenv-expand@8`'s interpolator assumes any `$` starts a variable reference; when the capture group comes back `undefined` it throws instead of leaving the `$` alone. Root `package.json` pinned `dotenv-cli` at `^6.0.0`, which caps at 6.x and pulls that broken `dotenv-expand`.

This is not zetachain-specific — any preset whose instance config contains a `$` would hit it. The documented example value for this variable in `docs/ENVS.md` contains one.

## Change

Pin `dotenv-cli` to `10.0.0`, matching what `deploy/tools/essential-dapps-chains-config-generator` and `deploy/tools/llms-txt-generator` already use. Also records the constraint in `tools/dev-server/CONTEXT.md` so it isn't re-learned.

## Reviewer notes

The dev-server scripts depend on two `dotenv-cli` behaviours that are easy to break on a major bump, so both were checked explicitly against 6.0.0, 7.4.4 and 10.0.0:

- **First `-e` file wins** (the run scripts list env files highest-priority-first) — unchanged.
- **`-v` variables apply after all `-e` files** (how `--port` overrides `NEXT_PUBLIC_APP_PORT`) — unchanged.

Beyond that, the full parsed `NEXT_PUBLIC_*` set was diffed between v6 and v10 for the `eth`, `tac`, `multichain`, `optimism` and `shibarium` presets — byte-identical in every case. Inline-`#` truncation of unquoted values behaves the same in both, so no silent value changes.

## Verification

- `pnpm dev:preset zetachain` — ready in 359ms, homepage renders live data, no console errors, and the `$` anchors survive intact into `window.__envs`.
- `pnpm dev:preset zetachain_testnet` — config fetches and parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)