### PR TITLE
Tighten the agent doc-reference checker and fix the paths it was hiding

### DIFF
--- a/.agents/rules/design-system.md
+++ b/.agents/rules/design-system.md
@@ -15,23 +15,23 @@ The app uses **Chakra UI v3** as its component and styling foundation.
 
 ## Project configuration
 
-The design system is layered on top of Chakra UI inside `toolkit/`:
+The design system is layered on top of Chakra UI inside `src/toolkit/`:
 
 | Path | Purpose |
 |---|---|
-| `toolkit/chakra/` | Custom wrappers for Chakra components — always prefer these over bare Chakra imports |
-| `toolkit/theme/theme.ts` | Theme entry point; uses Chakra v3's `createSystem` API to merge defaults with project config |
-| `toolkit/theme/foundations/semanticTokens.ts` | Full list of semantic color tokens (text, bg, border, icon, component-level tokens) |
-| `toolkit/theme/foundations/colors.ts` | Raw color palette referenced by semantic tokens |
-| `toolkit/theme/recipes/` | Component style recipes (slot recipes and simple recipes) |
-| `toolkit/components/` | Custom business components (forms, charts, tabs, etc.) built on top of Chakra |
-| `toolkit/hooks/` | Shared React hooks (useDisclosure, useClipboard, etc.) |
+| `src/toolkit/chakra/` | Custom wrappers for Chakra components — always prefer these over bare Chakra imports |
+| `src/toolkit/theme/theme.ts` | Theme entry point; uses Chakra v3's `createSystem` API to merge defaults with project config |
+| `src/toolkit/theme/foundations/semanticTokens.ts` | Full list of semantic color tokens (text, bg, border, icon, component-level tokens) |
+| `src/toolkit/theme/foundations/colors.ts` | Raw color palette referenced by semantic tokens |
+| `src/toolkit/theme/recipes/` | Component style recipes (slot recipes and simple recipes) |
+| `src/toolkit/components/` | Custom business components (forms, charts, tabs, etc.) built on top of Chakra |
+| `src/toolkit/hooks/` | Shared React hooks (useDisclosure, useClipboard, etc.) |
 
-The `Provider` component at `toolkit/chakra/provider.tsx` wraps `ChakraProvider` with the custom theme and color mode support. It must be mounted at the app root.
+The `Provider` component at `src/toolkit/chakra/provider.tsx` wraps `ChakraProvider` with the custom theme and color mode support. It must be mounted at the app root.
 
 ## Component import priority
 
-Always check `toolkit/chakra/` before importing from Chakra UI directly; if a wrapper exists there, use it.
+Always check `src/toolkit/chakra/` before importing from Chakra UI directly; if a wrapper exists there, use it.
 ESLint blocks the wrapped components by name, but the list is not exhaustive — the rule applies to any
 component that has a wrapper, caught or not.
 
@@ -39,7 +39,7 @@ component that has a wrapper, caught or not.
 
 Never use raw color values (hex, RGB, HSL). Always reference a token. Three sources are valid:
 
-1. **Semantic tokens** — context-aware, light/dark aware. Full list in `toolkit/theme/foundations/semanticTokens.ts`. Prefer these whenever a semantic meaning exists.
+1. **Semantic tokens** — context-aware, light/dark aware. Full list in `src/toolkit/theme/foundations/semanticTokens.ts`. Prefer these whenever a semantic meaning exists.
 
    ```tsx
    <Text color="text.secondary" />
@@ -48,13 +48,13 @@ Never use raw color values (hex, RGB, HSL). Always reference a token. Three sour
 
    Common groups: `text.*`, `bg.*`, `border.*`, `icon.*`, `link.*`, `button.*`, `badge.*`.
 
-2. **Project color palette** — scale and alpha colors defined in `toolkit/theme/foundations/colors.ts`: `gray`, `blue`, `red`, `orange`, `yellow`, `green`, `teal`, `cyan`, `purple`, `pink` (steps 50–900), `black`, `white`, `whiteAlpha.*`, `blackAlpha.*`.
+2. **Project color palette** — scale and alpha colors defined in `src/toolkit/theme/foundations/colors.ts`: `gray`, `blue`, `red`, `orange`, `yellow`, `green`, `teal`, `cyan`, `purple`, `pink` (steps 50–900), `black`, `white`, `whiteAlpha.*`, `blackAlpha.*`.
 
    ```tsx
    <Box bg="blue.50" color="gray.700" />
    ```
 
-3. **Brand colors** — also defined in `toolkit/theme/foundations/colors.ts`: `github`, `telegram`, `linkedin`, `discord`, `slack`, `twitter`, `opensea`, `facebook`, `medium`, `reddit`, `celo`, `clusters`.
+3. **Brand colors** — also defined in `src/toolkit/theme/foundations/colors.ts`: `github`, `telegram`, `linkedin`, `discord`, `slack`, `twitter`, `opensea`, `facebook`, `medium`, `reddit`, `celo`, `clusters`.
 
    ```tsx
    <Icon color="github" />
@@ -64,16 +64,16 @@ If a raw color value is truly unavoidable (e.g. a third-party embed), leave a co
 
 ## Design tokens
 
-The project customizes the following Chakra token categories in `toolkit/theme/`. Always use these tokens instead of raw CSS values:
+The project customizes the following Chakra token categories in `src/toolkit/theme/`. Always use these tokens instead of raw CSS values:
 
 | Token type | File | Example |
 |---|---|---|
-| Border radius | `foundations/borders.ts` | `borderRadius="md"` instead of `borderRadius="12px"` |
-| Shadows | `foundations/shadows.ts` | `boxShadow="size.md"` instead of a custom `box-shadow` |
-| Z-index | `foundations/zIndex.ts` | `zIndex="modal"` instead of a raw number |
-| Font weights | `theme.ts` (inline) | `fontWeight="semibold"` instead of `fontWeight={600}` |
-| Durations | `foundations/durations.ts` | Use duration tokens for CSS transitions |
-| Keyframes | `foundations/animations.ts` | Reference named keyframes for custom animations |
+| Border radius | `src/toolkit/theme/foundations/borders.ts` | `borderRadius="md"` instead of `borderRadius="12px"` |
+| Shadows | `src/toolkit/theme/foundations/shadows.ts` | `boxShadow="size.md"` instead of a custom `box-shadow` |
+| Z-index | `src/toolkit/theme/foundations/zIndex.ts` | `zIndex="modal"` instead of a raw number |
+| Font weights | `src/toolkit/theme/theme.ts` (inline) | `fontWeight="semibold"` instead of `fontWeight={600}` |
+| Durations | `src/toolkit/theme/foundations/durations.ts` | Use duration tokens for CSS transitions |
+| Keyframes | `src/toolkit/theme/foundations/animations.ts` | Reference named keyframes for custom animations |
 
 Available `radii` tokens: `none`, `sm` (4px), `base` (8px), `md` (12px), `lg` (16px), `xl` (24px), `full`.
 
@@ -91,7 +91,7 @@ Do not set `fontSize` or `lineHeight` directly. Apply the appropriate `textStyle
 <Text textStyle="text.sm">Label</Text>
 ```
 
-Available text styles (defined in `toolkit/theme/foundations/typography.ts`):
+Available text styles (defined in `src/toolkit/theme/foundations/typography.ts`):
 
 | Token | fontSize / lineHeight |
 |---|---|
@@ -111,7 +111,7 @@ For a regular text block, the `text.` prefix can be omitted.
 
 Do not override the default spacing of **internal parts** of compound components (e.g. adding custom padding to `DialogHeader` inside a `Dialog`, or to a `MenuList` item). The root component itself may be spaced freely; its sub-parts may not.
 
-This rule applies to all components from `toolkit/chakra/`.
+This rule applies to all components from `src/toolkit/chakra/`.
 
 ## Duplicated style props
 

--- a/.agents/skills/add-env-var/SKILL.md
+++ b/.agents/skills/add-env-var/SKILL.md
@@ -152,8 +152,8 @@ Most URL variables need a CSP allowance under `src/server/csp/policies/`.
 Gate the addition on the relevant config option being enabled — don't widen
 the CSP unconditionally.
 
-**Exceptions** — these are already auto-included by `policies/app.ts` and
-need no manual CSP work:
+**Exceptions** — these are already auto-included by `src/server/csp/policies/app.ts`
+and need no manual CSP work:
 
 - new API `endpoint` and `socketEndpoint` values that flow into `config.apis.*`.
 

--- a/.agents/skills/review-changes/prose-smells.md
+++ b/.agents/skills/review-changes/prose-smells.md
@@ -14,9 +14,9 @@ Three rules bind the baseline, mirroring `smells.md`:
   rule, suppress the smell that would contradict it.
 - **Always a judgement call.** Report a smell as a labelled possibility ("possible Sediment"), never as a
   violation.
-- **Skip what tooling enforces.** `lint:doc-links` already resolved every link, heading anchor and path —
-  including a path written short; cspell already ran. Their findings are facts, not smells — a reference that
-  does not resolve is never a finding here.
+- **Skip what tooling enforces.** `lint:doc-links` already resolved every link, heading anchor and path
+  reference, and flagged every path written short; cspell already ran. Their findings are facts, not smells —
+  neither a dead reference nor a shorthand path is ever a finding here.
 
 One defect, one label. Duplication and Shotgun Surgery describe the same mess from two directions — pick
 the sharper one.

--- a/.agents/skills/review-changes/prose-smells.md
+++ b/.agents/skills/review-changes/prose-smells.md
@@ -14,8 +14,9 @@ Three rules bind the baseline, mirroring `smells.md`:
   rule, suppress the smell that would contradict it.
 - **Always a judgement call.** Report a smell as a labelled possibility ("possible Sediment"), never as a
   violation.
-- **Skip what tooling enforces.** `lint:doc-links` already resolved every link, path reference and heading
-  anchor; cspell already ran. Their findings are facts, not smells — a broken link is never a finding here.
+- **Skip what tooling enforces.** `lint:doc-links` already resolved every link, heading anchor and path —
+  including a path written short; cspell already ran. Their findings are facts, not smells — a reference that
+  does not resolve is never a finding here.
 
 One defect, one label. Duplication and Shotgun Surgery describe the same mess from two directions — pick
 the sharper one.

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -20,7 +20,8 @@ sync Slack replies: there is nothing to convert, so the run is just harvest (Ste
 
 ## Spec location and structure
 
-- With a GitHub issue: `.agents/tasks/<issue-number>-<slug>/spec.md` (e.g. `.agents/tasks/3219-cross-chain-txs/spec.md`).
+- With a GitHub issue: `.agents/tasks/<issue-number>-<slug>/spec.md` — the bare issue number, then a
+  kebab-case slug naming the task.
 - Ad-hoc (no issue): `.agents/tasks/<slug>/spec.md`.
 - Every subtask of a medium/large task gets its own folder `subtasks/<NN>-<slug>/`, holding:
   - `brief.md` — the handoff from the initial grilling session for a subtask that isn't scoped yet. Its

--- a/tools/scripts/check-doc-links.mjs
+++ b/tools/scripts/check-doc-links.mjs
@@ -7,11 +7,15 @@
 // what a rule says, not on whether the rule's target still exists.
 //
 // These documents also carry paths that are *illustrations* rather than references — a template's output
-// column, an `e.g.`, a kind of file that lives in many slices. Checking those would produce noise that
-// trains everyone to ignore the checker, so an illustration is exempt wherever it cannot be mistaken for a
-// reference: a `<placeholder>` segment, an `(e.g. …)` parenthetical, or the right-hand side of a `→`. Each
-// exemption is scoped to the path itself rather than to its whole line, so a real reference standing beside
-// an illustration is still checked. Anything unmarked is read as a reference and has to resolve.
+// column, a kind of file that lives in many slices. Checking those would produce noise that trains everyone
+// to ignore the checker, so an illustration is exempt where it carries a mark that cannot be read as a
+// reference; `ILLUSTRATION_FORMS` below is the only statement of what those marks are. Each exemption is
+// scoped to the path itself rather than to its whole line, so a real reference standing beside an
+// illustration is still checked, and anything unmarked is read as a reference and has to resolve.
+//
+// An `e.g.` is deliberately *not* a mark. Prose that introduces a real file as an example is the common
+// case by far, and exempting it would leave those references unprotected against a later rename — the drift
+// this script exists to catch. An example that names no real file gets a `<placeholder>` segment instead.
 
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -88,11 +92,15 @@ function withoutFences(body) {
   });
 }
 
-// Blanks the marked-illustration regions and leaves the rest of the line checkable. A `→` runs to the end of
-// its table cell, because what follows the arrow is the hypothetical output of the pattern before it.
-const withoutIllustrations = (line) => line
-  .replace(/\([^)]*e\.g\.[^)]*\)?/g, '')
-  .replace(/→[^|]*/g, '');
+// Stated once, and printed on failure so the convention reaches an author at the moment they trip it rather
+// than in a document they would have to know to read.
+const ILLUSTRATION_FORMS = 'give it a <placeholder> segment, or place it after a → in a table row as the ' +
+  'output of the pattern before it';
+
+// Blanks the marked regions and leaves the rest of the line checkable. The arrow form is confined to table
+// rows, where a cell pairs a pattern with its filled-in output; in prose an arrow is ordinary punctuation
+// and the path after it is a reference like any other. The `<placeholder>` form is per-path, below.
+const withoutIllustrations = (line) => (/^\s*\|/.test(line) ? line.replace(/→[^|]*/g, '') : line);
 
 const isPlaceholder = (target) => /[<>{}*]|__/.test(target);
 
@@ -111,6 +119,15 @@ function resolves(realDir, target) {
 function shorthandFor(target) {
   const matches = tracked.filter((f) => f.endsWith(`/${ target }`));
   return matches.length === 1 ? matches[0] : undefined;
+}
+
+// A path whose parent directory sits beside the file was written relative to it — `components/Provider.tsx`
+// in a CONTEXT.md is a reference to a neighbour, and its absence is a break. Without this the whole relative
+// class goes unprotected: once broken, such a path is indistinguishable from `types/api.ts` naming a kind of
+// file, so a renamed neighbour would fail silently.
+function nearby(realDir, target) {
+  const parent = path.dirname(target);
+  return parent !== '.' && !target.endsWith('/') && existsSync(path.resolve(realDir, parent));
 }
 
 async function checkFile(fileRel, failures) {
@@ -136,7 +153,7 @@ async function checkFile(fileRel, failures) {
       const full = shorthandFor(target);
       if (full) {
         report(`${ target } is shorthand; write it in full: ${ full }`);
-      } else if (target.startsWith('./') || TOP_LEVEL.has(target.split('/')[0])) {
+      } else if (target.startsWith('./') || TOP_LEVEL.has(target.split('/')[0]) || nearby(realDir, target)) {
         report(`path reference does not exist: ${ target }`);
       }
     }
@@ -185,9 +202,7 @@ if (failures.length > 0) {
   // eslint-disable-next-line no-console
   console.error(
     `\n${ failures.length } unresolved reference(s) across ${ files.length } file(s).\n` +
-    'A path naming a shape rather than a file has to be marked as one, or it is read as a reference: give ' +
-    'it a <placeholder> segment, put it in an (e.g. …) parenthetical, or place it after a → as the output ' +
-    'of the pattern before it.',
+    `A path naming a shape rather than a file has to be marked as one, or it is read as a reference: ${ ILLUSTRATION_FORMS }.`,
   );
   process.exit(1);
 }

--- a/tools/scripts/check-doc-links.mjs
+++ b/tools/scripts/check-doc-links.mjs
@@ -1,39 +1,39 @@
 #!/usr/bin/env node
 
-// Resolves the cross-references in the agent instruction surface: markdown links, heading anchors, and
-// root-anchored paths in backticks. These files instruct agents rather than humans, so a reference that no
-// longer resolves does not merely read badly — it sends an agent to a file that is not there, and nothing
+// Resolves the cross-references in the agent instruction surface: markdown links, heading anchors, and the
+// file and directory paths in backticks. These files instruct agents rather than humans, so a reference that
+// no longer resolves does not merely read badly — it sends an agent to a file that is not there, and nothing
 // else in the toolchain notices. Kept mechanical on purpose: a review agent should spend its judgement on
 // what a rule says, not on whether the rule's target still exists.
 //
-// Deliberately narrow, because these documents are full of paths that are *illustrations* rather than
-// references — a template's output column, a kind of file that lives in many slices, an `e.g.`. Checking
-// those produces noise that trains everyone to ignore the checker, so only two forms are checked: a
-// markdown link, and a backtick path anchored at a repo root. Everything else is left alone.
+// These documents also carry paths that are *illustrations* rather than references — a template's output
+// column, an `e.g.`, a kind of file that lives in many slices. Checking those would produce noise that
+// trains everyone to ignore the checker, so an illustration is exempt wherever it cannot be mistaken for a
+// reference: a `<placeholder>` segment, an `(e.g. …)` parenthetical, or the right-hand side of a `→`. Each
+// exemption is scoped to the path itself rather than to its whole line, so a real reference standing beside
+// an illustration is still checked. Anything unmarked is read as a reference and has to resolve.
 
+import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { readdir, readFile, realpath } from 'node:fs/promises';
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 
-// The instruction surface. Task specs are excluded: they describe files that do not exist yet by design.
+// The instruction surface: the agent config directories, plus every per-directory CONTEXT.md wherever it
+// lives. Task specs are excluded — they describe files that do not exist yet by design.
 const ROOTS = [ '.agents', '.claude', '.cursor' ];
 const EXCLUDED = [ '.agents/tasks' ];
 const SKIPPED_DIRS = new Set([ 'node_modules', '.git', '.next' ]);
 
-// A backtick path is checked only when anchored here, because an anchored path asserts one location while
-// a bare `types/api.ts` names a kind of file that many directories legitimately have.
-const ANCHORS = [ '.agents/', '.claude/', '.cursor/', '.github/', 'src/', 'tools/', 'deploy/', 'docs/', 'playwright/', 'vitest/', './' ];
-
 const PATH_EXTENSIONS = /\.(?:md|mdc|mjs|json|jsonc|ya?ml|sh|tsx?)$/;
 
-// `→` maps a template to its hypothetical output; `e.g.` marks its paths as examples. Neither asserts that
-// the file exists, so lines carrying them are skipped rather than reported.
-const ILLUSTRATIVE = /→|e\.g\./;
+const tracked = execFileSync('git', [ 'ls-files' ], { cwd: ROOT, encoding: 'utf8' }).split('\n').filter(Boolean);
 
-// A template file's whole purpose is paths that do not exist yet.
-const isTemplate = (file) => /-template\.md$/.test(file);
+// Derived rather than listed, so a new top-level directory needs no edit here. A path is only expected to
+// resolve when its first segment is one of these: `types/api.ts` names a kind of file, `src/api/types.ts` a
+// location.
+const TOP_LEVEL = new Set(tracked.filter((f) => f.includes('/')).map((f) => f.split('/')[0]));
 
 async function collectMarkdown(dir, acc = []) {
   let entries;
@@ -47,9 +47,11 @@ async function collectMarkdown(dir, acc = []) {
     const rel = path.join(dir, entry.name);
     if (EXCLUDED.some((ex) => rel === ex || rel.startsWith(`${ ex }/`))) continue;
 
+    // A symlinked directory (`.claude/skills` → `../.agents/skills`) is not a directory to `readdir`, so the
+    // walk skips it — correctly, since the walk over `.agents` reaches those files by their real path.
     if (entry.isDirectory()) {
       if (!SKIPPED_DIRS.has(entry.name)) await collectMarkdown(rel, acc);
-    } else if (/\.mdc?$/.test(entry.name) && !isTemplate(entry.name)) {
+    } else if (/\.mdc?$/.test(entry.name)) {
       acc.push(rel);
     }
   }
@@ -86,13 +88,29 @@ function withoutFences(body) {
   });
 }
 
+// Blanks the marked-illustration regions and leaves the rest of the line checkable. A `→` runs to the end of
+// its table cell, because what follows the arrow is the hypothetical output of the pattern before it.
+const withoutIllustrations = (line) => line
+  .replace(/\([^)]*e\.g\.[^)]*\)?/g, '')
+  .replace(/→[^|]*/g, '');
+
 const isPlaceholder = (target) => /[<>{}*]|__/.test(target);
 
-// Resolved against the file's realpath, so a symlinked entry point (.claude/CLAUDE.md → .agents/AGENTS.md)
+// Resolved against the file's realpath, so a symlinked entry point (`.claude/CLAUDE.md` → `.agents/AGENTS.md`)
 // resolves its relative links from where the file really lives.
 function resolves(realDir, target) {
   const clean = target.replace(/^\.\//, '');
   return [ path.resolve(realDir, clean), path.resolve(ROOT, clean) ].find((c) => existsSync(c));
+}
+
+// A path that resolves nowhere may still name a real file written short — `toolkit/theme/theme.ts` for
+// `src/toolkit/theme/theme.ts`. Reported only when exactly one tracked file ends with it, which makes the
+// intended file certain; `types/api.ts` matches thirty of them and so asserts no single location to check.
+// Files only: a bare directory such as `hooks/` names a convention every slice follows, not one location,
+// and nothing distinguishes that from shorthand.
+function shorthandFor(target) {
+  const matches = tracked.filter((f) => f.endsWith(`/${ target }`));
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 async function checkFile(fileRel, failures) {
@@ -100,19 +118,27 @@ async function checkFile(fileRel, failures) {
   const lines = withoutFences(await readFile(path.join(ROOT, fileRel), 'utf8'));
 
   for (const [ index, rawLine ] of lines.entries()) {
-    if (ILLUSTRATIVE.test(rawLine)) continue;
+    const report = (message) => failures.push({ file: fileRel, line: index + 1, message });
+    const checkable = withoutIllustrations(rawLine);
 
-    const report = (target, reason) => failures.push({ file: fileRel, line: index + 1, target, reason });
-
-    // Backtick paths anchored at a repo root. Collected first, then stripped, so an inline code span
-    // holding a markdown-link example — `[Link Text](URL)` — is not read as a link.
-    const spans = [ ...rawLine.matchAll(/`([^`]+)`/g) ].map((m) => m[1]);
-    const line = rawLine.replace(/`[^`]+`/g, '');
+    // Backtick paths. Collected first, then stripped, so an inline code span holding a markdown-link
+    // example — `[Link Text](URL)` — is not read as a link.
+    const spans = [ ...checkable.matchAll(/`([^`]+)`/g) ].map((m) => m[1]);
+    const line = checkable.replace(/`[^`]+`/g, '');
 
     for (const target of spans) {
-      if (/\s/.test(target) || isPlaceholder(target)) continue;
-      if (!ANCHORS.some((a) => target.startsWith(a)) || !PATH_EXTENSIONS.test(target)) continue;
-      if (!resolves(realDir, target)) report(target, 'path reference does not exist');
+      if (/\s/.test(target) || isPlaceholder(target) || !target.includes('/')) continue;
+      // A trailing slash marks a directory, a known extension marks a file. Anything else in backticks — a
+      // config key, a dotted token, a fragment of prose — is not a path.
+      if (!target.endsWith('/') && !PATH_EXTENSIONS.test(target)) continue;
+      if (resolves(realDir, target)) continue;
+
+      const full = shorthandFor(target);
+      if (full) {
+        report(`${ target } is shorthand; write it in full: ${ full }`);
+      } else if (target.startsWith('./') || TOP_LEVEL.has(target.split('/')[0])) {
+        report(`path reference does not exist: ${ target }`);
+      }
     }
 
     // Markdown links, with an optional heading anchor.
@@ -125,29 +151,44 @@ async function checkFile(fileRel, failures) {
 
       const resolved = resolves(realDir, filePart);
       if (!resolved) {
-        report(target, 'link target does not exist');
+        report(`link target does not exist: ${ target }`);
       } else if (anchor && resolved.endsWith('.md')) {
         const slugs = await headingSlugs(resolved);
-        if (!slugs.has(anchor.toLowerCase())) report(target, 'heading anchor not found in target');
+        if (!slugs.has(anchor.toLowerCase())) report(`heading anchor not found in target: ${ target }`);
       }
     }
   }
 }
 
-const files = (await Promise.all(ROOTS.map((r) => collectMarkdown(r)))).flat();
-const failures = [];
+const walked = (await Promise.all(ROOTS.map((r) => collectMarkdown(r)))).flat();
+const contexts = tracked.filter((f) => path.basename(f) === 'CONTEXT.md');
 
+// One entry per real file. `.cursor/rules/*.mdc` and `.claude/CLAUDE.md` are symlinks onto files the walk
+// already reached under `.agents`, and checking a file twice reports each of its findings twice.
+const seen = new Map();
+for (const rel of [ ...walked, ...contexts ]) {
+  const real = await realpath(path.join(ROOT, rel));
+  if (!seen.has(real)) seen.set(real, rel);
+}
+const files = [ ...seen.values() ];
+
+const failures = [];
 for (const file of files) {
   await checkFile(file, failures);
 }
 
 if (failures.length > 0) {
-  for (const { file, line, target, reason } of failures) {
+  for (const { file, line, message } of failures) {
     // eslint-disable-next-line no-console
-    console.error(`${ file }:${ line } — ${ reason }: ${ target }`);
+    console.error(`${ file }:${ line } — ${ message }`);
   }
   // eslint-disable-next-line no-console
-  console.error(`\n${ failures.length } unresolved reference(s) across ${ files.length } file(s).`);
+  console.error(
+    `\n${ failures.length } unresolved reference(s) across ${ files.length } file(s).\n` +
+    'A path naming a shape rather than a file has to be marked as one, or it is read as a reference: give ' +
+    'it a <placeholder> segment, put it in an (e.g. …) parenthetical, or place it after a → as the output ' +
+    'of the pattern before it.',
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Description and Related Issue(s)

Follow-up to #3606, which introduced `pnpm lint:doc-links` — the checker that resolves cross-references in the agent instruction surface, so a renamed file cannot silently leave an agent pointed at something that is no longer there.

That checker shipped with three deliberately broad exemptions, chosen to get it to zero false positives on its first run. This measures what each one was actually suppressing. All three turned out to be scoped far wider than the cases they existed for, and the widest of them was hiding real references.

### Proposed Changes

| Exemption | What it was actually buying | Now |
| --- | --- | --- |
| skip whole `*-template.md` files | nothing — suppressed zero findings | removed, +3 files checked |
| skip any line containing `e.g.` or `→` | 147 lines silenced to spare **2** genuine illustrations | scoped to the path, and only inside a table row for `→`; `e.g.` is no longer an exemption at all |
| ignore unanchored paths | 3 references naming a *kind* of file — and 14 naming a real file written short | shorthand is now reported; the 14 are written in full |

**11 references are newly checked** that the whole-line skip used to hide, among them `AGENTS.md`'s own pointers to `GLOSSARY.md`, `registry.json` and `tools/dev-server/CONTEXT.md`.

Shorthand detection is decidable rather than heuristic: a path matching exactly one tracked file names that file (`toolkit/theme/theme.ts` for `src/toolkit/theme/theme.ts`), while `types/api.ts` matching thirty of them asserts no single location worth checking. The split was clean across all 17 unanchored references. Files only — a directory such as `hooks/` is a convention every slice follows, and nothing distinguishes that from shorthand.

Three coverage gaps surfaced while measuring, all fixed here:

- The **10 `CONTEXT.md` files were never scanned**, though `prose-smells.md` and `.cursor/BUGBOT.md` both name them as instruction surface. They are clean as they stand.
- **Every rules file was checked twice**, through its `.cursor/rules/*.mdc` symlink, so each finding printed twice. Deduplicated by realpath: 57 to 49 unique files.
- **Anchored directory references** were skipped for want of a file extension.

Two documentation fixes, both needed to make the tightened rules pass:

- `.agents/rules/design-system.md` wrote all of its paths against an implicit `toolkit/` root that is really `src/toolkit/`, so not one of them resolved from anywhere. 22 paths anchored.
- `policies/app.ts` is now `src/server/csp/policies/app.ts` in the `add-env-var` skill.

One marker remains — a `<placeholder>` segment, or the output side of a `→` inside a table row. It is stated once, in a single string the **failure message** prints, so the convention reaches an author at the moment they trip it and there is no second copy to drift.

`e.g.` was dropped as a marker deliberately. Prose introducing a real file as an example is the common case by far, so exempting the form left live references unprotected against a later rename — the drift this script exists to catch. An example naming no real file gets a placeholder segment instead.

A path resolved against its own directory gets the same protection. Once broken, such a path is indistinguishable from one naming a *kind* of file, so a renamed neighbour used to fail silently; a path whose parent sits beside the file is now read as a reference to that neighbour, which is most of what a `CONTEXT.md` contains.

### Breaking or Incompatible Changes

None for the app — this touches a lint script and the agent instruction files.

Worth knowing for in-flight branches: the checker now fails on things it used to let through. A path written short, a reference sharing a line with an `e.g.` or a prose `→`, a broken neighbour reference, or a broken reference inside a `CONTEXT.md` or a `*-template.md` will now fail `Checks` where it previously passed. A path that names no real file needs a `<placeholder>` segment.

### Additional Information

A green run proves nothing by itself, so each rule was verified to fire:

- A 20-case probe file — 10 references that must be reported, 10 that must stay silent. All 10 fired, all 10 stayed silent.
- The structural changes were proven by temporarily breaking a reference in a `CONTEXT.md`, in a `*-template.md`, and in a symlinked rules file. Each was reported, and the last exactly once.
- Every reference the removed exemptions had been hiding was broken in turn and confirmed to report, and the kind-of-file references (`types/api.ts`, `general/Page.tsx`) confirmed to stay silent when broken.
- Clean run green at 49 files; `eslint` and `cspell` clean.

Both probes were scratch files, deleted after use — there is no committed regression test for the script, which is the notable gap in this change. The checker is now complex enough (path-scoped exemptions, shorthand resolution, realpath deduplication) to deserve one.

Left alone deliberately: `.github` is not a root, since it holds no markdown at all — the `.github/*instructions*` glob in the review skill is forward-looking. Root-relative paths such as `/deploy/` stay unchecked.

## Checklist for PR author
- [x] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
