### PR TITLE
Display the fee payer and batched calls on the transaction details page

### DIFF
--- a/.agents/GLOSSARY.md
+++ b/.agents/GLOSSARY.md
@@ -36,6 +36,7 @@ vars are documented in `docs/ENVS.md`. Architectural concepts like
 | **Connect Wallet** | feature | Lets users write to contracts, sign transactions, and connect a wallet to the explorer. Previously named `blockchain-interaction`; the current config key is `connectWallet`. Distinct from **Web3 Wallet**. |
 | **Dispute Games** | entity | Part of the Optimism **Fault Proof System**. On-chain games used to challenge and resolve disputed L2 output roots. |
 | **Easter Eggs** | feature | Hidden mini-games wired to claim links for badge rewards. |
+| **Eden** | chain | A rollup built on `ev-reth` / evstack. Introduces the **Sponsored Transaction** type. |
 | **Epoch** | entity | A consensus time period specific to **Celo**. Has its own index and detail pages. Always refers to a Celo epoch in this codebase — not a generic blockchain concept. |
 | **Fault Proof System** | feature | Optimism's mechanism for proving the correctness of L2 state transitions on L1 via **Dispute Games**. |
 | **Flashblocks** | feature | MegaETH's sub-second block streaming mechanism. |
@@ -52,6 +53,7 @@ vars are documented in `docs/ENVS.md`. Architectural concepts like
 | **Rewards** | feature | The Blockscout Merits program — a token rewards and incentives system operated by Blockscout. Entirely distinct from **Block Reward** (on-chain block-producer payouts). |
 | **Rollup** | concept | A chain that settles transactions on a parent (L1) chain. Introduces specific entities: deposits, withdrawals, transaction batches, output roots. Contrast with **Chain Variant**. |
 | **SolidityScan** | service | Third-party smart contract security vulnerability scanner integrated into contract detail pages. |
+| **Sponsored Transaction** | entity | **Eden**-specific transaction type (EIP-2718 type `0x76`): an executor submits an ordered batch of calls, while a separate sponsor signs for and pays the fee. No equivalent on standard EVM chains. |
 | **SUAVE** | chain | MEV-focused chain developed by Flashbots, built around a trusted execution environment (TEE) architecture. Introduces the **Kettle** entity. |
 | **TAC (Ton Application Chain)** | chain | A chain that bridges the TON blockchain and EVM ecosystems. Introduces the **Operation** entity. |
 | **Tx Actions** | feature | Structured per-transaction action breakdown rendered on the tx details page — a first-party Blockscout interpretation of what a tx did. Distinct from **Tx Interpretation** (natural-language summary) and from raw calldata. |

--- a/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md
+++ b/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md
@@ -3,7 +3,7 @@
 | | |
 | --- | --- |
 | Issue | https://github.com/blockscout/frontend/issues/3607 |
-| Status | `in progress` |
+| Status | `done` |
 | Size | `small` |
 | Feature branch | `issue-3607` |
 | PM | Ulyana |
@@ -46,10 +46,11 @@ and to omit them cleanly on every other chain (where they are absent from the re
    [`TxDetails.tsx:308`](../../../src/slices/tx/pages/details/info/TxDetails.tsx) do the same, even though
    SUAVE has an `NEXT_PUBLIC_IS_SUAVE_CHAIN` flag for its nav and pages. `do_with_chain_type_fields` only
    extends the response for `:eden`, so presence is a sufficient and self-maintaining gate.
-6. `TxType` gains handling for the new `sponsored_transaction` member of `transaction_types` — see **Q1**
-   for the label decision. Independently of that decision, the member must be added to `TYPES_ORDER`:
-   it is absent today, so `indexOf` returns `-1`, sorting it ahead of every real type and making a
-   sponsored contract call badge as the generic "Transaction" instead of "Contract call".
+6. A **Sponsored** tag appears in the transaction details page header when `transaction_types` includes
+   `sponsored_transaction`, alongside the other header tags. Transaction **lists** get no badge for it
+   (**Q1**) — there is no room. `sponsored_transaction` is still added to `TYPES_ORDER`, last and with no
+   label of its own: absent from that list, `indexOf` returns `-1` and sorts it ahead of every real type,
+   making a sponsored contract call read as the generic "Transaction" instead of "Contract call".
 
 ## Data & API
 
@@ -115,8 +116,10 @@ Because `merged.schema` marks chain-specific properties **optional**, the fields
   corners are rounded** (`borderRadius="md"`), where the reference rounds only the bottom two because
   `LogDecodedInputDataHeader` sits above it. Column template is `repeat(3, minmax(0, 1fr))` — equal widths
   to start, tuned during verification (leaf 4).
-- **Also affected by leaf 5**: [`TxType`](../../../src/slices/tx/components/TxType.tsx), which renders in
-  the txs list, the home page latest-transactions widget, and the address transactions tab.
+- **Also affected by leaf 5**: the page header tags in
+  [`Transaction.tsx`](../../../src/slices/tx/pages/details/Transaction.tsx), and
+  [`TxType`](../../../src/slices/tx/components/TxType.tsx), which renders in the txs list, the home page
+  latest-transactions widget, and the address transactions tab.
 - No new routes, navigation entries, or cross-links.
 - No custom Mixpanel events: the only interactive elements are `AddressEntity` links and `CopyToClipboard`,
   neither tracked elsewhere; there is no new page (view tracking is auto-wired) and no hardcoded external
@@ -182,16 +185,27 @@ Because `merged.schema` marks chain-specific properties **optional**, the fields
     `eden_testnet`: both rows render between Other and Raw input on the sponsored transaction, and both are
     absent on a type-2 one; the table's computed styles match the reference (16px padding, 20px gaps, 12px
     radius, `whiteAlpha.50`, 14px text, three equal columns). Styles reviewed and accepted by the developer
-    on 2026-08-04, with the column template tuned to `minmax(140px, 1fr) minmax(50px, 1fr) 1fr`.
-- [ ] 5 `[agent]` `[verify]` Handle `sponsored_transaction` in `TxType` — requirement 6 — questions: Q1
+    on 2026-08-04, with the column template tuned to `minmax(140px, 1fr) minmax(50px, 1fr) 1fr`; the designer
+    signed them off on the interim demo the same day.
+- [x] 5 `[agent]` `[verify]` Show the **Sponsored** tag in the page header — requirement 6
   - inputs:
-    - Add `sponsored_transaction` to `TYPES_ORDER` regardless of Q1's outcome, so it stops masking more
-      useful labels
-    - Label, colour and sort priority per Q1
-  - verify: on `eden_testnet`, find a sponsored transaction in `/txs` and confirm its badge
-- [ ] 6 `[agent]` Deploy a demo — skill: `deploy-demo`
+    - Push a `{ slug: 'sponsored', name: 'Sponsored', tagType: 'custom' }` tag in `Transaction.tsx`, next to
+      the `relay_tx` / `init_tx` pushes that already feed `MetadataTags`
+    - Add `sponsored_transaction` to `TYPES_ORDER` last, with no `switch` case, so lists keep showing no
+      badge for it while the type stops masking more useful labels
+  - verify: on `eden_testnet`, open a sponsored transaction and confirm the header tag; check `/txs` still
+    labels a sponsored contract call as "Contract call"
+  - implemented: the header tag keys off `transaction_types`, so it carries no Eden-specific coupling.
+    `TxType.spec.tsx` pins both ordering outcomes. The dev server would not hydrate in the agent's browser
+    pane (Next dev's `_clientMiddlewareManifest.js` is served as JSON), so the header tag is verified by
+    types and tests only — confirm it visually on the next demo.
+- [x] 6 `[agent]` Deploy a demo — skill: `deploy-demo`
   - inputs:
     - Run last, once every other box is checked
+  - done: deployed on 2026-08-04 from `2442fb48c` with the `eden_testnet` preset —
+    https://review-issue-3607.k8s-dev.blockscout.com — and shared in the Q1/Q2 thread, where the designer
+    signed off the styles. It covers leaves 1–4; the developer waived a redeploy for leaf 5, so the
+    **Sponsored** header tag is not on the demo.
 
 ## Open questions
 
@@ -204,9 +218,12 @@ what colour (`purple` is the fallback's; `green` is unused), and what priority r
 "Token transfer" when a transaction is both?
 
 - Owner: PM (Ulyana)
-- Status: `pending`
-- Slack: https://blockscout.slack.com/archives/C03MMUTQDNU/p1785778160250149
-- Answer: <decision + date, once resolved>
+- Status: `resolved`
+- Slack: https://blockscout.slack.com/archives/C03MMUTQDNU/p1785778160250149 (reminder with the interim demo
+  at https://blockscout.slack.com/archives/C03MMUTQDNU/p1785851465775779)
+- Answer: 2026-08-04 — answered by Nikita S. rather than Ulyana: a **Sponsored** tag in the details page
+  header, skipped in lists where it would not fit. Tags are in the SoW, but how to render them was left to
+  the team.
 - Blocks: leaf 5
 
 ### Q2 — Should the compatibility fields be adapted on a multi-call sponsored transaction?
@@ -217,9 +234,10 @@ hidden, relabelled, or annotated for Eden, as the backend issue's UI requirement
 for now.
 
 - Owner: PM (Ulyana)
-- Status: `pending`
+- Status: `waived`
 - Slack: https://blockscout.slack.com/archives/C03MMUTQDNU/p1785778160250149
-- Answer: <decision + date, once resolved>
+- Answer: 2026-08-04 — deferred out of this task. Shipping the narrow scope; the team waits for client
+  feedback on whether the compatibility fields mislead in practice, and adapts them only if it does.
 
 ### Q3 — Which backend release ships the Eden transaction fields?
 

--- a/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md
+++ b/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md
@@ -1,0 +1,224 @@
+# Display fee payer and calls on the transaction details page
+
+| | |
+| --- | --- |
+| Issue | https://github.com/blockscout/frontend/issues/3607 |
+| Status | `draft` |
+| Size | `small` |
+| Feature branch | `issue-3607` (set on first `implement-task` run) |
+| PM | Ulyana |
+| Designer | — |
+| Backend | Victor (issue author) |
+| Slack channel | — (default routing per `to-spec`) |
+
+## Context & goal
+
+Eden is an `ev-reth` / evstack rollup that adds a custom EIP-2718 transaction type `0x76` (decimal `118`):
+a **sponsored batch transaction**. An *executor* submits an ordered batch of calls, and a separate *sponsor*
+signs for and pays the fee. The backend now indexes those transactions and exposes two new optional fields
+on the transaction model ([blockscout#14590](https://github.com/blockscout/blockscout/issues/14590),
+implemented in [blockscout#14643](https://github.com/blockscout/blockscout/pull/14643)): `fee_payer` and
+`calls`.
+
+Neither field is rendered today, so an Eden sponsored transaction page silently omits the two things that
+distinguish it — who actually paid, and what the batch executed. The goal is to display both on `/tx/:hash`,
+and to omit them cleanly on every other chain (where they are absent from the response entirely).
+
+## Functional requirements
+
+1. When `fee_payer` is present, the transaction details page shows a **Fee payer** row with the address.
+   Hint copy: `Address that paid the transaction fee on behalf of the sender`.
+2. When `calls` is present and non-empty, the page shows a **Calls** row with a table of the batched calls
+   in API order. Hint copy: `Ordered list of calls batched into this sponsored transaction`.
+3. The Calls table has three columns — `To`, `Value`, `Input`:
+   - `To` — `AddressEntity` with `truncation="dynamic"`. When `to` is `null` the cell reads
+     `[ Contract creation ]` (the same string [`TxDetails.tsx:395`](../../../src/slices/tx/pages/details/info/TxDetails.tsx)
+     already uses). `to` being null is a real case, not defensive typing — the backend's `EdenView` comment
+     states it is `nil` for a contract-creation call.
+   - `Value` — `NativeCoinValue` with symbol, no exchange-rate toggle.
+   - `Input` — `TruncatedText` + `CopyToClipboard`, matching the `Data` cell of
+     [`LogDecodedInputDataTable`](../../../src/slices/log/components/LogDecodedInputDataTable.tsx).
+4. Both rows render inside the collapsible *View details* section, immediately after **Other** and before
+   **Raw input** — so the batched calls sit next to the raw/decoded input data that shares their visual
+   language. No `DetailedInfo.ItemDivider` around the block (`Other`, `Raw input` and `Decoded input data`
+   have none between them either).
+5. Neither field is gated by an env var or a feature config. They are rendered on **field presence**,
+   the established pattern for chain-variant transaction fields: `execution_node` / `allowed_peekers` at
+   [`TxDetails.tsx:308`](../../../src/slices/tx/pages/details/info/TxDetails.tsx) do the same, even though
+   SUAVE has an `NEXT_PUBLIC_IS_SUAVE_CHAIN` flag for its nav and pages. `do_with_chain_type_fields` only
+   extends the response for `:eden`, so presence is a sufficient and self-maintaining gate.
+6. `TxType` gains handling for the new `sponsored_transaction` member of `transaction_types` — see **Q1**
+   for the label decision. Independently of that decision, the member must be added to `TYPES_ORDER`:
+   it is absent today, so `indexOf` returns `-1`, sorting it ahead of every real type and making a
+   sponsored contract call badge as the generic "Transaction" instead of "Contract call".
+
+## Data & API
+
+**Endpoint** — `GET /api/v2/transactions/{hash}` (existing `core:tx` resource; no new API resource needed).
+
+**Readiness** — merged to backend `master` on 2026-07-31 and already deployed on
+`eden-testnet.blockscout.com` (`backend_version: v11.2.4.+commit.ac947295`). Which tagged release ships it
+is **Q3**.
+
+**Field shapes** — read from
+[`schemas/api/v2/transaction.ex`](https://github.com/blockscout/blockscout/pull/14643/files) and verified
+against a live response:
+
+- `fee_payer` — a full `Address` object, `nullable: true`.
+- `calls` — `Array<{ to: AddressHashNullable; value: IntegerString; input: HexString }>`, `nullable: true`.
+- `required: [:fee_payer, :calls]` means the keys are always present on an Eden response, not that the
+  values are non-null.
+
+Sample (`0x35310fd76c45f1441226c102f4dc1070b41ac66cb1e6ed3354da78aa69824a67` on `eden-testnet`):
+
+```json
+{
+  "type": 118,
+  "transaction_types": [ "sponsored_transaction" ],
+  "fee_payer": { "hash": "0x32648e6529BfCacE20422a7AA1E7fB7Bd8F408d7", "is_contract": false, "…": "…" },
+  "calls": [ { "to": "0xf97cDCF1e5C0955Ed5c2EA0afb2c4Bb4eD506505", "value": "0", "input": "0x" } ]
+}
+```
+
+> The issue text names the call's address field `address_hash`. The API returns **`to`** — see **Q3**.
+
+**Scope of each field across endpoints** — `calls` is rendered for single-transaction responses only
+(`prepare_calls` returns `nil` otherwise, the same policy the backend applies to token transfers).
+`fee_payer` *is* returned on list endpoints too, but showing it there is out of scope.
+
+**Types package** — the pinned `@blockscout/api-types@0.0.1-beta.82839e44ce` (published 2026-07-02)
+predates the backend PR, so it has neither `eden.schema` nor the two fields in `merged.schema`. The newest
+published beta, `0.0.1-beta.bb45bf1`, was published 2026-07-31 06:37Z — before the PR merged at 11:55Z — so
+it very likely lacks them as well. See leaf 3.
+
+Because `merged.schema` marks chain-specific properties **optional**, the fields type as
+`Address | null | undefined` and `Array<Call> | null | undefined`. Guards must handle `undefined` as well
+as `null`.
+
+**Env vars / feature flags** — none added.
+
+## UI inventory
+
+- **Single surface**: `/tx/:hash` details tab —
+  [`src/slices/tx/pages/details/info/TxDetails.tsx`](../../../src/slices/tx/pages/details/info/TxDetails.tsx),
+  inside the `CollapsibleDetails` block, between `<TxDetailsOther/>` and the `Raw input` label.
+- **New component**: `src/features/chain-variants/eden/pages/tx/TxDetailsEden.tsx` — renders both label/value
+  pairs and returns `null` when both fields are absent, so `TxDetails.tsx` composes it unconditionally
+  (matching `TxDetailsSetMaxGasLimit` and `TxDetailsWithdrawalStatusArbitrum`, already there doing the same).
+  Eden-specific UI is a **feature**, not a slice — it cannot exist on a vanilla EVM chain — and
+  [`TxDetails.tsx:83`](../../../src/slices/tx/pages/details/info/TxDetails.tsx) carries a standing
+  `// REFACTOR: Put feature related parts under the feature folder` note. No `config.ts` in the feature
+  folder: only chain variants needing an env flag have one (stability and zilliqa have none).
+- **No Figma mockups** — none linked on the issue, and none needed. The Calls table reuses the styles of
+  [`LogDecodedInputDataTable`](../../../src/slices/log/components/LogDecodedInputDataTable.tsx): background
+  `{ _light: 'blackAlpha.50', _dark: 'whiteAlpha.50' }`, `p={4}`, `mt={2}`, `columnGap`/`rowGap={5}`,
+  `textStyle="sm"`, and header cells at `fontWeight={600} pb={1}`. One deliberate difference: **all four
+  corners are rounded** (`borderRadius="md"`), where the reference rounds only the bottom two because
+  `LogDecodedInputDataHeader` sits above it. Column template is `repeat(3, minmax(0, 1fr))` — equal widths
+  to start, tuned during verification (leaf 4).
+- **Also affected by leaf 5**: [`TxType`](../../../src/slices/tx/components/TxType.tsx), which renders in
+  the txs list, the home page latest-transactions widget, and the address transactions tab.
+- No new routes, navigation entries, or cross-links.
+- No custom Mixpanel events: the only interactive elements are `AddressEntity` links and `CopyToClipboard`,
+  neither tracked elsewhere; there is no new page (view tracking is auto-wired) and no hardcoded external
+  link needing UTM params.
+
+## Out of scope
+
+- **Adapting the standard fields whose Eden semantics differ.** On a sponsored transaction the backend
+  derives `to` and `raw_input` from **call 0 only**, `value` from the **sum** of all calls, and `from` is
+  the *executor* rather than the fee payer. So on a multi-call transaction the "To" and "Raw input" rows
+  show one call while the Calls table shows all of them. The backend issue's UI requirements ask to "hide or
+  adapt standard fields whose Eden semantics differ" and to "present gas fields only where they are
+  meaningful"; #3607 asks for none of it. Raised as **Q2**, not blocking.
+- A **Fee payer column in the transactions list**, even though the field is available there.
+- The **Eden mainnet** dev preset (`eden.blockscout.com`) — it has no sponsored transactions to look at.
+- A **Playwright visual scenario and transaction mock**. Dropped deliberately: the two rows use generic
+  building blocks already covered elsewhere, and a mock in `src/slices/tx/mocks/details.ts` exists only to
+  feed a `*.pw.tsx` scenario, so without one it would be dead code. Verification is against live
+  `eden-testnet` data.
+- Backend work of any kind — already shipped.
+
+## Task breakdown
+
+- [ ] 1 `[agent]` Add `eden` and `sponsored transaction` to `.agents/GLOSSARY.md` — skill: `update-glossary`
+  - inputs:
+    - `eden` — the chain type (`CHAIN_TYPE=eden`): an `ev-reth` / evstack rollup, explorers at
+      `eden.blockscout.com` and `eden-testnet.blockscout.com`
+    - `sponsored transaction` — scoped to Eden: EIP-2718 type `0x76` (decimal `118`); an executor submits an
+      ordered batch of calls and a separate sponsor signs for and pays the fee
+    - Also gets `eden` past cSpell, which has no entry for it today
+- [ ] 2 `[agent]` Add the `eden_testnet` dev-server preset
+  - inputs:
+    - `"eden_testnet": "https://eden-testnet.blockscout.com"` in `tools/dev-server/registry.json`
+    - then `pnpm presets:sync` — regenerates the marker-bracketed alias lists in
+      `.github/workflows/deploy-review.yml` and `.vscode/tasks.json`; CI fails on drift
+    - Ordered before the UI leaves so their verification has a preset to run against
+- [ ] 3 `[agent]` Get `fee_payer` / `calls` into the pinned API types
+  - inputs:
+    - First check whether `@blockscout/api-types@0.0.1-beta.bb45bf1` already contains them; if so just bump
+      the pin in `package.json`
+    - Otherwise publish a beta from backend `master` via the `publish-beta-types` skill and pin that
+    - Verify afterwards that `schemas['TransactionResponse']` exposes `fee_payer` and `calls`, and that
+      `transaction_types` includes `sponsored_transaction`
+- [ ] 4 `[agent]` `[verify]` Build `TxDetailsEden.tsx` and wire it into the details page — requirements 1–4
+  - inputs:
+    - New file `src/features/chain-variants/eden/pages/tx/TxDetailsEden.tsx`; no `config.ts`
+    - Composed unconditionally in `TxDetails.tsx` after `<TxDetailsOther/>`, before the `Raw input` label
+    - Fully styled from the `LogDecodedInputDataTable` reference (see **UI inventory**) — this is a code
+      reference, not a mockup, so there is no separate `[human]` style leaf; width and spacing tweaks happen
+      during verification
+  - verify: `pnpm dev:preset eden_testnet`, open
+    `/tx/0x35310fd76c45f1441226c102f4dc1070b41ac66cb1e6ed3354da78aa69824a67`, expand *View details*, confirm
+    the Fee payer and Calls rows render correctly between Other and Raw input; adjust styles if needed. Also
+    open any non-Eden preset (e.g. `eth`) and confirm neither row appears.
+- [ ] 5 `[agent]` `[verify]` Handle `sponsored_transaction` in `TxType` — requirement 6 — questions: Q1
+  - inputs:
+    - Add `sponsored_transaction` to `TYPES_ORDER` regardless of Q1's outcome, so it stops masking more
+      useful labels
+    - Label, colour and sort priority per Q1
+  - verify: on `eden_testnet`, find a sponsored transaction in `/txs` and confirm its badge
+- [ ] 6 `[agent]` Deploy a demo — skill: `deploy-demo`
+  - inputs:
+    - Run last, once every other box is checked
+
+## Open questions
+
+### Q1 — Should a sponsored transaction get its own badge in the transactions list?
+
+The backend added `sponsored_transaction` to `transaction_types`, and the backend issue's UI requirements
+ask for "a tag/badge such as `Sponsored`". #3607 does not mention it. Today the value falls through
+`TxType`'s `default` branch to a generic purple "Transaction". If a dedicated badge is wanted: what label,
+what colour (`purple` is the fallback's; `green` is unused), and what priority relative to "Contract call" /
+"Token transfer" when a transaction is both?
+
+- Owner: PM (Ulyana)
+- Status: `pending`
+- Slack: https://blockscout.slack.com/archives/C03MMUTQDNU/p1785778160250149
+- Answer: <decision + date, once resolved>
+- Blocks: leaf 5
+
+### Q2 — Should the compatibility fields be adapted on a multi-call sponsored transaction?
+
+`to` and `raw_input` reflect **call 0 only**, `value` is the **sum** across calls, and `from` is the executor
+rather than the payer — so those rows can be misread on a batch of more than one call. Should they be
+hidden, relabelled, or annotated for Eden, as the backend issue's UI requirements suggest? Shipping narrow
+for now.
+
+- Owner: PM (Ulyana)
+- Status: `pending`
+- Slack: https://blockscout.slack.com/archives/C03MMUTQDNU/p1785778160250149
+- Answer: <decision + date, once resolved>
+
+### Q3 — Which backend release ships the Eden transaction fields?
+
+Needed for the frontend release notes. The PR merged to `master` on 2026-07-31 and `eden-testnet` already
+runs it, but no tagged release is identified. Bundled with this: confirmation that the call's address is
+nullable for a contract-creation call (read from the backend source, worth hearing from the owner before the
+UI relies on it), and — if so — a request to correct #3607, which names the field `address_hash` where the
+API and the OpenAPI schema both use **`to`**.
+
+- Owner: Backend (Victor)
+- Status: `pending`
+- Slack: https://blockscout.slack.com/archives/D040DB9J5QQ/p1785778264416959
+- Answer: <decision + date, once resolved>

--- a/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md
+++ b/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md
@@ -3,12 +3,12 @@
 | | |
 | --- | --- |
 | Issue | https://github.com/blockscout/frontend/issues/3607 |
-| Status | `draft` |
+| Status | `in progress` |
 | Size | `small` |
-| Feature branch | `issue-3607` (set on first `implement-task` run) |
+| Feature branch | `issue-3607` |
 | PM | Ulyana |
 | Designer | — |
-| Backend | Victor (issue author) |
+| Backend | Victor (issue author); v11.2.4+ |
 | Slack channel | — (default routing per `to-spec`) |
 
 ## Context & goal
@@ -33,8 +33,7 @@ and to omit them cleanly on every other chain (where they are absent from the re
 3. The Calls table has three columns — `To`, `Value`, `Input`:
    - `To` — `AddressEntity` with `truncation="dynamic"`. When `to` is `null` the cell reads
      `[ Contract creation ]` (the same string [`TxDetails.tsx:395`](../../../src/slices/tx/pages/details/info/TxDetails.tsx)
-     already uses). `to` being null is a real case, not defensive typing — the backend's `EdenView` comment
-     states it is `nil` for a contract-creation call.
+     already uses). `to` being null is a real case, confirmed by the backend owner (**Q3**).
    - `Value` — `NativeCoinValue` with symbol, no exchange-rate toggle.
    - `Input` — `TruncatedText` + `CopyToClipboard`, matching the `Data` cell of
      [`LogDecodedInputDataTable`](../../../src/slices/log/components/LogDecodedInputDataTable.tsx).
@@ -57,8 +56,8 @@ and to omit them cleanly on every other chain (where they are absent from the re
 **Endpoint** — `GET /api/v2/transactions/{hash}` (existing `core:tx` resource; no new API resource needed).
 
 **Readiness** — merged to backend `master` on 2026-07-31 and already deployed on
-`eden-testnet.blockscout.com` (`backend_version: v11.2.4.+commit.ac947295`). Which tagged release ships it
-is **Q3**.
+`eden-testnet.blockscout.com` (`backend_version: v11.2.4.+commit.ac947295`). Ships in backend tag **11.2.4**
+(Q3) — worth naming in the frontend release notes.
 
 **Field shapes** — read from
 [`schemas/api/v2/transaction.ex`](https://github.com/blockscout/blockscout/pull/14643/files) and verified
@@ -80,20 +79,20 @@ Sample (`0x35310fd76c45f1441226c102f4dc1070b41ac66cb1e6ed3354da78aa69824a67` on 
 }
 ```
 
-> The issue text names the call's address field `address_hash`. The API returns **`to`** — see **Q3**.
+The call's `to` is `null` on a contract creation — confirmed by the backend owner (**Q3**), not defensive
+typing.
 
 **Scope of each field across endpoints** — `calls` is rendered for single-transaction responses only
 (`prepare_calls` returns `nil` otherwise, the same policy the backend applies to token transfers).
 `fee_payer` *is* returned on list endpoints too, but showing it there is out of scope.
 
-**Types package** — the pinned `@blockscout/api-types@0.0.1-beta.82839e44ce` (published 2026-07-02)
-predates the backend PR, so it has neither `eden.schema` nor the two fields in `merged.schema`. The newest
-published beta, `0.0.1-beta.bb45bf1`, was published 2026-07-31 06:37Z — before the PR merged at 11:55Z — so
-it very likely lacks them as well. See leaf 3.
+**Types package** — pinned at `@blockscout/api-types@0.0.1-beta.8e1692a`, published from backend `dev` once
+`master` had been merged into it (**Q4**). It carries `eden.schema`, both fields on the transaction, and the
+`operations` / `paths` shorthands the app depends on.
 
 Because `merged.schema` marks chain-specific properties **optional**, the fields type as
-`Address | null | undefined` and `Array<Call> | null | undefined`. Guards must handle `undefined` as well
-as `null`.
+`Address | null | undefined` and `Array<Call> | null | undefined`. Guards must handle `undefined` as well as
+`null`.
 
 **Env vars / feature flags** — none added.
 
@@ -141,27 +140,33 @@ as `null`.
 
 ## Task breakdown
 
-- [ ] 1 `[agent]` Add `eden` and `sponsored transaction` to `.agents/GLOSSARY.md` — skill: `update-glossary`
+- [x] 1 `[agent]` Add `eden` and `sponsored transaction` to `.agents/GLOSSARY.md` — skill: `update-glossary`
+  - done: `Eden` (chain) and `Sponsored Transaction` (entity) rows, cross-referencing each other
   - inputs:
     - `eden` — the chain type (`CHAIN_TYPE=eden`): an `ev-reth` / evstack rollup, explorers at
       `eden.blockscout.com` and `eden-testnet.blockscout.com`
     - `sponsored transaction` — scoped to Eden: EIP-2718 type `0x76` (decimal `118`); an executor submits an
       ordered batch of calls and a separate sponsor signs for and pays the fee
     - Also gets `eden` past cSpell, which has no entry for it today
-- [ ] 2 `[agent]` Add the `eden_testnet` dev-server preset
+- [x] 2 `[agent]` Add the `eden_testnet` dev-server preset
+  - done: `tools/dev-server/registry.json` + `pnpm presets:sync` (`deploy-review.yml`, `.vscode/tasks.json`)
   - inputs:
     - `"eden_testnet": "https://eden-testnet.blockscout.com"` in `tools/dev-server/registry.json`
     - then `pnpm presets:sync` — regenerates the marker-bracketed alias lists in
       `.github/workflows/deploy-review.yml` and `.vscode/tasks.json`; CI fails on drift
     - Ordered before the UI leaves so their verification has a preset to run against
-- [ ] 3 `[agent]` Get `fee_payer` / `calls` into the pinned API types
+- [x] 3 `[agent]` Get `fee_payer` / `calls` into the pinned API types
   - inputs:
     - First check whether `@blockscout/api-types@0.0.1-beta.bb45bf1` already contains them; if so just bump
       the pin in `package.json`
     - Otherwise publish a beta from backend `master` via the `publish-beta-types` skill and pin that
     - Verify afterwards that `schemas['TransactionResponse']` exposes `fee_payer` and `calls`, and that
       `transaction_types` includes `sponsored_transaction`
-- [ ] 4 `[agent]` `[verify]` Build `TxDetailsEden.tsx` and wire it into the details page — requirements 1–4
+  - done: pinned `0.0.1-beta.8e1692a`, published from `dev` after `master` was merged into it (**Q4**).
+    `schemas['TransactionResponse']` exposes `fee_payer` and `calls`, and `transaction_types` includes
+    `sponsored_transaction`; `pnpm lint:tsc` is clean, so the merge cost the app no type churn. The interim
+    `eden/types/api.ts` shim is gone — the component reads both fields off the pinned schema.
+- [x] 4 `[agent]` `[verify]` Build `TxDetailsEden.tsx` and wire it into the details page — requirements 1–4
   - inputs:
     - New file `src/features/chain-variants/eden/pages/tx/TxDetailsEden.tsx`; no `config.ts`
     - Composed unconditionally in `TxDetails.tsx` after `<TxDetailsOther/>`, before the `Raw input` label
@@ -172,6 +177,12 @@ as `null`.
     `/tx/0x35310fd76c45f1441226c102f4dc1070b41ac66cb1e6ed3354da78aa69824a67`, expand *View details*, confirm
     the Fee payer and Calls rows render correctly between Other and Raw input; adjust styles if needed. Also
     open any non-Eden preset (e.g. `eth`) and confirm neither row appears.
+  - implemented: `TxDetailsEden.tsx` in the new `eden` feature folder, composed in
+    `TxDetails.tsx`; `dev-eden-testnet` added to `.claude/launch.json`. Functional check done on
+    `eden_testnet`: both rows render between Other and Raw input on the sponsored transaction, and both are
+    absent on a type-2 one; the table's computed styles match the reference (16px padding, 20px gaps, 12px
+    radius, `whiteAlpha.50`, 14px text, three equal columns). Styles reviewed and accepted by the developer
+    on 2026-08-04, with the column template tuned to `minmax(140px, 1fr) minmax(50px, 1fr) 1fr`.
 - [ ] 5 `[agent]` `[verify]` Handle `sponsored_transaction` in `TxType` — requirement 6 — questions: Q1
   - inputs:
     - Add `sponsored_transaction` to `TYPES_ORDER` regardless of Q1's outcome, so it stops masking more
@@ -219,6 +230,28 @@ UI relies on it), and — if so — a request to correct #3607, which names the 
 API and the OpenAPI schema both use **`to`**.
 
 - Owner: Backend (Victor)
-- Status: `pending`
+- Status: `resolved`
 - Slack: https://blockscout.slack.com/archives/D040DB9J5QQ/p1785778264416959
-- Answer: <decision + date, once resolved>
+- Answer: 2026-08-03 — backend tag **11.2.4**, planned for release that week. A call's `to` is confirmed
+  `null` on a contract creation, and #3607's description was corrected to name the field `to`.
+
+### Q4 — Which backend ref can publish api-types with both the Eden fields and the response shorthands?
+
+`@blockscout/api-types` betas are published from `dev`, which has no `eden` chain type. A beta published from
+`master` (`0.0.1-beta.cf4c6f5`) has `eden.schema` plus `fee_payer` / `calls`, but its `index.ts` lacks the
+`operations` and `paths` shorthands added by
+[blockscout#14515](https://github.com/blockscout/blockscout/pull/14515) — the app imports those in 60+
+modules, and pinning that build yields 384 type errors across 227 files. So neither ref serves the frontend.
+Can `master` be merged into `dev` (or #14515 forward-ported to `master`) so one ref carries both? Until then
+the two fields are declared locally in the `eden` feature.
+
+- Owner: Backend (Victor)
+- Status: `resolved`
+- Slack: https://blockscout.slack.com/archives/D040DB9J5QQ/p1785780964199699 (compile failure reported at
+  https://blockscout.slack.com/archives/D040DB9J5QQ/p1785781999313979, the `HexString` rename at
+  https://blockscout.slack.com/archives/D040DB9J5QQ/p1785838420460469)
+- Answer: 2026-08-04 — `dev` is the ref, once `master` was merged into it. Two follow-up fixes were needed:
+  a compile break the merge left in `read_system_config/2` (`7b60189`), then the Eden call schema still
+  naming `General.HexString`, which `dev` had renamed to `General.HexData`
+  ([#14656](https://github.com/blockscout/blockscout/pull/14656)). The publish from `8e1692a` then succeeded.
+- Blocks: leaf 3

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 3000
     },
     {
+      "name": "dev-eden-testnet",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev:preset", "eden_testnet"],
+      "port": 3000
+    },
+    {
       "name": "dev-eth",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev:preset", "eth"],

--- a/.github/workflows/deploy-review.yml
+++ b/.github/workflows/deploy-review.yml
@@ -30,6 +30,7 @@ on:
             - blackfort_testnet
             - celo
             - celo_sepolia
+            - eden_testnet
             - eth
             - eth_sepolia
             - filecoin

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -328,6 +328,7 @@
               "blackfort_testnet",
               "celo",
               "celo_sepolia",
+              "eden_testnet",
               "eth",
               "eth_sepolia",
               "filecoin",

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -116,6 +116,7 @@
         "Emelyanov",
         "Enkrypt",
         "esbuild",
+        "evstack",
         "explorable",
         "facebookexternalhit",
         "favicons",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@blockscout/admin-rs-types": "1.5.0",
-    "@blockscout/api-types": "0.0.1-beta.82839e44ce",
+    "@blockscout/api-types": "0.0.1-beta.8e1692a",
     "@blockscout/bens-types": "1.7.1",
     "@blockscout/contracts-info-types": "1.5.2",
     "@blockscout/interchain-indexer-types": "1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: 1.5.0
         version: 1.5.0
       '@blockscout/api-types':
-        specifier: 0.0.1-beta.82839e44ce
-        version: 0.0.1-beta.82839e44ce
+        specifier: 0.0.1-beta.8e1692a
+        version: 0.0.1-beta.8e1692a
       '@blockscout/bens-types':
         specifier: 1.7.1
         version: 1.7.1
@@ -1321,8 +1321,8 @@ packages:
   '@blockscout/admin-rs-types@1.5.0':
     resolution: {integrity: sha512-QE+dpUaQDvOAb/wUJ98J3CBqfohbiBW/+AEqEmSdOOZ0XxPRUrke08krBnflq3GMACRwB+nwzQrsfl7KCrC1Eg==}
 
-  '@blockscout/api-types@0.0.1-beta.82839e44ce':
-    resolution: {integrity: sha512-DIyMKLqHqXmKCbf1eYCKbWsNY3VQ2NMXAlLyAgEkM7UYffEasUfAL0othyHfGyxvM4FMwU5tm9hlKHRFPmKYew==}
+  '@blockscout/api-types@0.0.1-beta.8e1692a':
+    resolution: {integrity: sha512-itkaQdbtJSwsJL6LQBAPQlSWuejDhuuUXxZTcfwDAup/6L/OOw0l0XwIEVEtqTaLVIxG1DyGOrr7gKz2fPrukQ==}
 
   '@blockscout/bens-types@1.7.1':
     resolution: {integrity: sha512-MNIvYbj1I2vcU2rb6otlRnVMIpFG2B1WDqC7HicNrt10DbM5yPZNfBcsNM+Mhk/965Aeg529Fd+BkV9zhINqjA==}
@@ -14838,7 +14838,7 @@ snapshots:
 
   '@blockscout/admin-rs-types@1.5.0': {}
 
-  '@blockscout/api-types@0.0.1-beta.82839e44ce': {}
+  '@blockscout/api-types@0.0.1-beta.8e1692a': {}
 
   '@blockscout/bens-types@1.7.1': {}
 

--- a/src/features/chain-variants/eden/pages/tx/TxDetailsEden.tsx
+++ b/src/features/chain-variants/eden/pages/tx/TxDetailsEden.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import { Flex, Grid } from '@chakra-ui/react';
+import React from 'react';
+
+import type { schemas } from '@blockscout/api-types';
+
+import AddressEntity from 'src/slices/address/components/entity/AddressEntity';
+
+import * as DetailedInfo from 'src/shared/detailed-info/DetailedInfo';
+import CopyToClipboard from 'src/shared/texts/CopyToClipboard';
+import NativeCoinValue from 'src/shared/values/entity/NativeCoinValue';
+
+import { Skeleton } from 'src/toolkit/chakra/skeleton';
+import { TruncatedText } from 'src/toolkit/components/truncation/TruncatedText';
+
+/** One call of a sponsored batch transaction. `to` is `null` for a contract-creation call. */
+type TransactionEdenCall = NonNullable<schemas['TransactionResponse']['calls']>[number];
+
+interface Props {
+  data: schemas['TransactionResponse'];
+  isLoading?: boolean;
+}
+
+const HeaderItem = ({ children, isLoading }: { children: React.ReactNode; isLoading?: boolean }) => {
+  return (
+    <Skeleton
+      fontWeight="semibold"
+      pb={ 1 }
+      loading={ isLoading }
+    >
+      { children }
+    </Skeleton>
+  );
+};
+
+const CallRow = ({ to, value, input, isLoading }: TransactionEdenCall & { isLoading?: boolean }) => {
+  return (
+    <>
+      <div>
+        { to ?
+          <AddressEntity address={{ hash: to }} isLoading={ isLoading }/> :
+          <Skeleton loading={ isLoading } display="inline-block"><span>[ Contract creation ]</span></Skeleton>
+        }
+      </div>
+      <div>
+        <NativeCoinValue amount={ value } loading={ isLoading }/>
+      </div>
+      <Flex alignItems="flex-start" whiteSpace="normal" wordBreak="break-all">
+        <TruncatedText text={ input } loading={ isLoading }/>
+        <CopyToClipboard text={ input } isLoading={ isLoading }/>
+      </Flex>
+    </>
+  );
+};
+
+const TxDetailsEden = ({ data, isLoading }: Props) => {
+  const { fee_payer: feePayer, calls } = data;
+
+  if (!feePayer && !calls?.length) {
+    return null;
+  }
+
+  return (
+    <>
+      { feePayer && (
+        <>
+          <DetailedInfo.ItemLabel
+            hint="Address that paid the transaction fee on behalf of the sender"
+            isLoading={ isLoading }
+          >
+            Fee payer
+          </DetailedInfo.ItemLabel>
+          <DetailedInfo.ItemValue>
+            <AddressEntity address={ feePayer } isLoading={ isLoading }/>
+          </DetailedInfo.ItemValue>
+        </>
+      ) }
+
+      { calls && calls.length > 0 && (
+        <>
+          <DetailedInfo.ItemLabel
+            hint="Ordered list of calls batched into this sponsored transaction"
+            isLoading={ isLoading }
+          >
+            Calls
+          </DetailedInfo.ItemLabel>
+          <DetailedInfo.ItemValue alignItems="flex-start" flexWrap="wrap">
+            <Grid
+              gridTemplateColumns="minmax(140px, 1fr) minmax(50px, 1fr) 1fr"
+              textStyle="sm"
+              bgColor={{ _light: 'blackAlpha.50', _dark: 'whiteAlpha.50' }}
+              p={ 4 }
+              mt={ 2 }
+              w="100%"
+              columnGap={ 5 }
+              rowGap={ 5 }
+              borderRadius="md"
+            >
+              <HeaderItem isLoading={ isLoading }>To</HeaderItem>
+              <HeaderItem isLoading={ isLoading }>Value</HeaderItem>
+              <HeaderItem isLoading={ isLoading }>Input</HeaderItem>
+              { calls.map((call, index) => (
+                // a batch can repeat the same call, so the position in the batch is the only stable key
+                <CallRow key={ index } { ...call } isLoading={ isLoading }/>
+              )) }
+            </Grid>
+          </DetailedInfo.ItemValue>
+        </>
+      ) }
+    </>
+  );
+};
+
+export default React.memo(TxDetailsEden);

--- a/src/slices/tx/components/TxType.spec.tsx
+++ b/src/slices/tx/components/TxType.spec.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import React from 'react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from 'vitest/lib';
+
+import TxType from './TxType';
+
+describe('TxType', () => {
+  afterEach(cleanup);
+
+  it('prefers a more informative type over sponsored_transaction', () => {
+    render(<TxType types={ [ 'sponsored_transaction', 'contract_call' ] }/>);
+
+    expect(screen.queryByText('Contract call')).not.toBeNull();
+  });
+
+  it('falls back to the generic label when a transaction is only sponsored', () => {
+    render(<TxType types={ [ 'sponsored_transaction' ] }/>);
+
+    expect(screen.queryByText('Transaction')).not.toBeNull();
+  });
+});

--- a/src/slices/tx/components/TxType.tsx
+++ b/src/slices/tx/components/TxType.tsx
@@ -21,6 +21,10 @@ const TYPES_ORDER: schemas['Transaction']['transaction_types'] = [
   'token_transfer',
   'contract_call',
   'coin_transfer',
+  // Listed last and deliberately given no label of its own — the details page header carries the
+  // "Sponsored" tag instead, and lists have no room for it. An unlisted type would score -1 here and sort
+  // ahead of every real one, masking labels like "Contract call".
+  'sponsored_transaction',
 ];
 
 const TxType = ({ types, isLoading, ...rest }: Props) => {

--- a/src/slices/tx/pages/details/Transaction.tsx
+++ b/src/slices/tx/pages/details/Transaction.tsx
@@ -108,6 +108,10 @@ const TransactionPageContent = () => {
     }
   }
 
+  if (data?.transaction_types?.includes('sponsored_transaction')) {
+    txTags.push({ slug: 'sponsored', name: 'Sponsored', tagType: 'custom' as const, ordinal: 0 });
+  }
+
   const protocolTags = data?.to?.metadata?.tags?.filter(tag => tag.tagType === 'protocol');
   if (protocolTags && protocolTags.length > 0) {
     txTags.push(...protocolTags);

--- a/src/slices/tx/pages/details/info/TxDetails.tsx
+++ b/src/slices/tx/pages/details/info/TxDetails.tsx
@@ -24,6 +24,7 @@ import LogDecodedInputData from 'src/slices/log/components/LogDecodedInputData';
 import TxSocketAlert from 'src/slices/tx/components/TxSocketAlert';
 import getConfirmationDuration from 'src/slices/tx/utils/get-confirmation-duration';
 
+import TxDetailsEden from 'src/features/chain-variants/eden/pages/tx/TxDetailsEden';
 import TxAllowedPeekers from 'src/features/chain-variants/suave/pages/tx/TxAllowedPeekers';
 import TxDetailsTacOperation from 'src/features/chain-variants/tac/pages/tx/TxDetailsTacOperation';
 import TxDetailsCrossChainMessages from 'src/features/cross-chain-txs/pages/tx/TxDetailsCrossChainMessages';
@@ -806,6 +807,8 @@ const TxDetails = ({ data, isLoading, socketStatus, noTxActions }: Props) => {
         ) }
 
         <TxDetailsOther nonce={ data.nonce } type={ data.type } position={ data.position } queueIndex={ data.scroll?.queue_index }/>
+
+        <TxDetailsEden data={ data } isLoading={ isLoading }/>
 
         <DetailedInfo.ItemLabel
           hint="Binary data included with the transaction. See logs tab for additional info"

--- a/tools/dev-server/registry.json
+++ b/tools/dev-server/registry.json
@@ -5,6 +5,7 @@
   "blackfort_testnet": "https://blackfort-testnet.blockscout.com",
   "celo": "https://celo.blockscout.com",
   "celo_sepolia": "https://celo-sepolia.blockscout.com",
+  "eden_testnet": "https://eden-testnet.blockscout.com",
   "eth": "https://eth.blockscout.com",
   "eth_sepolia": "https://eth-sepolia.blockscout.com",
   "filecoin": "https://filecoin.blockscout.com",


### PR DESCRIPTION
## Description and Related Issue(s)

Resolves #3607

Eden adds a custom transaction type — a *sponsored batch transaction*, where an executor submits an ordered batch of calls and a separate sponsor signs for and pays the fee. The backend exposes the two fields that describe this (`fee_payer` and `calls`), but the transaction details page rendered neither, so a sponsored transaction silently omitted who actually paid and what the batch executed.

Both fields are now shown on `/tx/:hash`, and the page header tags a sponsored transaction. Everything is gated on the fields being present in the response — the established pattern for chain-variant transaction fields (SUAVE's `execution_node` does the same) — so nothing appears on any other chain.

Plan and decisions: [`.agents/tasks/3607-tx-details-fee-payer-calls/spec.md`](https://github.com/blockscout/frontend/blob/issue-3607/.agents/tasks/3607-tx-details-fee-payer-calls/spec.md)

### Proposed Changes

- **Fee payer** and **Calls** rows on the transaction details page, inside the *View details* cut, between **Other** and **Raw input**. New component `src/features/chain-variants/eden/pages/tx/TxDetailsEden.tsx`, composed unconditionally by the tx slice and returning `null` when both fields are absent.
- The **Calls** table lists the batch in API order with `To` / `Value` / `Input` columns, reusing the visual language of the logs' decoded-input table. A call's `to` is `null` on a contract creation, rendered as `[ Contract creation ]`.
- A **Sponsored** tag in the details page header when `transaction_types` includes `sponsored_transaction`. Transaction lists deliberately get no badge — there is no room — but the type is registered in `TYPES_ORDER` so it stops masking more informative labels like "Contract call". Covered by `TxType.spec.tsx`.
- Bumped `@blockscout/api-types` to `0.0.1-beta.8e1692a`, the first published build carrying the `eden` chain type. No env variables were added or changed.
- Added the `eden_testnet` dev-server preset, and glossary entries for **Eden** and **Sponsored Transaction**.

### Breaking or Incompatible Changes

None.

### Additional Information

The API types are pinned to a **beta** built from the backend `dev` branch, because the fields ship in backend tag **11.2.4**, which is not released yet. The pin should move to a stable version once it is.

Two product questions were raised with the PM while this was built. The badge question is answered and implemented as above. The second — that on a multi-call batch the standard `to` and `raw_input` rows reflect only the first call, `value` is the sum across calls, and `from` is the executor rather than the payer — is deliberately left alone for now; the team is waiting on client feedback before adapting those fields. Both are recorded in the spec.

Demo (covers everything except the header tag, deployed before it landed): https://review-issue-3607.k8s-dev.blockscout.com/tx/0x35310fd76c45f1441226c102f4dc1070b41ac66cb1e6ed3354da78aa69824a67

## Checklist for PR author
- [x] I have tested these changes locally.
- [x] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [x] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added a feature or functionality that is not privacy-compliant (e.g., tracking, analytics, third-party services), I have disabled it for private mode.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request
