### PR TITLE
Clean up Rollbar noise from the deferred error-reporting listeners

### DIFF
--- a/src/services/rollbar/clientConfig.ts
+++ b/src/services/rollbar/clientConfig.ts
@@ -76,6 +76,11 @@ export function buildClientConfig(accessToken: string): Configuration {
 
       // Filter out client-side navigation cancellations
       'cancelled navigation',
+
+      // Opaque cross-origin script errors: the browser masks the details of an uncaught error
+      // thrown by a different-origin script (CORS), leaving only this string with no stack or
+      // payload. Unactionable, and sourced from third-party scripts we don't control.
+      'Script error',
     ],
     maxItems: 10, // Max items per page load
     // uncaught / unhandledrejection coverage is owned by the early window listeners in queue.ts —

--- a/src/services/rollbar/queue.spec.ts
+++ b/src/services/rollbar/queue.spec.ts
@@ -152,7 +152,6 @@ describe('rollbar queue', () => {
       expect(rollbarInstance.warn).not.toHaveBeenCalled();
       expect(errorHandler).toBeTypeOf('function');
       expect(removeEventListenerSpy).toHaveBeenCalledWith('error', errorHandler, true);
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('unhandledrejection', expect.any(Function));
     });
   });
 
@@ -175,21 +174,33 @@ describe('rollbar queue', () => {
       remove();
     });
 
-    it('should buffer unhandledrejection events until init', async() => {
+    it('should report a non-Error thrown value under a fallback message with the value as custom data', async() => {
       const queue = await importQueue();
       const remove = queue.installEarlyListeners();
-      const reason = new Error('rejected promise');
+      // A synchronous `throw` of a non-Error value would otherwise reach Rollbar as a bare object
+      // and be filed as a generic "null or missing arguments." item (issue #3566, subtask 3).
+      const thrown = { code: 'BOOM' };
 
-      window.dispatchEvent(new PromiseRejectionEvent('unhandledrejection', {
-        promise: Promise.resolve(),
-        reason,
-      }));
-      expect(rollbarInstance.error).not.toHaveBeenCalled();
-
+      window.dispatchEvent(new ErrorEvent('error', { message: 'Uncaught object', error: thrown }));
       await queue.init();
 
       expect(rollbarInstance.error).toHaveBeenCalledWith(
-        reason,
+        'Uncaught object',
+        { client_timestamp: CALL_TIME_S, error: thrown },
+      );
+
+      remove();
+    });
+
+    it('should fall back to the event message when there is no error object', async() => {
+      const queue = await importQueue();
+      const remove = queue.installEarlyListeners();
+
+      window.dispatchEvent(new ErrorEvent('error', { message: 'Script error.', error: null }));
+      await queue.init();
+
+      expect(rollbarInstance.error).toHaveBeenCalledWith(
+        'Script error.',
         { client_timestamp: CALL_TIME_S },
       );
 

--- a/src/services/rollbar/queue.ts
+++ b/src/services/rollbar/queue.ts
@@ -133,10 +133,32 @@ function withClientTimestamp(args: Array<Rollbar.LogArgument>, timestamp: number
   return next;
 }
 
+const UNCAUGHT_ERROR_FALLBACK_MESSAGE = 'Uncaught error';
+
 /**
- * Captures uncaught errors / unhandled rejections during (and after) the SDK deferral window.
- * Kept for the page lifetime on success — removed if init fails. Rollbar's own capture flags stay
- * off to avoid double-reporting.
+ * Coerces a thrown value into arguments Rollbar can build an occurrence from. Passed a bare
+ * non-Error object (or `null`) as its sole argument, Rollbar discards the payload and files a
+ * generic "Item sent with null or missing arguments." occurrence — so anything that is not an
+ * `Error` or `string` is reported under {@link UNCAUGHT_ERROR_FALLBACK_MESSAGE} with the raw value
+ * preserved as custom data.
+ */
+function toReport(value: unknown, message: string): Array<Rollbar.LogArgument> {
+  if (value instanceof Error || typeof value === 'string') {
+    return [ value ];
+  }
+  if (value === null || value === undefined) {
+    return [ message || UNCAUGHT_ERROR_FALLBACK_MESSAGE ];
+  }
+  return [ message || UNCAUGHT_ERROR_FALLBACK_MESSAGE, { error: value } ];
+}
+
+/**
+ * Captures uncaught errors during (and after) the SDK deferral window. Kept for the page lifetime
+ * on success — removed if init fails. Rollbar's own `captureUncaught` stays off to avoid
+ * double-reporting; `captureUnhandledRejections` is left off deliberately — on public instances
+ * unhandled rejections are dominated by wallet-extension / third-party noise with no usable
+ * payload (they file empty "null or missing arguments" items), and genuine page crashes surface as
+ * `critical` through the React error boundary, not here.
  */
 export function installEarlyListeners(): () => void {
   if (!isEnabled() || earlyListenersInstalled || typeof window === 'undefined') {
@@ -152,19 +174,13 @@ export function installEarlyListeners(): () => void {
     if (event.target instanceof Element) {
       return;
     }
-    log('error', [ event.error ?? event.message ]);
-  };
-
-  const handleRejection = (event: PromiseRejectionEvent) => {
-    log('error', [ event.reason ]);
+    log('error', toReport(event.error, event.message));
   };
 
   window.addEventListener('error', handleError, true);
-  window.addEventListener('unhandledrejection', handleRejection);
 
   const uninstall = () => {
     window.removeEventListener('error', handleError, true);
-    window.removeEventListener('unhandledrejection', handleRejection);
     earlyListenersInstalled = false;
     if (uninstallEarlyListeners === uninstall) {
       uninstallEarlyListeners = undefined;


### PR DESCRIPTION
## Description

Cleans up two sources of unactionable Rollbar noise introduced by the deferred-Rollbar refactor (#3568), which added early `unhandledrejection` and `error` window listeners that the app never had before.

- **Empty "Item sent with null or missing arguments." items** — the `unhandledrejection` listener forwarded `event.reason` as Rollbar's only argument; on public instances rejections are dominated by browser-extension / third-party noise with `null` or bare-object reasons that Rollbar can't turn into a message, so it files empty items (160+ occurrences on one item). The listener is removed — matching pre-refactor behavior (unhandled rejections were never reported before) with no loss of coverage, since genuine page crashes are reported as `critical` through the React error boundary. The remaining uncaught-`error` listener is guarded so a non-Error/non-string thrown value becomes a titled message with the raw value preserved as custom data, closing the same hole on that path.
- **Opaque "Script error." items** — the same `error` listener surfaces cross-origin script errors, which the browser masks to the bare string `"Script error."` with no stack or payload (a CORS measure), sourced from third-party scripts we don't control. `"Script error"` is added to `ignoredMessages` (the existing `'cross-origin'` entry doesn't match this literal string), keeping the listener's value for genuine same-origin uncaught errors.

## Environment variables

None

## Minimum API version

None

## Breaking or incompatible changes

None

## Additional information

Unit tests in `src/services/rollbar/queue.spec.ts` cover the guarded `error`-listener paths (non-Error thrown value → fallback message + custom data; `null` error → falls back to the event message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
