### PR TITLE
Token page: prime address query, split loading states, and skip JSON parse on API errors

### DIFF
--- a/.agents/rules/tests-unit.md
+++ b/.agents/rules/tests-unit.md
@@ -63,7 +63,7 @@ pnpm test:vitest path/to/file.spec.ts
 import { render, screen } from 'vitest/lib';
 ```
 
-`vitest/lib.tsx` re-exports everything from `@testing-library/react` and replaces `render` with a custom version that wraps the component in the full app provider stack (mirroring `playwright/TestApp.tsx`): Chakra, `QueryClientProvider` (no retry, no window-focus refetch), Socket (inert), `AppContextProvider`, Marketplace, Settings, GrowthBook, Wagmi (mock connector), Rewards, and CsvExport — heavy enough to mount whole page slices in jsdom.
+`vitest/lib.tsx` re-exports everything from `@testing-library/react` and replaces `render` with a custom version that wraps the component in the full app provider stack (mirroring `playwright/TestApp.tsx`): Chakra, `QueryClientProvider` (no retry, no window-focus refetch), Socket (inert by default — see below), `AppContextProvider`, Marketplace, Settings, GrowthBook, Wagmi (mock connector), Rewards, and CsvExport — heavy enough to mount whole page slices in jsdom.
 
 The `wrapper` export is also available if you need to pass it separately to RTL hooks:
 
@@ -83,6 +83,19 @@ await userEvent.click(button);
 await flushPromises();
 expect(screen.getByText('Loaded')).toBeInTheDocument();
 ```
+
+**`vitest/utils/mockSocket.ts`** — a fake Phoenix transport whose channels join immediately, for components that keep a query disabled until `useSocketChannel` reports a join. Only the `phoenix` `Socket` is replaced; `SocketProvider`, `useSocketChannel` and `useSocketMessage` run for real:
+
+```tsx
+import { mockSocket, MOCK_SOCKET_URL } from 'vitest/utils/mockSocket';
+
+mockSocket();
+const { default: Token } = await import('./Token');
+render(<TestApp socketUrl={ MOCK_SOCKET_URL }><Token/></TestApp>);
+await flushPromises();
+```
+
+It uses `vi.doMock`, so it only affects modules imported **after** the call — pair it with `vi.resetModules()` and dynamic imports. Pass `socketUrl` explicitly too: without a url the provider creates no socket at all. Server-sent events are not simulated yet.
 
 ## Mocking fetch responses
 

--- a/src/server/primedRequests/CONTEXT.md
+++ b/src/server/primedRequests/CONTEXT.md
@@ -39,7 +39,8 @@ cannot alter behavior, only timing:
 
 Each registered page has a colocated `*.primed.spec.tsx` that runs the real inline script and
 mounts the real page (in its layout) and asserts **primed ⊆ the page's first-render requests**,
-byte-identically. The subset direction is deliberate: priming is opt-in per resource, so
+byte-identically. The mount uses a fake socket transport (`vitest/utils/mockSocket.ts`) whose
+channels join immediately, so queries a page defers until its socket channel is up. The subset direction is deliberate: priming is opt-in per resource, so
 *under*-priming is fine, but priming something the page does not actually request on first render
 is a bug and fails the test. `index.spec.ts` additionally fails if a registered page lacks its
 spec. This is what lets the registry be trusted without a running backend.

--- a/src/server/primedRequests/pages/token.ts
+++ b/src/server/primedRequests/pages/token.ts
@@ -7,6 +7,7 @@ const hashFromRoute = { routeParam: 'hash' };
 const getResources = (): Array<PrimedResource> => [
   { resource: 'core:token', pathParams: { hash: hashFromRoute }, tabs: [ 'index' ] },
   { resource: 'core:token_counters', pathParams: { hash: hashFromRoute }, tabs: [ 'index' ] },
+  { resource: 'core:address', pathParams: { hash: hashFromRoute }, tabs: [ 'index' ] },
 ];
 
 export const tokenPage: PagePrimerConfig = {

--- a/src/server/utils/fetchApi.ts
+++ b/src/server/utils/fetchApi.ts
@@ -36,6 +36,7 @@ export default async function fetchApi<R extends ResourceName = never, S = Resou
       httpLogger.logger.info({ message: 'API fetch', url, code: response.status, duration });
     } else {
       httpLogger.logger.error({ message: 'API fetch', url, code: response.status, duration });
+      return;
     }
 
     return await response.json() as Promise<S>;

--- a/src/slices/token/pages/details/Token.tsx
+++ b/src/slices/token/pages/details/Token.tsx
@@ -127,7 +127,7 @@ const TokenPageContent = () => {
 
   throwOnResourceLoadError(tokenQuery);
 
-  const isMainDataLoading = tokenQuery.isPlaceholderData || addressQuery.isPlaceholderData;
+  const isMainDataLoading = tokenQuery.isPlaceholderData;
   const isFullDataLoading = isMainDataLoading || (address3rdPartyWidgets.isEnabled && address3rdPartyWidgets.configQuery.isPlaceholderData);
 
   const transfersCount = !tokenCountersQuery.isPlaceholderData && tokenCountersQuery.data?.transfers_count ?
@@ -154,18 +154,15 @@ const TokenPageContent = () => {
     addressQuery.data?.is_contract ? {
       id: 'contract',
       title: () => {
-        if (addressQuery.data?.is_verified) {
-          return (
-            <>
-              <span>Contract</span>
-              <SpriteIcon name="status/success" boxSize="14px" color="green.500"/>
-            </>
-          );
-        }
-
-        return 'Contract';
+        return (
+          <>
+            <span>Contract</span>
+            { addressQuery.data?.is_verified &&
+              <SpriteIcon name="status/success" boxSize="14px" color="green.500" isLoading={ addressQuery.isPlaceholderData }/> }
+          </>
+        );
       },
-      component: <Contract addressData={ addressQuery.data } isLoading={ isMainDataLoading }/>,
+      component: <Contract addressData={ addressQuery.data } isLoading={ isMainDataLoading || addressQuery.isPlaceholderData }/>,
       subTabs: CONTRACT_TAB_IDS,
     } : undefined,
     hasInventoryTab ? {

--- a/src/slices/token/pages/details/Token.tsx
+++ b/src/slices/token/pages/details/Token.tsx
@@ -50,6 +50,10 @@ const TokenPageContent = () => {
   useEtherscanRedirects();
   const queryClient = useQueryClient();
 
+  // Ideally, with the current API setup, we should wait until the socket connection is established before fetching the token data
+  // so the client does not miss events related to total supply changes.
+  // However, this would require moving the token request out of the primed list, which would reduce page-loading speed.
+  // Therefore, we decided not to do this, as we expect a very small number of affected users.
   const tokenQuery = useTokenQuery(hashString);
 
   const addressQuery = useApiQuery('core:address', {

--- a/src/slices/token/pages/details/Token.tsx
+++ b/src/slices/token/pages/details/Token.tsx
@@ -41,7 +41,6 @@ import RoutedTabs from 'src/toolkit/components/RoutedTabs/RoutedTabs';
 export type TokenTabs = 'token_transfers' | 'holders' | 'inventory';
 
 const TokenPageContent = () => {
-  const [ isQueryEnabled, setIsQueryEnabled ] = React.useState(false);
   const [ totalSupplySocket, setTotalSupplySocket ] = React.useState<number>();
   const router = useRouter();
 
@@ -56,7 +55,7 @@ const TokenPageContent = () => {
   const addressQuery = useApiQuery('core:address', {
     pathParams: { hash: hashString },
     queryOptions: {
-      enabled: isQueryEnabled && Boolean(router.query.hash),
+      enabled: Boolean(router.query.hash),
       placeholderData: addressStubs.ADDRESS_INFO,
     },
   });
@@ -83,13 +82,9 @@ const TokenPageContent = () => {
     });
   }, [ queryClient, hashString ]);
 
-  const enableQuery = React.useCallback(() => setIsQueryEnabled(true), []);
-
   const channel = useSocketChannel({
     topic: `tokens:${ hashString?.toLowerCase() }`,
     isDisabled: !hashString,
-    onJoin: enableQuery,
-    onSocketError: enableQuery,
   });
   useSocketMessage({
     channel,
@@ -123,7 +118,7 @@ const TokenPageContent = () => {
     queryOptions: { enabled: Boolean(hashString), placeholderData: TOKEN_COUNTERS },
   });
 
-  const address3rdPartyWidgets = useAddress3rdPartyWidgets('token', false, isQueryEnabled);
+  const address3rdPartyWidgets = useAddress3rdPartyWidgets('token', false);
 
   throwOnResourceLoadError(tokenQuery);
 

--- a/src/slices/token/pages/details/TokenPageTitle.tsx
+++ b/src/slices/token/pages/details/TokenPageTitle.tsx
@@ -45,14 +45,9 @@ interface Props {
 
 const TokenPageTitle = ({ tokenQuery, addressQuery, verifiedInfoQuery, hash }: Props) => {
   const multichainContext = useMultichainContext();
-  const addressHash = !tokenQuery.isPlaceholderData ? (tokenQuery.data?.address_hash || '') : '';
 
   const addressesForMetadataQuery = React.useMemo(() => ([ hash ].filter(Boolean)), [ hash ]);
   const addressMetadataQuery = useAddressMetadataInfoQuery(addressesForMetadataQuery);
-
-  const isLoading = tokenQuery.isPlaceholderData ||
-    addressQuery.isPlaceholderData ||
-    (config.features.verifiedTokens.isEnabled && verifiedInfoQuery.isPending);
 
   const tokenSymbolText = tokenQuery.data?.symbol ? ` (${ tokenQuery.data.symbol })` : '';
 
@@ -94,6 +89,11 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, verifiedInfoQuery, hash }: P
     multichainContext?.chain?.app_config,
   ]);
 
+  const isTagsLoading = tokenQuery.isPlaceholderData ||
+    addressQuery.isPlaceholderData ||
+    (config.features.addressMetadata.isEnabled && addressMetadataQuery.isPending) ||
+    (config.features.verifiedTokens.isEnabled && verifiedInfoQuery.isPending);
+
   const contentAfter = (
     <>
       { tokenQuery.data && <TokenEntity.Reputation value={ tokenQuery.data.reputation } ml={ 0 }/> }
@@ -113,7 +113,7 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, verifiedInfoQuery, hash }: P
         </Tooltip>
       ) }
       <MetadataTags
-        isLoading={ isLoading || (config.features.addressMetadata.isEnabled && addressMetadataQuery.isPending) }
+        isLoading={ isTagsLoading }
         tags={ tags }
         addressHash={ addressQuery.data?.hash }
         flexGrow={ 1 }
@@ -121,24 +121,26 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, verifiedInfoQuery, hash }: P
     </>
   );
 
+  const isMainDataLoading = tokenQuery.isPlaceholderData;
+  // should not be shown before the main title text is loaded
+  const isAddressDataLoading = tokenQuery.isPlaceholderData || addressQuery.isPlaceholderData;
+
   const secondRow = (
     <Flex alignItems="center" w="100%" minW={ 0 } columnGap={ 2 } rowGap={ 2 } flexWrap={{ base: 'wrap', lg: 'nowrap' }}>
-      { addressQuery.data && (
-        <AddressEntity
-          address={{ ...addressQuery.data, name: '' }}
-          isLoading={ isLoading }
-          variant="subheading"
-          icon={ multichainContext?.chain ? {
-            shield: { name: 'pie_chart', isLoading },
-          } : undefined }
-        />
-      ) }
-      { !isLoading && tokenQuery.data && <TokenAddToWallet token={ tokenQuery.data } variant="button"/> }
-      { addressQuery.data && <AddressQrCode hash={ addressQuery.data.hash } isLoading={ isLoading }/> }
-      <ActionsMenu isLoading={ isLoading }/>
+      <AddressEntity
+        address={{ ...addressQuery.data, name: '', hash: addressQuery.data?.hash || hash }}
+        isLoading={ isAddressDataLoading }
+        variant="subheading"
+        icon={ multichainContext?.chain ? {
+          shield: { name: 'pie_chart', isLoading: isAddressDataLoading },
+        } : undefined }
+      />
+      { !isMainDataLoading && tokenQuery.data && <TokenAddToWallet token={ tokenQuery.data } variant="button"/> }
+      <AddressQrCode hash={ hash } isLoading={ isMainDataLoading }/>
+      <ActionsMenu isLoading={ isMainDataLoading }/>
       <Flex ml={{ base: 0, lg: 'auto' }} columnGap={ 2 } flexGrow={{ base: 1, lg: 0 }}>
         <TokenVerifiedInfo verifiedInfoQuery={ verifiedInfoQuery }/>
-        <AlternativeExplorers type="token" pathParam={ addressHash } ml={{ base: 'auto', lg: 0 }}/>
+        <AlternativeExplorers type="token" pathParam={ hash } ml={{ base: 'auto', lg: 0 }}/>
       </Flex>
     </Flex>
   );
@@ -147,11 +149,11 @@ const TokenPageTitle = ({ tokenQuery, addressQuery, verifiedInfoQuery, hash }: P
     <>
       <PageTitle
         title={ `${ tokenQuery.data?.name || 'Unnamed token' }${ tokenSymbolText }` }
-        isLoading={ tokenQuery.isPlaceholderData }
+        isLoading={ isMainDataLoading }
         beforeTitle={ tokenQuery.data ? (
           <TokenEntity.Icon
             token={ tokenQuery.data }
-            isLoading={ tokenQuery.isPlaceholderData }
+            isLoading={ isMainDataLoading }
             variant="heading"
             chain={ multichainContext?.chain }
           />

--- a/vitest/lib.tsx
+++ b/vitest/lib.tsx
@@ -49,9 +49,14 @@ const wagmiConfig = createConfig({
   },
 });
 
-// The full app provider stack (mirrors playwright/TestApp.tsx; socket and wallet client stay
-// inert) — heavy enough to mount whole page slices in jsdom.
-const TestApp = ({ children }: { children: React.ReactNode }) => {
+interface TestAppProps {
+  children: React.ReactNode;
+  socketUrl?: string;
+}
+
+// The full app provider stack (mirrors playwright/TestApp.tsx; the wallet client stays inert, and
+// so does the socket unless `socketUrl` is given) — heavy enough to mount whole page slices in jsdom.
+const TestApp = ({ children, socketUrl }: TestAppProps) => {
   const [ queryClient ] = React.useState(() => new QueryClient({
     defaultOptions: {
       queries: {
@@ -64,7 +69,7 @@ const TestApp = ({ children }: { children: React.ReactNode }) => {
   return (
     <ChakraProvider>
       <QueryClientProvider client={ queryClient }>
-        <SocketProvider url={ undefined }>
+        <SocketProvider url={ socketUrl }>
           <AppContextProvider pageProps={ PAGE_PROPS }>
             <MarketplaceContext.Provider value={ marketplaceContext }>
               <SettingsContextProvider>

--- a/vitest/utils/checkPrimedRequests.tsx
+++ b/vitest/utils/checkPrimedRequests.tsx
@@ -9,6 +9,7 @@ import { expect, it, vi } from 'vitest';
 import flushPromises from './flushPromises';
 import withEnvs from './mockEnvs';
 import { mockNextRouter } from './mockRouter';
+import { mockSocket, MOCK_SOCKET_URL } from './mockSocket';
 
 // Drift check for the early-fetch primer (src/server/primedRequests): asserts that every
 // request the primer would fire for a page is also fired — with byte-identical URL and
@@ -58,6 +59,9 @@ export default function checkPrimedRequests(params: CheckPrimedRequestsParams) {
         // register the router mock AFTER withEnvs' resetModules so the subsequent dynamic
         // imports of Layout / page components pick it up (doMock before resetModules races)
         mockNextRouter(params.page, params.url);
+        // pages gate some queries on their socket channel joining; the mock joins right away so
+        // those requests belong to the first render here, as they effectively do in a browser
+        mockSocket();
 
         const { getPrimerScript } = await import('src/server/primedRequests');
 
@@ -86,7 +90,7 @@ export default function checkPrimedRequests(params: CheckPrimedRequestsParams) {
           params.loadComponent(),
         ]);
 
-        const { unmount } = render(<TestApp><Component/></TestApp>);
+        const { unmount } = render(<TestApp socketUrl={ MOCK_SOCKET_URL }><Component/></TestApp>);
 
         try {
           // let mount effects fire their queries and any second-wave queries subscribe
@@ -120,6 +124,7 @@ export default function checkPrimedRequests(params: CheckPrimedRequestsParams) {
       });
     } finally {
       vi.doUnmock('next/router');
+      vi.doUnmock('phoenix');
       fetchMock.resetMocks();
       window.__primedFetches = undefined;
       window.history.replaceState(null, '', '/');

--- a/vitest/utils/mockSocket.ts
+++ b/vitest/utils/mockSocket.ts
@@ -1,0 +1,64 @@
+import { vi } from 'vitest';
+
+// Phoenix socket mocking for Vitest.
+//
+// Replaces the transport only — `SocketProvider`, `useSocketChannel` and `useSocketMessage` stay
+// real. Channels join successfully, so the queries a page enables from an `onJoin` callback run
+// here the way they do in a browser. Server-sent events are not simulated: subscriptions made via
+// `channel.on` are accepted and never fire.
+//
+// Uses `vi.doMock`, which applies only to modules imported AFTER the call — pair it with
+// `resetModules` + dynamic imports (checkPrimedRequests.tsx), and clean up with
+// `vi.doUnmock('phoenix')`. Mounting under `vitest/lib`'s TestApp additionally requires passing
+// `socketUrl={ MOCK_SOCKET_URL }`, since the provider skips socket creation without a url.
+
+/** any non-empty url works — the mocked socket never opens a connection */
+export const MOCK_SOCKET_URL = 'wss://localhost/socket';
+
+interface MockPush {
+  receive: (status: string, callback: (response: unknown) => void) => MockPush;
+}
+
+function createMockPush(): MockPush {
+  const push: MockPush = {
+    receive: (status, callback) => {
+      if (status === 'ok') {
+        // a real join never resolves synchronously; keep the callback off the caller's stack so
+        // the whole `.receive()` chain is set up before any of it runs
+        queueMicrotask(() => callback({}));
+      }
+      return push;
+    },
+  };
+
+  return push;
+}
+
+function createMockChannel() {
+  let nextHandlerRef = 0;
+
+  return {
+    join: createMockPush,
+    leave: createMockPush,
+    push: createMockPush,
+    on: () => nextHandlerRef++,
+    off: () => {},
+  };
+}
+
+export function mockSocket() {
+  let nextListenerRef = 0;
+  const createListenerRef = () => String(nextListenerRef++);
+
+  class MockSocketClass {
+    connect() {}
+    disconnect() {}
+    onOpen = createListenerRef;
+    onClose = createListenerRef;
+    onError = createListenerRef;
+    off() {}
+    channel = createMockChannel;
+  }
+
+  vi.doMock('phoenix', () => ({ Socket: MockSocketClass }));
+}


### PR DESCRIPTION
## Description

Follow-up improvements for the token page load experience:

- Prime the `core:address` request alongside the token and counters so the address data can arrive with SSR.
- Split loading so the index tab can render token data while a slower address request is still pending (title, actions, and contract tab no longer wait on address alone).
- Fix `fetchApi` so non-OK responses are not parsed as JSON and returned as if they were successful data (avoids treating an error payload as real API data on the server).

## Environment variables

None

## Minimum API version

None

## Breaking or incompatible changes

None

## Additional information

—


Made with [Cursor](https://cursor.com)