### PR TITLE
Fix cross-chain In/Out tag always showing "In" on multichain instances

### DIFF
--- a/src/features/cross-chain-txs/components/CrossChainFromToTag.tsx
+++ b/src/features/cross-chain-txs/components/CrossChainFromToTag.tsx
@@ -4,21 +4,44 @@ import React from 'react';
 
 import { Badge, type BadgeProps } from 'src/toolkit/chakra/badge';
 
+const SELF_TAG = { text: 'Self', colorPalette: 'gray' as const };
+const OUT_TAG = { text: 'Out', colorPalette: 'orange' as const };
+const IN_TAG = { text: 'In', colorPalette: 'purple' as const };
+
 interface Props extends BadgeProps {
-  type: 'in' | 'out';
+  currentAddress: string;
+  sender?: string;
+  recipient?: string;
   isLoading?: boolean;
 }
 
-const CrossChainFromToTag = ({ type, isLoading, ...rest }: Props) => {
+const CrossChainFromToTag = ({ currentAddress, sender, recipient, isLoading, ...rest }: Props) => {
+
+  const { text, colorPalette } = (() => {
+    if (sender?.toLowerCase() === currentAddress.toLowerCase() && recipient?.toLowerCase() === currentAddress.toLowerCase()) {
+      return SELF_TAG;
+    }
+
+    if (sender?.toLowerCase() === currentAddress.toLowerCase()) {
+      return OUT_TAG;
+    }
+
+    if (recipient?.toLowerCase() === currentAddress.toLowerCase()) {
+      return IN_TAG;
+    }
+
+    return SELF_TAG;
+  })();
+
   return (
     <Badge
       loading={ isLoading }
-      colorPalette={ type === 'in' ? 'purple' : 'orange' }
-      minW={ 8 }
+      colorPalette={ colorPalette }
+      minW={ 10 }
       justifyContent="center"
       { ...rest }
     >
-      { type === 'in' ? 'In' : 'Out' }
+      { text }
     </Badge>
   );
 };

--- a/src/features/cross-chain-txs/components/CrossChainFromToTagTx.tsx
+++ b/src/features/cross-chain-txs/components/CrossChainFromToTagTx.tsx
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import React from 'react';
+
+import type { InterchainMessage } from '@blockscout/interchain-indexer-types';
+
+import CrossChainFromToTag from './CrossChainFromToTag';
+
+interface Props {
+  data: InterchainMessage;
+  isLoading?: boolean;
+  currentAddress: string;
+}
+
+const CrossChainFromToTagTx = ({ data, isLoading, currentAddress }: Props) => {
+  const transfersNum = data.transfers.length;
+
+  if (transfersNum === 1) {
+    const { sender, recipient } = data.transfers[0];
+    if (sender?.hash.toLowerCase() === currentAddress.toLowerCase() || recipient?.hash.toLowerCase() === currentAddress.toLowerCase()) {
+      return (
+        <CrossChainFromToTag
+          currentAddress={ currentAddress }
+          sender={ sender?.hash }
+          recipient={ recipient?.hash }
+          isLoading={ isLoading }
+        />
+      );
+    }
+  }
+
+  return (
+    <CrossChainFromToTag
+      currentAddress={ currentAddress }
+      sender={ data.sender?.hash }
+      recipient={ data.recipient?.hash }
+      isLoading={ isLoading }
+    />
+  );
+};
+
+export default React.memo(CrossChainFromToTagTx);

--- a/src/features/cross-chain-txs/components/token-transfers/TokenTransfersCrossChainListItem.tsx
+++ b/src/features/cross-chain-txs/components/token-transfers/TokenTransfersCrossChainListItem.tsx
@@ -8,7 +8,6 @@ import type { InterchainTransfer } from '@blockscout/interchain-indexer-types';
 import AddressEntityInterchain from 'src/slices/address/components/entity/AddressEntityInterchain';
 import TxEntityInterchain from 'src/slices/tx/components/entity/TxEntityInterchain';
 
-import config from 'src/config';
 import dayjs from 'src/shared/date-and-time/dayjs';
 import Time from 'src/shared/date-and-time/Time';
 import ListItemMobile from 'src/shared/lists/ListItemMobile';
@@ -41,7 +40,9 @@ const TokenTransfersCrossChainListItem = ({ data, isLoading, rowGap = 3, current
         <CrossChainTxsStatusTag status={ data.status } loading={ isLoading } mode="full"/>
         { currentAddress && (
           <CrossChainFromToTag
-            type={ data.sender?.hash.toLowerCase() === currentAddress.toLowerCase() && config.chain.id === data.source_chain?.id ? 'out' : 'in' }
+            currentAddress={ currentAddress }
+            sender={ data.sender?.hash }
+            recipient={ data.recipient?.hash }
             isLoading={ isLoading }
           />
         ) }

--- a/src/features/cross-chain-txs/components/token-transfers/TokenTransfersCrossChainTable.tsx
+++ b/src/features/cross-chain-txs/components/token-transfers/TokenTransfersCrossChainTable.tsx
@@ -31,8 +31,7 @@ const TokenTransfersCrossChainTable = ({ data, isLoading, top, currentAddress, r
       <TableRoot tableLayout="auto">
         <TableHeaderSticky top={ top }>
           <TableRow>
-            <TableColumnHeader w="42px"/>
-            { currentAddress && <TableColumnHeader w="44px"/> }
+            <TableColumnHeader w={ currentAddress ? '86px' : '42px' }/>
             <TableColumnHeader>Source token</TableColumnHeader>
             <TableColumnHeader/>
             <TableColumnHeader>Target token</TableColumnHeader>

--- a/src/features/cross-chain-txs/components/token-transfers/TokenTransfersCrossChainTableItem.tsx
+++ b/src/features/cross-chain-txs/components/token-transfers/TokenTransfersCrossChainTableItem.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-import { chakra, VStack } from '@chakra-ui/react';
+import { chakra, HStack, VStack } from '@chakra-ui/react';
 import React from 'react';
 
 import type { InterchainTransfer } from '@blockscout/interchain-indexer-types';
@@ -9,7 +9,6 @@ import AddressEntityInterchain from 'src/slices/address/components/entity/Addres
 import AddressFromToIcon from 'src/slices/address/components/from-to/AddressFromToIcon';
 import TxEntityInterchain from 'src/slices/tx/components/entity/TxEntityInterchain';
 
-import config from 'src/config';
 import TimeWithTooltip from 'src/shared/date-and-time/TimeWithTooltip';
 import ChainLabel from 'src/shared/external-chains/ChainLabel';
 import TokenValueInterchain from 'src/shared/values/entity/TokenValueInterchain';
@@ -34,17 +33,19 @@ const TokenTransfersCrossChainTableItem = ({ data, isLoading, currentAddress }: 
 
   return (
     <TableRow>
-      <TableCell w="42px">
-        <CrossChainTxsStatusTag status={ data.status } loading={ isLoading }/>
+      <TableCell>
+        <HStack gap={ 1 }>
+          <CrossChainTxsStatusTag status={ data.status } loading={ isLoading }/>
+          { currentAddress && (
+            <CrossChainFromToTag
+              currentAddress={ currentAddress }
+              sender={ data.sender?.hash }
+              recipient={ data.recipient?.hash }
+              isLoading={ isLoading }
+            />
+          ) }
+        </HStack>
       </TableCell>
-      { currentAddress && (
-        <TableCell>
-          <CrossChainFromToTag
-            type={ data.sender?.hash.toLowerCase() === currentAddress.toLowerCase() && config.chain.id === data.source_chain?.id ? 'out' : 'in' }
-            isLoading={ isLoading }
-          />
-        </TableCell>
-      ) }
       <TableCell maxW="150px">
         <VStack alignItems="start">
           { data.source_token && (

--- a/src/features/cross-chain-txs/components/txs/TransactionsCrossChainListItem.tsx
+++ b/src/features/cross-chain-txs/components/txs/TransactionsCrossChainListItem.tsx
@@ -58,7 +58,9 @@ const TransactionsCrossChainListItem = ({ data, isLoading, rowGap = 3, currentAd
         <CrossChainTxsStatusTag status={ data.status } loading={ isLoading } mode="full"/>
         { currentAddress && (
           <CrossChainFromToTag
-            type={ data.sender?.hash.toLowerCase() === currentAddress.toLowerCase() && config.chain.id === data.source_chain?.id ? 'out' : 'in' }
+            currentAddress={ currentAddress }
+            sender={ data.sender?.hash }
+            recipient={ data.recipient?.hash }
             isLoading={ isLoading }
           />
         ) }

--- a/src/features/cross-chain-txs/components/txs/TransactionsCrossChainTable.tsx
+++ b/src/features/cross-chain-txs/components/txs/TransactionsCrossChainTable.tsx
@@ -32,8 +32,7 @@ const TransactionsCrossChainTable = ({ data, isLoading, top, stickyHeader, curre
       <TableRoot tableLayout="auto">
         <TableHeaderComponent top={ stickyHeader ? top : undefined }>
           <TableRow>
-            <TableColumnHeader w="42px"/>
-            { currentAddress && <TableColumnHeader w="44px"/> }
+            <TableColumnHeader w={ currentAddress ? '86px' : '42px' }/>
             <TableColumnHeader>Message</TableColumnHeader>
             <TableColumnHeader>
               <Flex alignItems="center" flexWrap="nowrap">

--- a/src/features/cross-chain-txs/components/txs/TransactionsCrossChainTableItem.tsx
+++ b/src/features/cross-chain-txs/components/txs/TransactionsCrossChainTableItem.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-import { chakra, VStack } from '@chakra-ui/react';
+import { chakra, HStack, VStack } from '@chakra-ui/react';
 import { route } from 'nextjs-routes';
 import React from 'react';
 
@@ -21,7 +21,7 @@ import { TableCell, TableRow } from 'src/toolkit/chakra/table';
 import { mdash } from 'src/toolkit/utils/htmlEntities';
 
 import CrossChainBridgeLink from '../CrossChainBridgeLink';
-import CrossChainFromToTag from '../CrossChainFromToTag';
+import CrossChainFromToTagTx from '../CrossChainFromToTagTx';
 import CrossChainMessageEntity from '../CrossChainMessageEntity';
 import CrossChainTxsStatusTag from '../CrossChainTxsStatusTag';
 
@@ -54,16 +54,17 @@ const TransactionsCrossChainTableItem = ({ data, isLoading, currentAddress }: Pr
   return (
     <TableRow>
       <TableCell w="42px">
-        <CrossChainTxsStatusTag status={ data.status } loading={ isLoading }/>
+        <HStack gap={ 1 }>
+          <CrossChainTxsStatusTag status={ data.status } loading={ isLoading }/>
+          { currentAddress && (
+            <CrossChainFromToTagTx
+              data={ data }
+              currentAddress={ currentAddress }
+              isLoading={ isLoading }
+            />
+          ) }
+        </HStack>
       </TableCell>
-      { currentAddress && (
-        <TableCell>
-          <CrossChainFromToTag
-            type={ data.sender?.hash.toLowerCase() === currentAddress.toLowerCase() && config.chain.id === data.source_chain?.id ? 'out' : 'in' }
-            isLoading={ isLoading }
-          />
-        </TableCell>
-      ) }
       <TableCell>
         <CrossChainMessageEntity id={ data.message_id } isLoading={ isLoading } lineHeight="24px" fontWeight={ 700 }/>
       </TableCell>

--- a/src/slices/address/components/entity/AddressEntityInterchain.tsx
+++ b/src/slices/address/components/entity/AddressEntityInterchain.tsx
@@ -21,8 +21,8 @@ interface Props extends EntityProps, JsxStyleProps {
 const AddressEntityInterchain = ({ chain, currentAddress, ...props }: Props) => {
 
   const isCurrentChain = chain?.id === config.chain.id;
-  const isCurrentAddress = isCurrentChain && currentAddress?.toLowerCase() === props.address.hash.toLowerCase();
   const isMultichainAddress = multichainConfig()?.chains.some(({ id }) => id === chain?.id);
+  const isCurrentAddress = (isCurrentChain || isMultichainAddress) && currentAddress?.toLowerCase() === props.address.hash.toLowerCase();
 
   if (isCurrentChain || isMultichainAddress) {
     return <AddressEntity { ...props } chain={ isMultichainAddress ? undefined : chain } noLink={ isCurrentAddress }/>;


### PR DESCRIPTION
## Description

Resolves #3608

On multichain instances the cross-chain In/Out tag always showed **In**, because direction required `config.chain.id` to match the source chain — and that id is unset when there is no single current chain.

Direction is now derived only from whether the page address is the sender and/or recipient. Adds a **Self** tag when both sides are the page address. Shared logic lives in `CrossChainFromToTagTx` and is used by the cross-chain transfers and messages list/table rows.

## Environment variables

None

## Minimum API version

None

## Breaking or incompatible changes

None

## Additional information

None

Made with [Cursor](https://cursor.com)