### PR TITLE
Don't feed the placeholder dapp URL to the marketplace iframe

### DIFF
--- a/src/features/marketplace/components/MarketplaceAppIframe.tsx
+++ b/src/features/marketplace/components/MarketplaceAppIframe.tsx
@@ -80,11 +80,11 @@ const Content = chakra(({ appUrl, address, message, isEssentialDapp, className }
       minW="100%"
       className={ className }
     >
-      { (isFrameLoading) && (
+      { (isFrameLoading || !appUrl) && (
         <ContentLoader/>
       ) }
 
-      { isReady && (
+      { isReady && appUrl && (
         <chakra.iframe
           key={ iframeKey }
           allow={ IFRAME_ALLOW_ATTRIBUTE }

--- a/src/features/marketplace/pages/dapp/MarketplaceApp.tsx
+++ b/src/features/marketplace/pages/dapp/MarketplaceApp.tsx
@@ -41,7 +41,10 @@ export default function MarketplaceApp() {
 
   const { setIsAutoConnectDisabled } = useMarketplaceContext();
 
-  const appUrl = useMemo(() => getAppUrl(data?.url, router), [ data?.url, router ]);
+  const appUrl = useMemo(
+    () => getAppUrl(isPlaceholderData ? undefined : data?.url, router),
+    [ data?.url, isPlaceholderData, router ],
+  );
 
   const message = useMemo(() => ({
     blockscoutColorMode: colorMode,


### PR DESCRIPTION
Closes #3581

## Problem

`useAppQuery` serves a stub app (`src/features/marketplace/stubs.ts`) as `placeholderData` while the real dapp loads. That stub's `url` is `https://example.com`, and the dapp page passed it straight into the iframe `src` — so the browser actually fetched `example.com` and flashed it before the real dapp URL arrived.

The stub URL caused a second, quieter bug: `getAppUrl` validates a user-supplied `?url=` param by comparing its origin against the app's. Against the stub, a legitimate `?url=` was treated as a foreign origin and silently stripped from the router.

## Changes

- `MarketplaceApp.tsx` — pass `undefined` to `getAppUrl` while `isPlaceholderData` is true, so no URL is derived from stub data.
- `MarketplaceAppIframe.tsx` — keep the iframe unmounted and the `ContentLoader` visible until a real `appUrl` exists. This also covers the essential-dapp page (`Swap.tsx`), where `appUrl` comes from config and can legitimately be `undefined`.

## Notes for the reviewer

- The stub is still used for the top bar skeletons; only the iframe stops consuming it.
- Verified with a temporary Playwright test that delayed the dapp API response and asserted `example.com` was never requested — it passed with this change. The test is not included in this branch; happy to add it if you'd like a permanent regression guard.
- Playwright can't be run from an agent worktree: `playwright-ct.config.ts` sets `testIgnore: '.claude/worktrees/**'`, so a run inside one finds 0 tests. I worked around it with a throwaway config override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)