### PR TITLE
Keep flashblocks rendering one at a time as the block interval drops to 200ms

### DIFF
--- a/src/features/flashblocks/hooks/useFlashblocksSocketData.ts
+++ b/src/features/flashblocks/hooks/useFlashblocksSocketData.ts
@@ -14,7 +14,7 @@ import { SECOND } from 'src/toolkit/utils/consts';
 const flashblocksFeature = config.features.flashblocks;
 
 const MAX_FLASHBLOCKS_COUNT = 50;
-const QUEUE_TIME_THRESHOLD = 200;
+const QUEUE_TIME_THRESHOLD = 150;
 
 type Status = 'initial' | 'connected' | 'disconnected' | 'error';
 


### PR DESCRIPTION
## Description

The flashblocks list batches incoming socket messages in a short window before flushing them to the UI: a block that arrives less than `QUEUE_TIME_THRESHOLD` after the previous flush is queued and rendered together with the next one. The window was 200ms, which sat just under the 250ms interval OP Stack produced blocks at, so in practice every block was rendered on its own.

OP Labs is dropping the subblock interval from 250ms to 200ms (OP Sepolia from Aug 17, OP Mainnet from Aug 31, per the [subblocks notice](https://docs.optimism.io/notices/subblocks)). At that spacing a large share of arrivals would fall inside a 200ms window and get flushed in pairs — no data or counters lost, but visibly chunkier list updates. Lowering the threshold to 150ms restores the one-at-a-time rendering and leaves headroom for jitter on both the OP Stack and MegaETH streams.

The same notice zeroes `state_root`, `block_hash`, `withdrawals_root` and `withdrawals` in the payload. Audited: the frontend reads none of them (`state_root` and `block_hash` appear in `FlashblockItemApiOptimism` but are never accessed; `withdrawals*` are absent entirely), the payload is parsed without schema validation so zero values cannot fail the parse, and block links are built from the block number rather than the hash. No change needed there.

## Environment variables

None.

## Minimum API version

None.

## Breaking or incompatible changes

None.

## Additional information

None.
