### PR TITLE
Rename OP Stack Flashblocks to Subblocks in the UI

### DIFF
--- a/.agents/GLOSSARY.md
+++ b/.agents/GLOSSARY.md
@@ -39,7 +39,7 @@ vars are documented in `docs/ENVS.md`. Architectural concepts like
 | **Eden** | chain | A rollup built on `ev-reth` / evstack. Introduces the **Sponsored Transaction** type. |
 | **Epoch** | entity | A consensus time period specific to **Celo**. Has its own index and detail pages. Always refers to a Celo epoch in this codebase — not a generic blockchain concept. |
 | **Fault Proof System** | feature | Optimism's mechanism for proving the correctness of L2 state transitions on L1 via **Dispute Games**. |
-| **Flashblocks** | feature | MegaETH's sub-second block streaming mechanism. |
+| **Flashblocks** | feature | Code name for the sub-second pre-confirmation block streaming feature. Surfaced to users as **Subblocks** on OP Stack chains (OP Labs renamed it from "Flashblocks") and as **mini-blocks** on MegaETH. The `flashblocks` code name and `FLASHBLOCKS` env vars are retained. |
 | **Hot Contracts** | feature | Ranked list of the most recently and frequently interacted-with smart contracts on the network. |
 | **Interchain Indexer** | service | Microservice that indexes cross-chain messages and token transfers across heterogeneous chains. General-purpose interop indexer, not ZetaChain-specific. Provides "Cross chain txs" feature. Distinct from **CCTX**. |
 | **Interop Messages** | entity | **Deprecated** Cross-rollup messages passed between OP Stack chains using the native interoperability protocol. Distinct from **Interchain Indexer** messages. |

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -958,11 +958,11 @@ If the feature is enabled, a single button or a dropdown (if more than 1 item is
 
 ### Flashblocks
 
-This feature allows users to view [Flashblocks](https://docs.base.org/base-chain/flashblocks/apps)-related content in the explorer, including the Flashblocks real-time feed. It currently supports only Base chains.
+Real-time feed of sub-second pre-confirmation blocks. The same feature backs two stacks: on OP Stack chains these blocks are called **Subblocks** (OP Labs' current name; formerly "Flashblocks") and are streamed from the endpoint below; on **MegaETH** they are called **mini-blocks** and are streamed from the MegaETH RPC endpoint (see [MegaETH](#megaeth)). The `FLASHBLOCKS` variable name is retained across both.
 
 | Variable | Type | Description | Compulsoriness | Default value | Example value | Version |
 | --- | --- | --- | --- | --- | --- | --- |
-| NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL | `string` | Public WebSocket endpoint to stream Flashblocks data | Required | - | `wss://mainnet.flashblocks.base.org/ws` | v2.3.0+ |
+| NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL | `string` | Public WebSocket endpoint to stream Subblocks data on OP Stack chains | Required | - | `wss://mainnet.flashblocks.base.org/ws` | v2.3.0+ |
 
 &nbsp;
 

--- a/src/features/flashblocks/config.ts
+++ b/src/features/flashblocks/config.ts
@@ -26,7 +26,7 @@ const config: Feature<{ socketUrl: string; type: 'optimism' | 'megaEth'; name: s
       isEnabled: true,
       socketUrl,
       type: 'optimism',
-      name: 'flashblock',
+      name: 'subblock',
     });
   }
 


### PR DESCRIPTION
## What

OP Labs renamed **Flashblocks → Subblocks** for OP Stack chains ([notice](https://docs.optimism.io/notices/subblocks)) and asked consumers to follow. This renames every OP-facing occurrence in the explorer UI.

The user-facing name is derived entirely from the feature config's `name` value, so a single change to the optimism variant renames all of it:

- Blocks page tab: **Subblocks**
- Stats labels: **Subblocks (sec)**, **Subblock time**
- Real-time feed hint text
- New-items socket notice

## Why not a wider rename

- **MegaETH shares this feature** but keeps its own user-facing name (**mini-blocks**), so its variant is deliberately untouched.
- The internal code name (`flashblocks` feature/folder) and the `NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL` env var are **retained** — renaming the env var would break operator configs for no UI benefit. Docs and the glossary now explain that one feature backs both stacks under two user-facing names.

## Changes

- `src/features/flashblocks/config.ts` — optimism variant `name: 'flashblock'` → `'subblock'`
- `docs/ENVS.md` — Flashblocks section description now covers both OP Stack (Subblocks) and MegaETH (mini-blocks); env var name unchanged
- `.agents/GLOSSARY.md` — updated definition to cover both stacks (also corrects the prior "MegaETH's" attribution)

## Verification

- Ran the `base` preset locally; confirmed in the live UI the tab and stat labels read **Subblocks / Subblock**, with **no** "Flashblock" text remaining.
- `pnpm lint:tsc` ✅ · cspell ✅

## Note

Companion to the already-landed 250ms→200ms interval change (e0d8d66f5), per the same OP Labs request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)