### PR TITLE
Fix chain switch error blocking L2→L1 withdrawal claims

### DIFF
--- a/src/config/test-utils/env-presets.ts
+++ b/src/config/test-utils/env-presets.ts
@@ -18,7 +18,7 @@ export const ENVS_MAP: Record<string, Array<[string, string]>> = {
   ],
   arbitrumRollup: [
     [ 'NEXT_PUBLIC_ROLLUP_TYPE', 'arbitrum' ],
-    [ 'NEXT_PUBLIC_ROLLUP_PARENT_CHAIN', '{"name":"DuckChain","baseUrl":"https://localhost:3101"}' ],
+    [ 'NEXT_PUBLIC_ROLLUP_PARENT_CHAIN', '{"name":"DuckChain","baseUrl":"https://localhost:3101","id":11155111,"rpcUrls":["https://localhost:3101"],"currency":{"name":"Ether","symbol":"ETH","decimals":18},"isTestnet":true}' ],
     [ 'NEXT_PUBLIC_ROLLUP_DA_CELESTIA_NAMESPACE', '0x1234' ],
     [ 'NEXT_PUBLIC_ROLLUP_DA_CELESTIA_CELENIUM_URL', 'https://mocha.celenium.io/blob' ],
   ],

--- a/src/features/rollup/arbitrum/pages/txn-withdrawals/ArbitrumL2TxnWithdrawalsClaimButton.tsx
+++ b/src/features/rollup/arbitrum/pages/txn-withdrawals/ArbitrumL2TxnWithdrawalsClaimButton.tsx
@@ -12,6 +12,7 @@ import type { ResourceError } from 'src/api/resources';
 
 import Web3Boundary from 'src/features/connect-wallet/components/Web3Boundary';
 import useWallet from 'src/features/connect-wallet/hooks/useWallet';
+import WithdrawalClaimButton from 'src/features/rollup/common/components/WithdrawalClaimButton';
 
 import config from 'src/config';
 import getErrorMessage from 'src/shared/errors/get-error-message';
@@ -20,7 +21,6 @@ import getErrorProp from 'src/shared/errors/get-error-prop';
 import capitalizeFirstLetter from 'src/shared/texts/capitalize-first-letter';
 
 import { Button } from 'src/toolkit/chakra/button';
-import { Skeleton } from 'src/toolkit/chakra/skeleton';
 import { toaster } from 'src/toolkit/chakra/toaster';
 
 import ArbitrumL2TxnWithdrawalsClaimTx from './ArbitrumL2TxnWithdrawalsClaimTx';
@@ -128,17 +128,13 @@ const ArbitrumL2TxnWithdrawalsClaimButtonContent = ({ messageId, txHash, complet
   const isLoading = isPending || web3Wallet.isOpen;
 
   return (
-    <Skeleton loading={ isDataLoading }>
-      <Button
-        size="sm"
-        variant="outline"
-        onClick={ handleClaimClick }
-        loading={ isLoading }
-        loadingText="Claim"
-      >
-        Claim
-      </Button>
-    </Skeleton>
+    <WithdrawalClaimButton
+      onClick={ handleClaimClick }
+      loading={ isLoading }
+      loadingSkeleton={ isDataLoading }
+    >
+      Claim
+    </WithdrawalClaimButton>
   );
 };
 

--- a/src/features/rollup/common/components/WithdrawalClaimButton.tsx
+++ b/src/features/rollup/common/components/WithdrawalClaimButton.tsx
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import React from 'react';
+
+import { chains } from 'src/features/connect-wallet/utils/chains';
+import { useMultichainContext } from 'src/features/multichain/context';
+
+import config from 'src/config';
+import { getFeaturePayload } from 'src/config/utils/features';
+
+import type { ButtonProps } from 'src/toolkit/chakra/button';
+import { Button } from 'src/toolkit/chakra/button';
+import { Tooltip } from 'src/toolkit/chakra/tooltip';
+
+const WithdrawalClaimButton = (props: ButtonProps) => {
+
+  const multichainContext = useMultichainContext();
+  const parentChain = getFeaturePayload((multichainContext?.chain.app_config ?? config).features.rollup)?.parentChain;
+  const isParentChainConfigured = Boolean(parentChain?.id && chains.some(chain => chain.id === parentChain.id));
+
+  return (
+    <Tooltip
+      content="The direct claim flow is not available because the parent chain is not configured. Please contact the project team to report this issue."
+      disabled={ isParentChainConfigured }
+    >
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={ !isParentChainConfigured }
+        { ...props }
+      >
+        Claim
+      </Button>
+    </Tooltip>
+  );
+};
+
+export default React.memo(WithdrawalClaimButton);

--- a/src/features/rollup/optimism/components/OptimisticL2ClaimButton.tsx
+++ b/src/features/rollup/optimism/components/OptimisticL2ClaimButton.tsx
@@ -14,6 +14,8 @@ import { Button } from 'src/toolkit/chakra/button';
 import { Link } from 'src/toolkit/chakra/link';
 import { useDisclosure } from 'src/toolkit/hooks/useDisclosure';
 
+import WithdrawalClaimButton from '../../common/components/WithdrawalClaimButton';
+
 const rollupFeature = config.features.rollup;
 
 export const canClaimDirectlyGuard = (data: Omit<schemas['OptimismTransactionWithdrawal'], 'nonce'>) => {
@@ -57,7 +59,11 @@ const OptimisticL2ClaimButton = ({ data, from, onSuccess, source }: Props) => {
             />
           </Web3Boundary>
         ) }
-        <Button variant="outline" size="sm" onClick={ modal.onOpen }>Claim</Button>
+        <WithdrawalClaimButton
+          onClick={ modal.onOpen }
+        >
+          Claim
+        </WithdrawalClaimButton>
       </>
     );
   }

--- a/tools/dev-server/registry.json
+++ b/tools/dev-server/registry.json
@@ -12,7 +12,7 @@
   "garnet": "https://explorer.garnetchain.com",
   "gnosis": "https://gnosis.blockscout.com",
   "gnosis_chiado": "https://gnosis-chiado.blockscout.com",
-  "hpp": "https://hpp.blockscout.com",
+  "hpp": "https://explorer.hpp.io",
   "immutable": "https://explorer.immutable.com",
   "mega_eth": "https://megaeth.blockscout.com",
   "multichain": "https://explorer.blockscout.com",


### PR DESCRIPTION
## Description

Resolves #3640

Clicking Claim on an L2→L1 withdrawal was calling `switchChain` even when the parent chain was missing from the wallet's configured chain list, which produced the opaque "An error occurred when attempting to switch chain" toast and never submitted the claim.

Shared `WithdrawalClaimButton` now checks that the parent chain id is present in the wagmi chains list and disables Claim with a tooltip when it isn't, for both Optimism and Arbitrum claim entry points.

Also updates the `hpp` dev-server preset URL to `https://explorer.hpp.io` (the instance where this was reproduced).

## Environment variables

None

## Minimum API version

None

## Breaking or incompatible changes

None

## Additional information

Reproduce with `pnpm dev:preset hpp` on a withdrawal ready for claim.

Made with [Cursor](https://cursor.com)