### PR TITLE
Add a time-zone toggle to the CSV export dialog

### DIFF
--- a/src/features/csv-export/components/CsvExport.tsx
+++ b/src/features/csv-export/components/CsvExport.tsx
@@ -17,6 +17,8 @@ import type { ResourceName, ResourcePathParams } from 'src/api/resources';
 import buildUrl from 'src/api/utils/build-url';
 import isNeedProxy from 'src/api/utils/is-need-proxy';
 
+import { useSettingsContext } from 'src/shell/top-bar/settings/context';
+
 import { useMultichainContext } from 'src/features/multichain/context';
 
 import config from 'src/config';
@@ -76,6 +78,8 @@ const CsvExport = <R extends ResourceName>({
   const recaptcha = useReCaptcha();
   const csvExportContext = useCsvExportContext();
   const apiFetch = useApiFetch();
+  const settings = useSettingsContext();
+  const isLocalTime = settings?.isLocalTime ?? true;
 
   const chain = chainData || multichainContext?.chain;
 
@@ -101,7 +105,7 @@ const CsvExport = <R extends ResourceName>({
   const fetchFactorySync = React.useCallback((data?: FormFields) => {
     return async(recaptchaToken?: string) => {
       const url = buildUrl(resourceName, pathParams, {
-        ...serializeFormFields(data),
+        ...serializeFormFields(data, isLocalTime),
         ...queryParams,
       }, undefined, chain);
 
@@ -126,7 +130,7 @@ const CsvExport = <R extends ResourceName>({
 
       return response;
     };
-  }, [ resourceName, pathParams, queryParams, chain ]);
+  }, [ resourceName, pathParams, queryParams, chain, isLocalTime ]);
 
   const fetchFactoryAsync = React.useCallback((data?: FormFields) => {
     return async(recaptchaToken?: string) => {
@@ -135,7 +139,7 @@ const CsvExport = <R extends ResourceName>({
       return apiFetch<typeof resourceName>(resourceName, {
         pathParams,
         queryParams: {
-          ...serializeFormFields(data),
+          ...serializeFormFields(data, isLocalTime),
           ...queryParams,
         },
         chain,
@@ -147,7 +151,7 @@ const CsvExport = <R extends ResourceName>({
         },
       }) as Promise<CsvExportDownloadResponse>;
     };
-  }, [ apiFetch, chain, pathParams, queryParams, resourceName ]);
+  }, [ apiFetch, chain, pathParams, queryParams, resourceName, isLocalTime ]);
 
   const downloadFileSync = React.useCallback(async(data?: FormFields) => {
     try {
@@ -158,8 +162,9 @@ const CsvExport = <R extends ResourceName>({
         blob,
         getFileName({
           type,
-          params: { ...mergedParams, ...serializeFormFields(data) },
+          params: { ...mergedParams, ...serializeFormFields(data, isLocalTime) },
           chainConfig,
+          isLocalTime,
         }),
       );
       return true;
@@ -171,7 +176,7 @@ const CsvExport = <R extends ResourceName>({
     } finally {
       setIsPending(false);
     }
-  }, [ chainConfig, fetchFactorySync, mergedParams, recaptcha, type ]);
+  }, [ chainConfig, fetchFactorySync, mergedParams, recaptcha, type, isLocalTime ]);
 
   const downloadFileAsync = React.useCallback(async(data?: FormFields) => {
     try {
@@ -186,9 +191,10 @@ const CsvExport = <R extends ResourceName>({
           status: 'pending',
           type,
           params: pickBy({
-            ...serializeFormFields(data),
+            ...serializeFormFields(data, isLocalTime),
             ...mergedParams,
             chain_id: chain?.id,
+            is_local_time: String(isLocalTime),
           }, (value) => value !== '' && value !== undefined && value !== null),
           is_highlighted: false,
         };
@@ -217,7 +223,7 @@ const CsvExport = <R extends ResourceName>({
     } finally {
       setIsPending(false);
     }
-  }, [ chain, csvExportContext, fetchFactoryAsync, mergedParams, recaptcha, type ]);
+  }, [ chain, csvExportContext, fetchFactoryAsync, mergedParams, recaptcha, type, isLocalTime ]);
 
   const handleButtonClick = React.useCallback(() => {
     if (periodFilter) {

--- a/src/features/csv-export/components/dialog/CsvExportDialog.tsx
+++ b/src/features/csv-export/components/dialog/CsvExportDialog.tsx
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import { chakra, Flex } from '@chakra-ui/react';
-import { getLocalTimeZone, now } from '@internationalized/date';
+import { getLocalTimeZone, now, toCalendarDateTime } from '@internationalized/date';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import type { FormFields } from './types';
+
+import { useSettingsContext } from 'src/shell/top-bar/settings/context';
+import SettingsLocalTime from 'src/shell/top-bar/settings/time-format/SettingsLocalTime';
 
 import { Button } from 'src/toolkit/chakra/button';
 import { DialogBody, DialogContent, DialogHeader, DialogRoot } from 'src/toolkit/chakra/dialog';
@@ -23,13 +26,20 @@ interface Props {
 }
 
 const CsvExportDialog = ({ open, onOpenChange, onFormSubmit, onCancel, children, isAsyncDownload }: Props) => {
+  const settings = useSettingsContext();
+  const isLocalTime = settings?.isLocalTime ?? true;
+
   const formApi = useForm<FormFields>({
     mode: 'onBlur',
-    defaultValues: {
-      // truncated to whole minutes, matching what the picker itself can express
-      from_period: [ now(getLocalTimeZone()).set({ second: 0, millisecond: 0 }).subtract({ days: 1 }) ],
-      to_period: [ now(getLocalTimeZone()).set({ second: 0, millisecond: 0 }) ],
-    },
+    defaultValues: (() => {
+      // the picker holds bare wall-clock values; seed them with "now" read in the zone the toggle
+      // currently selects, truncated to whole minutes to match what the picker can express
+      const currentWallClock = toCalendarDateTime(now(isLocalTime ? getLocalTimeZone() : 'UTC')).set({ second: 0, millisecond: 0 });
+      return {
+        from_period: [ currentWallClock.subtract({ days: 1 }) ],
+        to_period: [ currentWallClock ],
+      };
+    })(),
   });
 
   const { handleSubmit, formState } = formApi;
@@ -46,7 +56,7 @@ const CsvExportDialog = ({ open, onOpenChange, onFormSubmit, onCancel, children,
   }, [ onOpenChange, formState.isSubmitting, onCancel ]);
 
   return (
-    <DialogRoot open={ open } onOpenChange={ handleOpenChange } size={{ lgDown: 'full', lg: 'md' }}>
+    <DialogRoot open={ open } onOpenChange={ handleOpenChange } size={{ lgDown: 'full', lg: 'sm' }}>
       <DialogContent>
         <FormProvider { ...formApi }>
           <chakra.form
@@ -58,16 +68,15 @@ const CsvExportDialog = ({ open, onOpenChange, onFormSubmit, onCancel, children,
             </DialogHeader>
             <DialogBody>
               { children }
+              <SettingsLocalTime id="csv-export-local-time" mt={ 6 } width="calc(100% - 1px)"/>
               <Flex
-                columnGap={ 3 }
                 rowGap={ 3 }
-                mt={ 6 }
-                flexDir={{ base: 'column', lg: 'row' }}
-                alignItems={{ base: 'flex-start', lg: 'center' }}
-                w="100%"
+                mt={ 3 }
+                flexDir="column"
+                alignItems="stretch"
               >
-                <CsvExportFormDateField name="from_period" formApi={ formApi }/>
-                <CsvExportFormDateField name="to_period" formApi={ formApi }/>
+                <CsvExportFormDateField name="from_period" formApi={ formApi } isLocalTime={ isLocalTime }/>
+                <CsvExportFormDateField name="to_period" formApi={ formApi } isLocalTime={ isLocalTime }/>
               </Flex>
               <Button
                 variant="solid"

--- a/src/features/csv-export/components/dialog/CsvExportDialog.tsx
+++ b/src/features/csv-export/components/dialog/CsvExportDialog.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import { chakra, Flex } from '@chakra-ui/react';
-import { getLocalTimeZone, now, toCalendarDateTime } from '@internationalized/date';
+import { getLocalTimeZone, now, toCalendarDateTime, toTimeZone, toZoned } from '@internationalized/date';
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
@@ -42,7 +42,31 @@ const CsvExportDialog = ({ open, onOpenChange, onFormSubmit, onCancel, children,
     })(),
   });
 
-  const { handleSubmit, formState } = formApi;
+  const { handleSubmit, formState, getValues, setValue } = formApi;
+
+  // when the zone toggle flips, re-express the held wall-clock values in the new zone instant-preserving
+  // (18:40 local → 16:40 UTC), so the toggle only changes how the picked moment is shown — never which
+  // moment it is. Matches how the global "Local time format" setting re-expresses timestamps everywhere.
+  const prevIsLocalTimeRef = React.useRef(isLocalTime);
+  React.useEffect(() => {
+    const prevIsLocalTime = prevIsLocalTimeRef.current;
+    if (prevIsLocalTime === isLocalTime) {
+      return;
+    }
+    prevIsLocalTimeRef.current = isLocalTime;
+
+    const fromZone = prevIsLocalTime ? getLocalTimeZone() : 'UTC';
+    const toZone = isLocalTime ? getLocalTimeZone() : 'UTC';
+
+    ([ 'from_period', 'to_period' ] as const).forEach((name) => {
+      const [ date ] = getValues(name) ?? [];
+      // a date-only or already-zoned value carries no ambiguous wall-clock to re-express
+      if (!date || !('hour' in date) || 'timeZone' in date) {
+        return;
+      }
+      setValue(name, [ toCalendarDateTime(toTimeZone(toZoned(date, fromZone), toZone)) ], { shouldValidate: true });
+    });
+  }, [ isLocalTime, getValues, setValue ]);
 
   const handleOpenChange: OnOpenChangeHandler = React.useCallback(({ open }) => {
     if (formState.isSubmitting && !open) {

--- a/src/features/csv-export/components/dialog/CsvExportFormDateField.tsx
+++ b/src/features/csv-export/components/dialog/CsvExportFormDateField.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
 import type { DateValue } from '@chakra-ui/react';
-import { getLocalTimeZone, parseAbsolute } from '@internationalized/date';
+import { getLocalTimeZone, now, toCalendarDateTime } from '@internationalized/date';
 import { capitalize } from 'es-toolkit';
 import React from 'react';
 import type { UseFormReturn } from 'react-hook-form';
@@ -13,9 +13,10 @@ import { FormFieldDate } from 'src/toolkit/components/forms/fields/FormFieldDate
 interface Props {
   formApi: UseFormReturn<FormFields>;
   name: 'from_period' | 'to_period';
+  isLocalTime: boolean;
 }
 
-const CsvExportFormDateField = ({ formApi, name }: Props) => {
+const CsvExportFormDateField = ({ formApi, name, isLocalTime }: Props) => {
   const { formState, getValues, trigger } = formApi;
 
   const validate = React.useCallback((newValue: Array<DateValue>) => {
@@ -43,15 +44,23 @@ const CsvExportFormDateField = ({ formApi, name }: Props) => {
     }
   }, [ formState.errors.from_period, formState.errors.to_period, getValues, name, trigger ]);
 
-  const maxDate = React.useMemo(() => parseAbsolute(new Date().toISOString(), getLocalTimeZone()), []);
+  const maxDate = React.useMemo(
+    () => toCalendarDateTime(now(isLocalTime ? getLocalTimeZone() : 'UTC')),
+    [ isLocalTime ],
+  );
 
   return (
     <FormFieldDate<FormFields, typeof name>
+      // remount on zone change: the underlying date-picker only re-syncs its displayed text when the
+      // value or locale changes, not when the format (and thus the suffix) does, so a bare toggle would
+      // leave the old suffix on screen until the dialog is reopened
+      key={ isLocalTime ? 'local' : 'utc' }
       name={ name }
       max={ maxDate }
       placeholder={ capitalize(name.replace('_period', '')) }
       required
       withTime
+      timeZoneSuffix={ isLocalTime ? undefined : 'UTC' }
       bgColor="dialog.bg"
       // a bare function would be lost: FormFieldDate spreads rules.validate into an object
       // in order to add its own min/max validator

--- a/src/features/csv-export/components/downloads/CsvExportDownloadsItem.tsx
+++ b/src/features/csv-export/components/downloads/CsvExportDownloadsItem.tsx
@@ -16,6 +16,7 @@ import shortenString from 'src/shared/texts/shorten-string';
 import SpriteIcon from 'src/sprite/SpriteIcon';
 
 import { Button } from 'src/toolkit/chakra/button';
+import { DATE_TIME_FORMAT } from 'src/toolkit/chakra/date-picker';
 import { Link } from 'src/toolkit/chakra/link';
 import { Status } from 'src/toolkit/chakra/status';
 import { SECOND } from 'src/toolkit/utils/consts';
@@ -136,8 +137,15 @@ const CsvExportDownloadsItem = ({ index, data }: Props) => {
 
   const exportDetailsText = (() => {
     const chainText = chainData ? `on ${ chainData.name }` : undefined;
+    // render the submitted period in the same zone (and matching format) the dialog showed — legacy
+    // items predating the toggle carry no flag and fall back to local time
+    const isLocalTime = data.params.is_local_time !== 'false';
+    const formatPeriod = (value: string) => {
+      const formatted = isLocalTime ? dayjs(value).format(DATE_TIME_FORMAT) : dayjs(value).utc().format(DATE_TIME_FORMAT);
+      return isLocalTime ? formatted : `${ formatted } UTC`;
+    };
     const periodText = data.params.from_period && data.params.to_period ?
-      `from ${ dayjs(data.params.from_period).format('lll') } to ${ dayjs(data.params.to_period).format('lll') }` :
+      `from ${ formatPeriod(data.params.from_period) } to ${ formatPeriod(data.params.to_period) }` :
       undefined;
 
     if (data.type === 'token_holders') {

--- a/src/features/csv-export/components/downloads/CsvExportDownloadsItem.tsx
+++ b/src/features/csv-export/components/downloads/CsvExportDownloadsItem.tsx
@@ -16,7 +16,7 @@ import shortenString from 'src/shared/texts/shorten-string';
 import SpriteIcon from 'src/sprite/SpriteIcon';
 
 import { Button } from 'src/toolkit/chakra/button';
-import { DATE_TIME_FORMAT } from 'src/toolkit/chakra/date-picker';
+import { DATE_PICKER_DATE_TIME_FORMAT } from 'src/toolkit/chakra/date-picker';
 import { Link } from 'src/toolkit/chakra/link';
 import { Status } from 'src/toolkit/chakra/status';
 import { SECOND } from 'src/toolkit/utils/consts';
@@ -141,7 +141,7 @@ const CsvExportDownloadsItem = ({ index, data }: Props) => {
     // items predating the toggle carry no flag and fall back to local time
     const isLocalTime = data.params.is_local_time !== 'false';
     const formatPeriod = (value: string) => {
-      const formatted = isLocalTime ? dayjs(value).format(DATE_TIME_FORMAT) : dayjs(value).utc().format(DATE_TIME_FORMAT);
+      const formatted = isLocalTime ? dayjs(value).format(DATE_PICKER_DATE_TIME_FORMAT) : dayjs(value).utc().format(DATE_PICKER_DATE_TIME_FORMAT);
       return isLocalTime ? formatted : `${ formatted } UTC`;
     };
     const periodText = data.params.from_period && data.params.to_period ?

--- a/src/features/csv-export/utils/get-file-name.ts
+++ b/src/features/csv-export/utils/get-file-name.ts
@@ -7,13 +7,17 @@ import dayjs from 'src/shared/date-and-time/dayjs';
 
 import getPrefixByFilter from './get-prefix-by-filter';
 
+// filename-safe: no colons or dots, unlike the absolute ISO strings stored in the params
+const PERIOD_FILE_NAME_FORMAT = 'YYYY-MM-DD-HH-mm';
+
 interface Params {
   type: CsvExportType;
   params: Record<string, string>;
   chainConfig?: typeof config;
+  isLocalTime: boolean;
 }
 
-export default function getFileName({ type, params, chainConfig }: Params): string {
+export default function getFileName({ type, params, chainConfig, isLocalTime }: Params): string {
   const chainText = chainConfig?.chain.name ? `${ chainConfig.chain.name.replace(' ', '_').toLowerCase() }` : '';
 
   if (type === 'token_holders') {
@@ -25,7 +29,11 @@ export default function getFileName({ type, params, chainConfig }: Params): stri
   }
 
   if (type.startsWith('address_')) {
-    const dateText = params.from_period && params.to_period ? `from_${ params.from_period }_to_${ params.to_period }` : '';
+    const formatPeriod = (isoString: string) =>
+      (isLocalTime ? dayjs(isoString) : dayjs(isoString).utc()).format(PERIOD_FILE_NAME_FORMAT);
+    const dateText = params.from_period && params.to_period ?
+      `from_${ formatPeriod(params.from_period) }_to_${ formatPeriod(params.to_period) }${ isLocalTime ? '' : '_UTC' }` :
+      '';
     const entityPrefix = getPrefixByFilter(params?.filter_type, params?.filter_value);
 
     return [

--- a/src/features/csv-export/utils/serialize-form-fields.spec.ts
+++ b/src/features/csv-export/utils/serialize-form-fields.spec.ts
@@ -15,7 +15,7 @@ const localFieldsOf = (isoString: string) => {
 
 describe('serializeFormFields', () => {
   it('returns an empty object when there is no data', () => {
-    expect(serializeFormFields(undefined)).toEqual({});
+    expect(serializeFormFields(undefined, true)).toEqual({});
   });
 
   it('omits fields whose value was cleared', () => {
@@ -24,17 +24,17 @@ describe('serializeFormFields', () => {
       to_period: [ new CalendarDateTime(2026, 7, 30, 12, 0) ],
     } as FormFields;
 
-    expect(Object.keys(serializeFormFields(data))).toEqual([ 'to_period' ]);
+    expect(Object.keys(serializeFormFields(data, true))).toEqual([ 'to_period' ]);
   });
 
   it('returns an empty object when every field was cleared', () => {
-    expect(serializeFormFields({ from_period: [], to_period: [] } as FormFields)).toEqual({});
+    expect(serializeFormFields({ from_period: [], to_period: [] } as FormFields, true)).toEqual({});
   });
 
   it('resolves a CalendarDateTime in the local zone, preserving the wall clock', () => {
     const data = { from_period: [ new CalendarDateTime(2026, 7, 30, 12, 0) ] } as FormFields;
 
-    const result = serializeFormFields(data).from_period;
+    const result = serializeFormFields(data, true).from_period;
 
     expect(result).toMatch(/Z$/);
     expect(localFieldsOf(result)).toEqual([ 2026, 7, 30, 12, 0 ]);
@@ -49,7 +49,7 @@ describe('serializeFormFields', () => {
   it('treats a date-only value as local midnight', () => {
     const data = { from_period: [ new CalendarDate(2026, 7, 30) ] } as FormFields;
 
-    expect(localFieldsOf(serializeFormFields(data).from_period)).toEqual([ 2026, 7, 30, 0, 0 ]);
+    expect(localFieldsOf(serializeFormFields(data, true).from_period)).toEqual([ 2026, 7, 30, 0, 0 ]);
   });
 
   it('keeps the instant of a zoned value regardless of the local zone', () => {
@@ -57,7 +57,7 @@ describe('serializeFormFields', () => {
       from_period: [ parseAbsolute('2026-07-30T09:05:00Z', 'America/New_York') ],
     } as FormFields;
 
-    expect(serializeFormFields(data).from_period).toBe('2026-07-30T09:05:00.000Z');
+    expect(serializeFormFields(data, true).from_period).toBe('2026-07-30T09:05:00.000Z');
   });
 
   it('serializes every populated field', () => {
@@ -66,7 +66,7 @@ describe('serializeFormFields', () => {
       to_period: [ new CalendarDateTime(2026, 7, 30, 17, 45) ],
     } as FormFields;
 
-    const result = serializeFormFields(data);
+    const result = serializeFormFields(data, true);
 
     expect(localFieldsOf(result.from_period)).toEqual([ 2026, 7, 29, 8, 30 ]);
     expect(localFieldsOf(result.to_period)).toEqual([ 2026, 7, 30, 17, 45 ]);

--- a/src/features/csv-export/utils/serialize-form-fields.spec.ts
+++ b/src/features/csv-export/utils/serialize-form-fields.spec.ts
@@ -40,6 +40,12 @@ describe('serializeFormFields', () => {
     expect(localFieldsOf(result)).toEqual([ 2026, 7, 30, 12, 0 ]);
   });
 
+  it('reads the wall clock as UTC when local time is off', () => {
+    const data = { from_period: [ new CalendarDateTime(2026, 7, 30, 12, 0) ] } as FormFields;
+
+    expect(serializeFormFields(data, false).from_period).toBe('2026-07-30T12:00:00.000Z');
+  });
+
   it('treats a date-only value as local midnight', () => {
     const data = { from_period: [ new CalendarDate(2026, 7, 30) ] } as FormFields;
 

--- a/src/features/csv-export/utils/serialize-form-fields.ts
+++ b/src/features/csv-export/utils/serialize-form-fields.ts
@@ -15,7 +15,7 @@ const toAbsoluteString = (date: DateValue, isLocalTime: boolean): string => {
   return toZoned(date, isLocalTime ? getLocalTimeZone() : 'UTC').toAbsoluteString();
 };
 
-export default function serializeFormFields(data?: FormFields, isLocalTime: boolean = true): Record<string, string> {
+export default function serializeFormFields(data: FormFields | undefined, isLocalTime: boolean): Record<string, string> {
   const result: Record<string, string> = {};
 
   Object.entries(data ?? {}).forEach(([ key, value ]) => {

--- a/src/features/csv-export/utils/serialize-form-fields.ts
+++ b/src/features/csv-export/utils/serialize-form-fields.ts
@@ -5,20 +5,23 @@ import { getLocalTimeZone, toZoned } from '@internationalized/date';
 
 import type { FormFields } from '../components/dialog/types';
 
-// the date picker yields wall-clock values carrying no time zone, so they are resolved
-// in the user's zone before the API receives them as absolute timestamps
-const toAbsoluteString = (date: DateValue): string => {
-  const zoned = 'timeZone' in date ? date : toZoned(date, getLocalTimeZone());
-  return zoned.toAbsoluteString();
+// the date picker yields wall-clock values carrying no time zone; the toggle in the dialog decides
+// whether those wall-clock digits are read as local time or as UTC before the API receives them as
+// absolute timestamps
+const toAbsoluteString = (date: DateValue, isLocalTime: boolean): string => {
+  if ('timeZone' in date) {
+    return date.toAbsoluteString();
+  }
+  return toZoned(date, isLocalTime ? getLocalTimeZone() : 'UTC').toAbsoluteString();
 };
 
-export default function serializeFormFields(data?: FormFields): Record<string, string> {
+export default function serializeFormFields(data?: FormFields, isLocalTime: boolean = true): Record<string, string> {
   const result: Record<string, string> = {};
 
   Object.entries(data ?? {}).forEach(([ key, value ]) => {
     const [ date ] = value ?? [];
     if (date) {
-      result[key] = toAbsoluteString(date);
+      result[key] = toAbsoluteString(date, isLocalTime);
     }
   });
 

--- a/src/shell/top-bar/settings/time-format/SettingsLocalTime.tsx
+++ b/src/shell/top-bar/settings/time-format/SettingsLocalTime.tsx
@@ -19,8 +19,8 @@ const SettingsLocalTime = (props: SwitchProps) => {
   return (
     <Switch
       id="local-time"
-      defaultChecked={ isLocalTime }
-      onChange={ toggleIsLocalTime }
+      checked={ isLocalTime }
+      onCheckedChange={ toggleIsLocalTime }
       direction="rtl"
       justifyContent="space-between"
       w="100%"

--- a/src/shell/top-bar/settings/time-format/SettingsLocalTime.tsx
+++ b/src/shell/top-bar/settings/time-format/SettingsLocalTime.tsx
@@ -2,11 +2,12 @@
 
 import React from 'react';
 
+import type { SwitchProps } from 'src/toolkit/chakra/switch';
 import { Switch } from 'src/toolkit/chakra/switch';
 
 import { useSettingsContext } from '../context';
 
-const SettingsLocalTime = () => {
+const SettingsLocalTime = (props: SwitchProps) => {
   const settingsContext = useSettingsContext();
 
   if (!settingsContext) {
@@ -24,6 +25,7 @@ const SettingsLocalTime = () => {
       justifyContent="space-between"
       w="100%"
       minH="34px"
+      { ...props }
     >
       Local time format
     </Switch>

--- a/src/toolkit/chakra/date-picker.tsx
+++ b/src/toolkit/chakra/date-picker.tsx
@@ -21,8 +21,8 @@ export interface DatePickerValueChangeDetails {
   view: 'day' | 'month' | 'year';
 }
 
-export const DATE_FORMAT = 'MMM D, YYYY';
-export const DATE_TIME_FORMAT = 'MMM D, YYYY H:mm';
+const DATE_FORMAT = 'MMM D, YYYY';
+export const DATE_PICKER_DATE_TIME_FORMAT = 'MMM D, YYYY H:mm';
 
 // a ZonedDateTime stringifies with an IANA suffix ("...+02:00[Europe/Madrid]") that dayjs cannot parse,
 // so every value is narrowed to a plain calendar date-time before formatting
@@ -33,7 +33,7 @@ const format = (date: DateValue) => {
 };
 
 const formatWithTime = (date: DateValue) => {
-  return toDayjs(date).format(DATE_TIME_FORMAT);
+  return toDayjs(date).format(DATE_PICKER_DATE_TIME_FORMAT);
 };
 
 const parse = (value: string): DateValue | undefined => {

--- a/src/toolkit/chakra/date-picker.tsx
+++ b/src/toolkit/chakra/date-picker.tsx
@@ -21,8 +21,8 @@ export interface DatePickerValueChangeDetails {
   view: 'day' | 'month' | 'year';
 }
 
-const DATE_FORMAT = 'MMM D, YYYY';
-const DATE_TIME_FORMAT = 'MMM D, YYYY H:mm';
+export const DATE_FORMAT = 'MMM D, YYYY';
+export const DATE_TIME_FORMAT = 'MMM D, YYYY H:mm';
 
 // a ZonedDateTime stringifies with an IANA suffix ("...+02:00[Europe/Madrid]") that dayjs cannot parse,
 // so every value is narrowed to a plain calendar date-time before formatting
@@ -95,12 +95,14 @@ const getDefaultDateValue = (withCurrentTime?: boolean): CalendarDateTime => {
 export interface DatePickerProps extends ChakraDatePicker.RootProps {
   withTime?: boolean;
   errorText?: string;
+  timeZoneSuffix?: string;
 }
 
 export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
   function DatePicker({
     placeholder,
     withTime,
+    timeZoneSuffix,
     value: valueProp,
     defaultValue,
     onValueChange: onValueChangeProp,
@@ -115,10 +117,22 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
     ...rest
   }, ref) {
 
+    const formatValue = React.useCallback((date: DateValue) => {
+      const base = withTime ? formatWithTime(date) : format(date);
+      return withTime && timeZoneSuffix ? `${ base } ${ timeZoneSuffix }` : base;
+    }, [ withTime, timeZoneSuffix ]);
+
+    const parseValue = React.useCallback((value: string) => {
+      // the suffix is display-only, so it is stripped before the date itself is parsed back
+      const cleaned = timeZoneSuffix && value.endsWith(timeZoneSuffix) ?
+        value.slice(0, -timeZoneSuffix.length).trimEnd() :
+        value;
+      return withTime ? parseWithTime(cleaned) : parse(cleaned);
+    }, [ withTime, timeZoneSuffix ]);
+
     const onValueChange = React.useCallback((value: Array<DateValue> | undefined) => {
-      const formatValue = withTime ? formatWithTime : format;
       onValueChangeProp?.({ value: value ?? [], valueAsString: value?.map(formatValue) ?? [], view: 'day' });
-    }, [ onValueChangeProp, withTime ]);
+    }, [ onValueChangeProp, formatValue ]);
 
     const [ value, setValue ] = useControllableState<Array<DateValue> | undefined>({
       value: valueProp,
@@ -179,8 +193,8 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
         closeOnSelect={ !withTime }
         lazyMount
         unmountOnExit
-        format={ withTime ? formatWithTime : format }
-        parse={ withTime ? parseWithTime : parse }
+        format={ formatValue }
+        parse={ parseValue }
         value={ value }
         onValueChange={ handleDateChange }
         min={ min }

--- a/src/toolkit/chakra/time-picker.tsx
+++ b/src/toolkit/chakra/time-picker.tsx
@@ -349,7 +349,7 @@ export const TimePicker = ({
           </InputGroup>
         </Field>
       </PopoverTrigger>
-      <PopoverContent borderRadius="base" w="100%" minW="160px" maxW="260px" zIndex="tooltip">
+      <PopoverContent borderRadius="base" w="100%" minW="160px" zIndex="tooltip">
         <PopoverBody>
           <HStack gap={ 3 } alignItems="flex-start">
             <VStack ref={ hoursContainerRef } gap={ `${ GAP_HEIGHT }px` } maxH="232px" overflowY="scroll" scrollbarWidth="none" scrollSnapType="y mandatory">


### PR DESCRIPTION
## Description

Resolves #3615

The CSV export dialog's From/To pickers gave no indication of which time
zone the entered wall-clock was read in — it was silently resolved in the
user's local zone — so users couldn't tell what "time" the export period
actually meant.

This surfaces the app's existing "Local time format" setting inside the
dialog (bound to the same global `isLocalTime` preference) and makes the
pickers zone-explicit. With the toggle **on** (local, default) the
wall-clock is read as local with no suffix; with it **off** (UTC) the
wall-clock is read as UTC and a "UTC" suffix is shown on the fields, the
async downloads-list period, and the downloaded file name. The submitted
zone is persisted per async download item so its period always renders in
the same zone and format the dialog showed. The shared `DatePicker` gains
an optional `timeZoneSuffix` prop; the field is remounted on zone change
because the underlying picker only re-syncs its displayed text on
value/locale changes, not on a format change.

## Environment variables

None

## Minimum API version

None (the From/To filter is still sent as absolute UTC timestamps; only the client-side interpretation and display changed).

## Breaking or incompatible changes

None

## Additional information

- The zone-aware file name applies to the synchronous download path; asynchronously generated files are named by the backend.
- Legacy async download items created before this change carry no zone flag and fall back to local-time rendering.
