### PR TITLE
Stop false "N more transfers" notices on the NFT instance transfers tab

### DIFF
--- a/src/slices/token-transfer/pages/token/TokenTransfer.tsx
+++ b/src/slices/token-transfer/pages/token/TokenTransfer.tsx
@@ -35,6 +35,11 @@ const TokenTransfer = ({ tokenId, token, isLoading: isLoadingProp, tokenInstance
   const [ newItemsCount, setNewItemsCount ] = useGradualIncrement(0);
   const [ showSocketErrorAlert, setShowSocketErrorAlert ] = React.useState(false);
 
+  // The backend emits `token_transfer` events for the whole token, not per instance, so on the NFT
+  // instance page they produce false "N more transfers" notices. Only listen on the token-level page.
+  // See https://github.com/blockscout/frontend/issues/3653
+  const isSocketEnabled = !tokenId;
+
   const transfersQuery = useQueryWithPages({
     resourceName: tokenId ? 'core:token_instance_transfers' : 'core:token_transfers',
     pathParams: { hash: token?.address_hash, id: tokenId },
@@ -60,7 +65,7 @@ const TokenTransfer = ({ tokenId, token, isLoading: isLoadingProp, tokenInstance
     topic: `tokens:${ token?.address_hash.toLowerCase() }`,
     onSocketClose: handleSocketClose,
     onSocketError: handleSocketError,
-    isDisabled: transfersQuery.isPlaceholderData || transfersQuery.isError || transfersQuery.pagination.page !== 1,
+    isDisabled: !isSocketEnabled || transfersQuery.isPlaceholderData || transfersQuery.isError || transfersQuery.pagination.page !== 1,
   });
   useSocketMessage({
     channel,
@@ -76,7 +81,7 @@ const TokenTransfer = ({ tokenId, token, isLoading: isLoadingProp, tokenInstance
         <TokenTransferTable
           data={ transfersQuery.data?.items }
           top={ ACTION_BAR_HEIGHT_DESKTOP }
-          showSocketInfo={ transfersQuery.pagination.page === 1 }
+          showSocketInfo={ isSocketEnabled && transfersQuery.pagination.page === 1 }
           showSocketErrorAlert={ showSocketErrorAlert }
           socketInfoNum={ newItemsCount }
           tokenId={ tokenId }
@@ -87,7 +92,7 @@ const TokenTransfer = ({ tokenId, token, isLoading: isLoadingProp, tokenInstance
         />
       </Box>
       <Box display={{ base: 'block', lg: 'none' }}>
-        { transfersQuery.pagination.page === 1 && (
+        { isSocketEnabled && transfersQuery.pagination.page === 1 && (
           <SocketNewItemsNotice.Mobile
             num={ newItemsCount }
             showErrorAlert={ showSocketErrorAlert }

--- a/src/slices/token-transfer/pages/token/TokenTransfer.tsx
+++ b/src/slices/token-transfer/pages/token/TokenTransfer.tsx
@@ -36,7 +36,7 @@ const TokenTransfer = ({ tokenId, token, isLoading: isLoadingProp, tokenInstance
   const [ showSocketErrorAlert, setShowSocketErrorAlert ] = React.useState(false);
 
   // The backend emits `token_transfer` events for the whole token, not per instance, so on the NFT
-  // instance page they produce false "N more transfers" notices. Only listen on the token-level page.
+  // instance page they produce false "N more transfers" notices.
   // See https://github.com/blockscout/frontend/issues/3653
   const isSocketEnabled = !tokenId;
 


### PR DESCRIPTION
## Description

Resolves #3653

The token transfers table is shared between the token-level transfers tab and the
NFT instance transfers tab. It subscribed to the whole-token `tokens:<hash>` WebSocket
channel and its `token_transfer` event. On an instance page the backend still emits
events for the entire token, so transfers of *other* instances surfaced as false
"N more token transfers" notices.

Gated the socket subscription and both its notices (desktop `showSocketInfo` and the
mobile `SocketNewItemsNotice`) behind `isSocketEnabled = !tokenId`, so real-time
updates run only on the token-level page. `tokenId` is present only in the instance case.

## Environment variables

None

## Minimum API version

None

## Breaking or incompatible changes

None

## Additional information

None
