### PR TITLE
Add a Slack reply watcher to the product-task workflow

### DIFF
--- a/.agents/skills/grill-the-task/SKILL.md
+++ b/.agents/skills/grill-the-task/SKILL.md
@@ -97,7 +97,8 @@ Route every question the session couldn't answer to the person who owns it.
 3. Draft one message per owner: brief task context (issue link), the questions, and why they block progress.
    Write all Slack messages in **Russian** — the team's internal language (the spec itself stays in English).
 4. **Show every draft (with its destination) to the user and wait for explicit approval** — never send
-   unreviewed outreach.
+   unreviewed *new* outreach. (In-thread follow-ups on a thread already approved here are exempt — see
+   "Watch for replies" below.)
 5. Send (`slack_send_message`), then keep each thread's permalink for the question's `questions.md` entry.
 
 If the Slack MCP tools are unavailable, record the questions with owners anyway and tell the user to route
@@ -109,27 +110,32 @@ routes it manually.
 ### Watch for replies and drive each question to settled
 
 Once the questions are sent, don't hand the reply round-trip back to the developer to poll. Launch the
-**`slack-watch`** skill under `Monitor(persistent: true)` with one `CHANNEL:THREAD_TS` argument per
-`pending` question thread (the channel id and parent `ts` from each `slack_send_message` you just sent).
-Adding or resolving a question later means stopping that Monitor and relaunching it with the new thread
-list — questions move at human pace, so the restart is free. If the tokens aren't set up, `slack-watch`
-guides the developer through it; until then, the developer polls manually as before.
+**`slack-watch`** skill with one `CHANNEL:THREAD_TS` argument per `pending` question thread (the channel
+id and parent `ts` from each `slack_send_message` you just sent). That skill owns how to start, stop, and
+relaunch on Claude Code vs Cursor — follow it. Adding or resolving a question later means stopping the
+watcher and relaunching with the new thread list; questions move at human pace, so the restart is free.
+If the tokens aren't set up, `slack-watch` guides the developer through it; until then, the developer
+polls manually as before.
 
-On each `NEW …` notification the Monitor surfaces, read the reply with `slack_read_thread` on that
-`thread_ts`, then for the question that thread belongs to:
+On each `NEW …` notification, read the reply with `slack_read_thread` on that `thread_ts`, then for the
+question that thread belongs to:
 
-- **Assess** the reply against the question's `Resolved when:` criterion.
+- **Assess** the reply against the question's `Resolved when:` criterion — session-held here, since this
+  runs before `to-spec`; it only becomes a `questions.md` line once `to-spec` writes one (lifecycle step 2).
 - **Insufficient** → send a clarifying **follow-up to the colleague directly, in the same thread, without
   developer approval** — this is continuing a conversation the developer already opened. Cap: **3**
   consecutive follow-ups per question, then escalate. Opening a *new* thread or contacting a *new* person
   stays approval-gated (Step 3 rules unchanged).
 - **Sufficient** → **propose in the session chat**: the answer arrived, the proposed resolution, and the
-  exact `questions.md` / spec / ticket edits it implies. **Edit no file.** Apply the changes only after the
-  developer accepts in-session — so `implement-ticket`'s question gate never releases work a human hasn't
-  read (the fold-in itself is `.agents/tasks/README.md` step 4).
-- **Escalate via `PushNotification`** (one line: which task/question and why it's stuck) when the answer
-  needs *frontend* knowledge only the developer has, the 3-follow-up cap is hit, or the colleague goes
-  silent.
+  edits it implies. **Edit no file.** Apply only after the developer accepts in-session. Where the answer
+  lands depends on how far the task has come: once `to-spec` has run, fold it into `questions.md` (the
+  fold-in is `.agents/tasks/README.md` step 4) — so `implement-ticket`'s question gate never releases work
+  a human hasn't read; before that (still grilling, or a small task that never gets a spec), hold it in
+  session to inform the forthcoming spec or to unblock the in-session implementation.
+- **Escalate** (one line: which task/question and why it's stuck) when the answer needs *frontend*
+  knowledge only the developer has, the 3-follow-up cap is hit, or the colleague goes silent.
+  Claude Code: `PushNotification` with that line. Cursor: the same line in this session chat — Cursor has
+  no OS nudge.
 
 Every message posted to a colleague carries a disclosure — they must be able to tell they're in a
 technical back-and-forth with an agent. Prefer the Slack connector's own attribution if it appends one;

--- a/.agents/skills/grill-the-task/SKILL.md
+++ b/.agents/skills/grill-the-task/SKILL.md
@@ -106,6 +106,35 @@ them manually.
 Outreach is complete when every question has a recorded permalink — or an explicit note that the developer
 routes it manually.
 
+### Watch for replies and drive each question to settled
+
+Once the questions are sent, don't hand the reply round-trip back to the developer to poll. Launch the
+**`slack-watch`** skill under `Monitor(persistent: true)` with one `CHANNEL:THREAD_TS` argument per
+`pending` question thread (the channel id and parent `ts` from each `slack_send_message` you just sent).
+Adding or resolving a question later means stopping that Monitor and relaunching it with the new thread
+list — questions move at human pace, so the restart is free. If the tokens aren't set up, `slack-watch`
+guides the developer through it; until then, the developer polls manually as before.
+
+On each `NEW …` notification the Monitor surfaces, read the reply with `slack_read_thread` on that
+`thread_ts`, then for the question that thread belongs to:
+
+- **Assess** the reply against the question's `Resolved when:` criterion.
+- **Insufficient** → send a clarifying **follow-up to the colleague directly, in the same thread, without
+  developer approval** — this is continuing a conversation the developer already opened. Cap: **3**
+  consecutive follow-ups per question, then escalate. Opening a *new* thread or contacting a *new* person
+  stays approval-gated (Step 3 rules unchanged).
+- **Sufficient** → **propose in the session chat**: the answer arrived, the proposed resolution, and the
+  exact `questions.md` / spec / ticket edits it implies. **Edit no file.** Apply the changes only after the
+  developer accepts in-session — so `implement-ticket`'s question gate never releases work a human hasn't
+  read (the fold-in itself is `.agents/tasks/README.md` step 4).
+- **Escalate via `PushNotification`** (one line: which task/question and why it's stuck) when the answer
+  needs *frontend* knowledge only the developer has, the 3-follow-up cap is hit, or the colleague goes
+  silent.
+
+Every message posted to a colleague carries a disclosure — they must be able to tell they're in a
+technical back-and-forth with an agent. Prefer the Slack connector's own attribution if it appends one;
+otherwise append `— via @Honk 🪿`. All follow-ups stay in **Russian**, like the original outreach.
+
 ## Step 4 — Size and hand off
 
 Decide, by a rough sizing judgment, whether the task needs a spec — one session of work or not. No formal

--- a/.agents/skills/slack-watch/SKILL.md
+++ b/.agents/skills/slack-watch/SKILL.md
@@ -2,11 +2,11 @@
 name: slack-watch
 description: >-
   Watch Slack threads (DMs and channels) for new replies over a Socket Mode
-  WebSocket, printing one line per genuinely-new reply. Use to be notified —
-  inside a live session, under the Monitor tool.
+  WebSocket, printing one line per genuinely-new reply. Use to be notified
+  inside a live local Claude Code or Cursor session (not a cloud agent).
 ---
 
-<!-- cspell:ignore acks xapp xoxp xoxb WXYZ -->
+<!-- cspell:ignore acks xapp xoxp xoxb WXYZ AwaitShell -->
 
 # Slack watch
 
@@ -27,13 +27,19 @@ From **this skill's directory** (the folder that contains this `SKILL.md`):
 
 If 2 fails: give the user **Setup** below and stop. Do not store the tokens yourself.
 
-The sandbox cannot read the Keychain or reach `slack.com` — run under the Monitor tool with those allowed.
+**Local session only** — the Keychain and the socket both live on this Mac. If you are a cloud agent, stop and tell the developer to run this in local Claude Code or Cursor.
 
-**Done when:** every check passes, or the run has stopped for setup.
+**Done when:** every check passes, or the run has stopped for setup (or cloud).
 
 ## 2. Run
 
-Each watched thread is one `CHANNEL:THREAD_TS` argv item — the channel id (a DM is `D…`, a channel `C…`, a private group `G…`) and the parent `ts`, both from the `slack_send_message` / permalink you already hold. The script routes each by its id prefix; channel threads only report if the Honk bot is a member of that channel. Launch it under **`Monitor` with `persistent: true`** so each printed line becomes an in-session notification for the lifetime of the session:
+Each watched thread is one `CHANNEL:THREAD_TS` argv item — the channel id (a DM is `D…`, a channel `C…`, a private group `G…`) and the parent `ts`, both from the `slack_send_message` / permalink you already hold. The script routes each by its id prefix; channel threads only report if the Honk bot is a member of that channel.
+
+Launch so each stdout line wakes this session. Use the recipe whose tools you have.
+
+### Claude Code
+
+`Monitor` with `persistent: true`. The sandbox cannot read the Keychain or reach `slack.com` — allow both on that Monitor.
 
 ```
 Monitor(
@@ -43,20 +49,41 @@ Monitor(
 )
 ```
 
-Give the absolute path to `scripts/slack-watch` if the Monitor's working directory is not this skill's directory.
+Give the absolute path to `scripts/slack-watch` if Monitor's working directory is not this skill's directory.
+
+### Cursor (local IDE)
+
+Background `Shell` (`block_until_ms: 0`) with `notify_on_output` and `required_permissions: ["all"]` (Keychain + `slack.com`). Cursor floors notification debounce at 5s — two `NEW` lines in one burst may arrive as one wake; on wake, read the terminal output and handle every `NEW` line, not only the last.
+
+```
+Shell(
+  command: "<absolute>/scripts/slack-watch C0123ABCD:1700000000.000200 D0456WXYZ:1700000100.000700",
+  description: "Slack reply watcher",
+  block_until_ms: 0,
+  required_permissions: ["all"],
+  notify_on_output: { pattern: "^NEW |^RECONNECTED", reason: "Slack reply" },
+)
+```
+
+Use the absolute path. Smoke-check the terminal output file once so a failed start is not silent.
 
 ### Output lines
 
 - `NEW channel=<C…> thread_ts=<ts> ts=<ts>` — a new reply landed (or was missed during downtime and reconciled on reconnect). Read it with `slack_read_thread` on that `thread_ts`. Our own messages — the developer's **and** the Honk bot's, including agent follow-ups posted as either — and the thread's pre-existing history are **not** reported.
 - `RECONNECTED` — the socket re-opened after a drop; a catch-up for every watched thread has just run, so any `NEW` lines around it are the replies missed while it was down.
 
-Diagnostics (auth or reconnect failures) go to stderr — Monitor's output file, not notifications; Read it if the watcher seems quiet.
+Diagnostics (auth or reconnect failures) go to stderr — Claude's Monitor output file, or Cursor's terminal file; Read it if the watcher seems quiet.
 
 ### Changing the watched set
 
-All state lives in the process (thread list, per-thread last-seen `ts`, `event_id` dedupe). There is no state file. To add or remove a thread, **stop the Monitor (`TaskStop`) and relaunch** with the new argument list. Re-spawning re-baselines to "from now" — earlier replies are already in the session transcript, so nothing is double-reported.
+All state lives in the process (thread list, per-thread last-seen `ts`, `event_id` dedupe). There is no state file. To add or remove a thread, **stop and relaunch** with the new argument list.
 
-**Done when:** the Monitor is running and reporting, or the run has stopped for setup.
+- Claude Code: `TaskStop` on that Monitor, then launch again.
+- Cursor: kill the PID in that shell's header, `AwaitShell` so the completion ping is consumed, then launch again.
+
+Re-spawning re-baselines to "from now" — earlier replies are already in the session transcript, so nothing is double-reported.
+
+**Done when:** the watcher is running and reporting, or the run has stopped for setup.
 
 ## Setup
 

--- a/.agents/skills/slack-watch/SKILL.md
+++ b/.agents/skills/slack-watch/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: slack-watch
+description: >-
+  Watch Slack threads for new replies over a Socket Mode WebSocket, printing one
+  line per genuinely-new reply. Use to be notified — inside a live session, under
+  the Monitor tool.
+---
+
+<!-- cspell:ignore acks xapp xoxp WXYZ -->
+
+# Slack watch
+
+A push subscription to replies in specific Slack threads. The script holds a Socket Mode WebSocket, acks every event, and prints one line per new reply — nothing else. It knows nothing about tasks or questions; it filters a thread list you give it and reports. The caller (a session, a skill) decides what a reply means and reads it via the Slack MCP (`slack_read_thread`).
+
+macOS. Two tokens live in the Keychain; the script reads them and never prints them. It does **not** print message content or event payloads — the underlying `message.im` feed is a DM firehose.
+
+## 1. Ready
+
+From **this skill's directory** (the folder that contains this `SKILL.md`):
+
+1. `scripts/slack-watch` is executable.
+2. Keychain has both services, metadata only (no `-w`):
+   - `security find-generic-password -s slack-orchestrator-app-token`
+   - `security find-generic-password -s slack-orchestrator-user-token`
+3. Node 22+ is on `PATH` (`node --version`) — the script uses the built-in `WebSocket` and `fetch`, no npm deps.
+
+If 2 fails: give the user **Setup** below and stop. Do not store the tokens yourself.
+
+The sandbox cannot read the Keychain or reach `slack.com` — run under the Monitor tool with those allowed.
+
+**Done when:** every check passes, or the run has stopped for setup.
+
+## 2. Run
+
+Each watched thread is one `CHANNEL:THREAD_TS` argv item — the channel id (a DM is `D…`) and the parent `ts`, both from the `slack_send_message` / permalink you already hold. Launch it under **`Monitor` with `persistent: true`** so each printed line becomes an in-session notification for the lifetime of the session:
+
+```
+Monitor(
+  command: "scripts/slack-watch C0123ABCD:1700000000.000200 D0456WXYZ:1700000100.000700",
+  description: "Slack reply watcher",
+  persistent: true,
+)
+```
+
+Give the absolute path to `scripts/slack-watch` if the Monitor's working directory is not this skill's directory.
+
+### Output lines
+
+- `NEW channel=<C…> thread_ts=<ts> ts=<ts>` — a new reply landed (or was missed during downtime and reconciled on reconnect). Read it with `slack_read_thread` on that `thread_ts`. Own messages (the developer's, including agent follow-ups posted as them) and the thread's pre-existing history are **not** reported.
+- `RECONNECTED` — the socket re-opened after a drop; a catch-up for every watched thread has just run, so any `NEW` lines around it are the replies missed while it was down.
+
+Diagnostics (auth or reconnect failures) go to stderr — Monitor's output file, not notifications; Read it if the watcher seems quiet.
+
+### Changing the watched set
+
+All state lives in the process (thread list, per-thread last-seen `ts`, `event_id` dedupe). There is no state file. To add or remove a thread, **stop the Monitor (`TaskStop`) and relaunch** with the new argument list. Re-spawning re-baselines to "from now" — earlier replies are already in the session transcript, so nothing is double-reported.
+
+**Done when:** the Monitor is running and reporting, or the run has stopped for setup.
+
+## Setup
+
+One private Slack app in the Blockscout workspace (**api.slack.com/apps → your app**), carrying two tokens:
+
+- **App-level token** (`xapp-`), scope `connections:write` — created under **Socket Mode → toggle on → generate token**. Opens the WebSocket.
+- **User token** (`xoxp-`), **User Token Scopes** `im:history` + `chat:write`. Under **Event Subscriptions → on behalf of users**, subscribe **`message.im` only** — not `message.channels` / `message.groups` (that is a firehose on a user token). Reads replies for catch-up and posts in the developer's own voice.
+
+Store both in the Keychain yourself (the script never writes them):
+
+```bash
+security add-generic-password -U -s slack-orchestrator-app-token  -a "$USER" -w   # prompts for xapp-…
+security add-generic-password -U -s slack-orchestrator-user-token -a "$USER" -w   # prompts for xoxp-…
+```
+
+The bot user is **Honk** 🪿 (`honk`) — enable it under **App Home** so the disclosure identity exists.

--- a/.agents/skills/slack-watch/SKILL.md
+++ b/.agents/skills/slack-watch/SKILL.md
@@ -1,27 +1,28 @@
 ---
 name: slack-watch
 description: >-
-  Watch Slack threads for new replies over a Socket Mode WebSocket, printing one
-  line per genuinely-new reply. Use to be notified — inside a live session, under
-  the Monitor tool.
+  Watch Slack threads (DMs and channels) for new replies over a Socket Mode
+  WebSocket, printing one line per genuinely-new reply. Use to be notified —
+  inside a live session, under the Monitor tool.
 ---
 
-<!-- cspell:ignore acks xapp xoxp WXYZ -->
+<!-- cspell:ignore acks xapp xoxp xoxb WXYZ -->
 
 # Slack watch
 
-A push subscription to replies in specific Slack threads. The script holds a Socket Mode WebSocket, acks every event, and prints one line per new reply — nothing else. It knows nothing about tasks or questions; it filters a thread list you give it and reports. The caller (a session, a skill) decides what a reply means and reads it via the Slack MCP (`slack_read_thread`).
+A push subscription to replies in specific Slack threads — **DM threads and channel threads both**. The script holds one Socket Mode WebSocket, acks every event, and prints one line per new reply — nothing else. It knows nothing about tasks or questions; it filters a thread list you give it and reports. The caller (a session, a skill) decides what a reply means and reads it via the Slack MCP (`slack_read_thread`).
 
-macOS. Two tokens live in the Keychain; the script reads them and never prints them. It does **not** print message content or event payloads — the underlying `message.im` feed is a DM firehose.
+macOS. Three tokens live in the Keychain; the script reads them and never prints them. It does **not** print message content or event payloads — the underlying `message.im` feed is a DM firehose. DMs are watched with the developer's **user** token; channels are watched with the **bot** token, which only sees channels the Honk bot was invited into (so no firehose there). A single Socket Mode connection carries both the bot and user events.
 
 ## 1. Ready
 
 From **this skill's directory** (the folder that contains this `SKILL.md`):
 
 1. `scripts/slack-watch` is executable.
-2. Keychain has both services, metadata only (no `-w`):
+2. Keychain has all three services, metadata only (no `-w`):
    - `security find-generic-password -s slack-orchestrator-app-token`
    - `security find-generic-password -s slack-orchestrator-user-token`
+   - `security find-generic-password -s slack-orchestrator-bot-token`
 3. Node 22+ is on `PATH` (`node --version`) — the script uses the built-in `WebSocket` and `fetch`, no npm deps.
 
 If 2 fails: give the user **Setup** below and stop. Do not store the tokens yourself.
@@ -32,7 +33,7 @@ The sandbox cannot read the Keychain or reach `slack.com` — run under the Moni
 
 ## 2. Run
 
-Each watched thread is one `CHANNEL:THREAD_TS` argv item — the channel id (a DM is `D…`) and the parent `ts`, both from the `slack_send_message` / permalink you already hold. Launch it under **`Monitor` with `persistent: true`** so each printed line becomes an in-session notification for the lifetime of the session:
+Each watched thread is one `CHANNEL:THREAD_TS` argv item — the channel id (a DM is `D…`, a channel `C…`, a private group `G…`) and the parent `ts`, both from the `slack_send_message` / permalink you already hold. The script routes each by its id prefix; channel threads only report if the Honk bot is a member of that channel. Launch it under **`Monitor` with `persistent: true`** so each printed line becomes an in-session notification for the lifetime of the session:
 
 ```
 Monitor(
@@ -46,7 +47,7 @@ Give the absolute path to `scripts/slack-watch` if the Monitor's working directo
 
 ### Output lines
 
-- `NEW channel=<C…> thread_ts=<ts> ts=<ts>` — a new reply landed (or was missed during downtime and reconciled on reconnect). Read it with `slack_read_thread` on that `thread_ts`. Own messages (the developer's, including agent follow-ups posted as them) and the thread's pre-existing history are **not** reported.
+- `NEW channel=<C…> thread_ts=<ts> ts=<ts>` — a new reply landed (or was missed during downtime and reconciled on reconnect). Read it with `slack_read_thread` on that `thread_ts`. Our own messages — the developer's **and** the Honk bot's, including agent follow-ups posted as either — and the thread's pre-existing history are **not** reported.
 - `RECONNECTED` — the socket re-opened after a drop; a catch-up for every watched thread has just run, so any `NEW` lines around it are the replies missed while it was down.
 
 Diagnostics (auth or reconnect failures) go to stderr — Monitor's output file, not notifications; Read it if the watcher seems quiet.
@@ -59,16 +60,16 @@ All state lives in the process (thread list, per-thread last-seen `ts`, `event_i
 
 ## Setup
 
-One private Slack app in the Blockscout workspace (**api.slack.com/apps → your app**), carrying two tokens:
+One private Slack app in the Blockscout workspace (**api.slack.com/apps → your app**), carrying three tokens. Enable the bot user **Honk** 🪿 (`honk`) under **App Home** first — it is both the channel-reading identity and the disclosure identity.
 
 - **App-level token** (`xapp-`), scope `connections:write` — created under **Socket Mode → toggle on → generate token**. Opens the WebSocket.
-- **User token** (`xoxp-`), **User Token Scopes** `im:history` + `chat:write`. Under **Event Subscriptions → on behalf of users**, subscribe **`message.im` only** — not `message.channels` / `message.groups` (that is a firehose on a user token). Reads replies for catch-up and posts in the developer's own voice.
+- **User token** (`xoxp-`), **User Token Scopes** `im:history` + `chat:write`. Under **Event Subscriptions → on behalf of users**, subscribe **`message.im` only** — not `message.channels` / `message.groups` (that is a firehose on a user token). Reads DM replies and posts in the developer's own voice.
+- **Bot token** (`xoxb-`), **Bot Token Scopes** `channels:history` (add `groups:history` for private channels) + `chat:write`. Under **Event Subscriptions → bot events**, subscribe **`message.channels`** (and `message.groups` for private channels). Bot events fire only for channels the bot is a member of, so **invite Honk to each question channel** (`/invite @Honk`) — that is what scopes the channel feed instead of firehosing.
 
-Store both in the Keychain yourself (the script never writes them):
+Store all three in the Keychain yourself (the script never writes them):
 
 ```bash
 security add-generic-password -U -s slack-orchestrator-app-token  -a "$USER" -w   # prompts for xapp-…
 security add-generic-password -U -s slack-orchestrator-user-token -a "$USER" -w   # prompts for xoxp-…
+security add-generic-password -U -s slack-orchestrator-bot-token  -a "$USER" -w   # prompts for xoxb-…
 ```
-
-The bot user is **Honk** 🪿 (`honk`) — enable it under **App Home** so the disclosure identity exists.

--- a/.agents/skills/slack-watch/scripts/slack-watch
+++ b/.agents/skills/slack-watch/scripts/slack-watch
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// Slack Socket Mode reply watcher. Holds the WebSocket, acks every event, and
+// prints one line per genuinely-new reply in a watched thread. It does no
+// reasoning: the live session reads the thread itself (via the Slack MCP) when
+// a NEW line arrives. It never prints message content and never logs event
+// payloads — the user-token message.im feed is a DM firehose and must not leak.
+//
+// Two tokens, both from the macOS Keychain, never in argv, a dotfile, or output:
+//   app-level (xapp-)  opens the Socket Mode socket   — slack-orchestrator-app-token
+//   user      (xoxp-)  reads replies for catch-up      — slack-orchestrator-user-token
+//
+// Node 22+ only: relies on the built-in global WebSocket and fetch — no npm deps.
+// cspell:ignore acks xapp xoxp
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+
+const APP_TOKEN_SERVICE = 'slack-orchestrator-app-token';
+const USER_TOKEN_SERVICE = 'slack-orchestrator-user-token';
+const FATAL_AUTH_ERRORS = new Set(['invalid_auth', 'not_authed', 'account_inactive', 'token_revoked']);
+
+function die(msg) {
+  process.stderr.write(`slack-watch: ${msg}\n`);
+  process.exit(1);
+}
+
+function warn(msg) {
+  // stderr only — Monitor routes it to the output file, not to notifications.
+  process.stderr.write(`slack-watch: ${msg}\n`);
+}
+
+function emit(line) {
+  process.stdout.write(line + '\n');
+}
+
+function keychain(service) {
+  try {
+    return execFileSync('security', ['find-generic-password', '-s', service, '-w'], {
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    die(`no token in Keychain under service '${service}' — see the slack-watch skill (Setup)`);
+  }
+}
+
+const num = (ts) => parseFloat(ts);
+
+// argv: one "CHANNEL:THREAD_TS" per watched thread. lastTs is the per-thread
+// watermark; it starts at thread_ts and only ever advances.
+const watched = new Map();
+for (const arg of process.argv.slice(2)) {
+  const i = arg.indexOf(':');
+  if (i < 0) die(`bad thread arg '${arg}', expected CHANNEL:THREAD_TS`);
+  const channel = arg.slice(0, i);
+  const thread_ts = arg.slice(i + 1);
+  watched.set(`${channel}:${thread_ts}`, { channel, thread_ts, lastTs: thread_ts });
+}
+if (watched.size === 0) die('no threads to watch — pass CHANNEL:THREAD_TS args');
+
+const appToken = keychain(APP_TOKEN_SERVICE);
+const userToken = keychain(USER_TOKEN_SERVICE);
+
+const seenEventIds = new Set();
+let selfId = null; // the developer's own user id — their messages are not replies to notify on.
+let ws = null;
+let established = false; // flips on the first `hello`; later `hello`s mean a reconnect.
+let reconnectTimer = null;
+
+async function call(method, token, params = {}, httpMethod = 'GET') {
+  const qs = new URLSearchParams(params).toString();
+  const url = `https://slack.com/api/${method}` + (httpMethod === 'GET' && qs ? `?${qs}` : '');
+  const res = await fetch(url, {
+    method: httpMethod,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(httpMethod === 'POST' ? { 'Content-Type': 'application/x-www-form-urlencoded' } : {}),
+    },
+    body: httpMethod === 'POST' ? qs : undefined,
+  });
+  return res.json();
+}
+
+// Advance each thread's watermark to Slack's current state. emitMissed=false is
+// the first-connect baseline (adopt "from now" silently — earlier replies are
+// already in the session transcript); emitMissed=true is the post-downtime
+// catch-up that prints what was missed while the socket was down.
+async function reconcile(emitMissed) {
+  for (const w of watched.values()) {
+    let res;
+    try {
+      res = await call('conversations.replies', userToken, {
+        channel: w.channel,
+        ts: w.thread_ts,
+        oldest: w.lastTs,
+        inclusive: 'false',
+        limit: '200',
+      });
+    } catch (e) {
+      warn(`replies ${w.channel}: ${e.message}`);
+      continue;
+    }
+    if (!res.ok) {
+      warn(`replies ${w.channel}: ${res.error}`);
+      continue;
+    }
+    for (const m of res.messages || []) {
+      if (m.subtype || m.user === selfId) continue; // edits/joins and our own posts are not replies
+      if (num(m.ts) <= num(w.lastTs)) continue;
+      if (emitMissed) emit(`NEW channel=${w.channel} thread_ts=${w.thread_ts} ts=${m.ts}`);
+      w.lastTs = m.ts;
+    }
+  }
+}
+
+function handleEvent(payload) {
+  const eventId = payload.event_id;
+  if (eventId) {
+    if (seenEventIds.has(eventId)) return;
+    seenEventIds.add(eventId);
+  }
+  const e = payload.event;
+  if (!e || e.type !== 'message' || e.subtype) return; // plain messages only
+  if (e.user === selfId) return; // our own follow-ups arrive here too — ignore them
+  const thread_ts = e.thread_ts;
+  if (!thread_ts) return; // a top-level message, not a threaded reply
+  const w = watched.get(`${e.channel}:${thread_ts}`);
+  if (!w || num(e.ts) <= num(w.lastTs)) return;
+  emit(`NEW channel=${e.channel} thread_ts=${thread_ts} ts=${e.ts}`);
+  w.lastTs = e.ts;
+}
+
+function handleFrame(data) {
+  let msg;
+  try {
+    msg = JSON.parse(data);
+  } catch {
+    return;
+  }
+  if (msg.type === 'hello') {
+    if (!established) {
+      established = true;
+      reconcile(false);
+    } else {
+      emit('RECONNECTED');
+      reconcile(true);
+    }
+    return;
+  }
+  if (msg.type === 'disconnect') {
+    // Slack asks us to reconnect (refresh/too-many-connections). Close and the
+    // close handler reopens on a fresh URL.
+    if (ws) ws.close();
+    return;
+  }
+  if (msg.envelope_id) {
+    // Ack within Slack's 3s window, before doing anything else with the event.
+    ws.send(JSON.stringify({ envelope_id: msg.envelope_id }));
+  }
+  if (msg.type === 'events_api') handleEvent(msg.payload);
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) return;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    connect().catch(scheduleReconnect);
+  }, 1000);
+}
+
+async function connect() {
+  const open = await call('apps.connections.open', appToken, {}, 'POST');
+  if (!open.ok) {
+    if (FATAL_AUTH_ERRORS.has(open.error)) die(`apps.connections.open: ${open.error} (check the app-level token)`);
+    throw new Error(`apps.connections.open: ${open.error}`);
+  }
+  ws = new WebSocket(open.url);
+  ws.addEventListener('message', (ev) => handleFrame(typeof ev.data === 'string' ? ev.data : ''));
+  ws.addEventListener('close', scheduleReconnect);
+  ws.addEventListener('error', () => {}); // a close event always follows; reconnect there
+}
+
+(async () => {
+  const auth = await call('auth.test', userToken);
+  if (!auth.ok) die(`auth.test: ${auth.error} (check the user token)`);
+  selfId = auth.user_id;
+  await connect();
+})().catch(scheduleReconnect);

--- a/.agents/skills/slack-watch/scripts/slack-watch
+++ b/.agents/skills/slack-watch/scripts/slack-watch
@@ -5,18 +5,25 @@
 // a NEW line arrives. It never prints message content and never logs event
 // payloads — the user-token message.im feed is a DM firehose and must not leak.
 //
-// Two tokens, both from the macOS Keychain, never in argv, a dotfile, or output:
-//   app-level (xapp-)  opens the Socket Mode socket   — slack-orchestrator-app-token
-//   user      (xoxp-)  reads replies for catch-up      — slack-orchestrator-user-token
+// A single Socket Mode connection carries the app's bot events and its user
+// events together, so DM and channel threads are watched over one socket. The
+// two identities split by conversation type: DMs are the developer's own (user
+// token), channels belong to the Honk bot invited into them (bot token).
+//
+// Three tokens, all from the macOS Keychain, never in argv, a dotfile, or output:
+//   app-level (xapp-)  opens the Socket Mode socket          — slack-orchestrator-app-token
+//   user      (xoxp-)  reads DM replies, is the DM identity   — slack-orchestrator-user-token
+//   bot       (xoxb-)  reads channel replies, is the bot ident — slack-orchestrator-bot-token
 //
 // Node 22+ only: relies on the built-in global WebSocket and fetch — no npm deps.
-// cspell:ignore acks xapp xoxp
+// cspell:ignore acks xapp xoxp xoxb
 'use strict';
 
 const { execFileSync } = require('node:child_process');
 
 const APP_TOKEN_SERVICE = 'slack-orchestrator-app-token';
 const USER_TOKEN_SERVICE = 'slack-orchestrator-user-token';
+const BOT_TOKEN_SERVICE = 'slack-orchestrator-bot-token';
 const FATAL_AUTH_ERRORS = new Set(['invalid_auth', 'not_authed', 'account_inactive', 'token_revoked']);
 
 function die(msg) {
@@ -59,12 +66,18 @@ if (watched.size === 0) die('no threads to watch — pass CHANNEL:THREAD_TS args
 
 const appToken = keychain(APP_TOKEN_SERVICE);
 const userToken = keychain(USER_TOKEN_SERVICE);
+const botToken = keychain(BOT_TOKEN_SERVICE);
 
 const seenEventIds = new Set();
-let selfId = null; // the developer's own user id — their messages are not replies to notify on.
+const ownIds = new Set(); // our own user ids (developer + Honk bot) — never a reply to notify on.
 let ws = null;
 let established = false; // flips on the first `hello`; later `hello`s mean a reconnect.
 let reconnectTimer = null;
+
+// DM channels (D…) are read with the user token; channels (C…) and private
+// groups (G…) are read with the bot token, which has history only where the bot
+// was invited.
+const tokenFor = (channel) => (channel[0] === 'D' ? userToken : botToken);
 
 async function call(method, token, params = {}, httpMethod = 'GET') {
   const qs = new URLSearchParams(params).toString();
@@ -88,7 +101,7 @@ async function reconcile(emitMissed) {
   for (const w of watched.values()) {
     let res;
     try {
-      res = await call('conversations.replies', userToken, {
+      res = await call('conversations.replies', tokenFor(w.channel), {
         channel: w.channel,
         ts: w.thread_ts,
         oldest: w.lastTs,
@@ -104,7 +117,9 @@ async function reconcile(emitMissed) {
       continue;
     }
     for (const m of res.messages || []) {
-      if (m.subtype || m.user === selfId) continue; // edits/joins and our own posts are not replies
+      // Drop edits/joins/bot_message and our own posts. `thread_broadcast` is a
+      // genuine reply the author also sent to the channel — keep it.
+      if ((m.subtype && m.subtype !== 'thread_broadcast') || ownIds.has(m.user)) continue;
       if (num(m.ts) <= num(w.lastTs)) continue;
       if (emitMissed) emit(`NEW channel=${w.channel} thread_ts=${w.thread_ts} ts=${m.ts}`);
       w.lastTs = m.ts;
@@ -119,8 +134,9 @@ function handleEvent(payload) {
     seenEventIds.add(eventId);
   }
   const e = payload.event;
-  if (!e || e.type !== 'message' || e.subtype) return; // plain messages only
-  if (e.user === selfId) return; // our own follow-ups arrive here too — ignore them
+  // plain messages and thread_broadcast replies only — drop edits/joins/bot_message.
+  if (!e || e.type !== 'message' || (e.subtype && e.subtype !== 'thread_broadcast')) return;
+  if (ownIds.has(e.user)) return; // our own follow-ups (developer or bot) arrive here too — ignore them
   const thread_ts = e.thread_ts;
   if (!thread_ts) return; // a top-level message, not a threaded reply
   const w = watched.get(`${e.channel}:${thread_ts}`);
@@ -180,8 +196,11 @@ async function connect() {
 }
 
 (async () => {
-  const auth = await call('auth.test', userToken);
-  if (!auth.ok) die(`auth.test: ${auth.error} (check the user token)`);
-  selfId = auth.user_id;
+  const user = await call('auth.test', userToken);
+  if (!user.ok) die(`auth.test: ${user.error} (check the user token)`);
+  ownIds.add(user.user_id);
+  const bot = await call('auth.test', botToken);
+  if (!bot.ok) die(`auth.test: ${bot.error} (check the bot token)`);
+  ownIds.add(bot.user_id);
   await connect();
 })().catch(scheduleReconnect);

--- a/.agents/skills/slack-watch/scripts/slack-watch
+++ b/.agents/skills/slack-watch/scripts/slack-watch
@@ -179,7 +179,11 @@ function scheduleReconnect() {
   if (reconnectTimer) return;
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
-    connect().catch(scheduleReconnect);
+    // Retry the whole init, not just connect(): if a startup auth.test threw
+    // (network/JSON), ownIds is still empty, and opening the socket then would
+    // report our own posts as NEW. init() re-runs auth.test until ownIds is
+    // populated; on a plain socket drop it skips straight to connect().
+    init().catch(scheduleReconnect);
   }, 1000);
 }
 
@@ -195,12 +199,20 @@ async function connect() {
   ws.addEventListener('error', () => {}); // a close event always follows; reconnect there
 }
 
-(async () => {
-  const user = await call('auth.test', userToken);
-  if (!user.ok) die(`auth.test: ${user.error} (check the user token)`);
-  ownIds.add(user.user_id);
-  const bot = await call('auth.test', botToken);
-  if (!bot.ok) die(`auth.test: ${bot.error} (check the bot token)`);
-  ownIds.add(bot.user_id);
+// Establish our own identities, then open the socket. ownIds is populated
+// atomically — both auth.test calls succeed before either id is added — so a
+// thrown call leaves it empty and a retry re-runs both. Once it is filled (the
+// common case on a socket-drop reconnect) init() skips auth.test and reconnects.
+async function init() {
+  if (ownIds.size === 0) {
+    const user = await call('auth.test', userToken);
+    if (!user.ok) die(`auth.test: ${user.error} (check the user token)`);
+    const bot = await call('auth.test', botToken);
+    if (!bot.ok) die(`auth.test: ${bot.error} (check the bot token)`);
+    ownIds.add(user.user_id);
+    ownIds.add(bot.user_id);
+  }
   await connect();
-})().catch(scheduleReconnect);
+}
+
+init().catch(scheduleReconnect);

--- a/.agents/skills/to-spec/questions-template.md
+++ b/.agents/skills/to-spec/questions-template.md
@@ -3,11 +3,16 @@
 <!-- One entry per question, with a stable id (`Q01`, `Q02`, …). The id is what a ticket names in its
 `Blocked by` to declare the question gates it, so ids never change once assigned. `to-spec` creates this
 file and records each Slack permalink when the question is sent; answers are folded in later by a plain
-edit — the decision as a phrase plus its date, not the deliberation. -->
+edit — the decision as a phrase plus its date, not the deliberation.
+
+`Resolved when:` names the discrete facts a sufficient reply must contain — write it when authoring the
+question. It gives "is this answer enough?" something concrete to check against and gives a follow-up a
+target. Phrase it as a checklist of facts." -->
 
 ### Q01 — <question>
 
 - Owner: <role> (<name>)
 - Status: `pending` \| `resolved` \| `waived`
+- Resolved when: <the discrete facts a sufficient reply must contain>
 - Slack: <permalink, once sent>
 - Answer: <the decision as a phrase, + date>


### PR DESCRIPTION
## Description

Adds a push-based Slack reply watcher to the spec-driven product-task workflow, removing the developer as the manual transport for question-thread replies. When a colleague replies in a question thread, the live session learns of it on its own, judges the reply against the question's acceptance criterion, follows up in-thread directly, and proposes the resolution back in the session chat — pulling the developer in only when frontend knowledge is needed.

- **New `slack-watch` skill** (`.agents/skills/slack-watch/`) — a Node 22 Socket Mode watcher (built-in `WebSocket`/`fetch`, no npm deps) packaged like `slack-file`. It holds one socket, acks every event, filters to `CHANNEL:THREAD_TS` threads passed as argv, dedupes on `event_id`, reconciles missed replies on reconnect, and prints only `NEW …` / `RECONNECTED`. Tokens are read from the macOS Keychain and never printed; message content and event payloads are never logged. Runs under the `Monitor` tool (`persistent: true`).
- **`grill-the-task` Step 3** — after sending questions, launch the watcher over the `pending` threads and run the on-reply consumer loop: assess against `Resolved when:`, send bounded autonomous follow-ups (cap 3) in threads the developer already opened, propose resolutions in-chat without editing any file, and escalate via `PushNotification` when stuck.
- **`questions.md` template** — new `Resolved when:` field giving each question a concrete acceptance criterion to assess replies and target follow-ups against.

Covers **both DM threads and channel threads** — matching Step 3, where product questions go to the frontend channel and API/design questions go to a DM. A single Socket Mode connection carries the app's bot and user events together; the watcher splits by conversation type: DMs use the developer's user token (its own voice, `message.im` + `im:history`), channels use the Honk bot token (`message.channels` + `channels:history`), which only sees channels the bot was invited into — so the channel feed is scoped, not a firehose. Replies from either of our own identities (developer and Honk) are never reported.

The watcher edits no repo files autonomously — the developer accepts every resolution in-session, so `implement-ticket`'s question gate is untouched. Slack app + Keychain token setup (three tokens: app-level, user, bot) is documented in the skill's Setup section and done by the developer.

## Environment variables

None.

## Minimum API version

None.

## Breaking or incompatible changes

None.

## Additional information

Docs/agent-tooling only — no application code changes.
