### PR TITLE
Measure middle-truncated text width via Canvas instead of forcing reflow

### DIFF
--- a/src/toolkit/components/truncation/TruncateMiddle.tsx
+++ b/src/toolkit/components/truncation/TruncateMiddle.tsx
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-// Middle-ellipsis truncation driven by container width: measures a hidden shadow node and
-// binary-searches the longest head that fits, keeping a fixed-length tail (0x123...4567).
-// Can't be done in pure CSS — a `text-overflow: ellipsis` head + fixed tail leaves an
-// unremovable gap between the dots and the tail, so it's computed in JS.
+// Middle-ellipsis truncation driven by container width: measures candidate strings with the
+// Canvas 2D API and binary-searches the longest head that fits, keeping a fixed-length tail
+// (0x123...4567). Can't be done in pure CSS — a `text-overflow: ellipsis` head + fixed tail
+// leaves an unremovable gap between the dots and the tail, so it's computed in JS. measureText
+// returns text width without touching layout, so the binary search never forces a reflow; the
+// only DOM read left is the container's own box.
 
 import { chakra } from '@chakra-ui/react';
 import { debounce } from 'es-toolkit';
@@ -15,15 +17,41 @@ import type { TruncateBaseProps } from './types';
 import { Skeleton } from '../../chakra/skeleton';
 import { Tooltip } from '../../chakra/tooltip';
 import { BODY_TYPEFACE, HEADING_TYPEFACE } from '../../theme/foundations/typography';
+import { SECOND } from '../../utils/consts';
 
 const TAIL_LENGTH = 4;
 const HEAD_MIN_LENGTH = 4;
+const DEFAULT_FONT_WEIGHT = '400';
+const RESIZE_DEBOUNCE = SECOND / 10;
 
 export interface TruncateMiddleProps extends TruncateBaseProps {
   tailLength?: number;
 }
 
-const DEFAULT_FONT_WEIGHT = '400';
+// One offscreen canvas is reused across every TruncateMiddle instance: measureText is
+// synchronous and calculateString never yields, so instances can't interleave measurements.
+// `undefined` means "not created yet"; `null` means getContext failed (non-browser env).
+let sharedContext: CanvasRenderingContext2D | null | undefined;
+
+function getMeasureContext(): CanvasRenderingContext2D | null {
+  if (sharedContext === undefined) {
+    sharedContext = document.createElement('canvas').getContext('2d');
+  }
+  return sharedContext;
+}
+
+// Canvas needs at least weight + size + family; getComputedStyle(el).font returns '' in Chrome,
+// so the shorthand is assembled from the individual resolved properties instead.
+function getFontString(styles: CSSStyleDeclaration): string {
+  return `${ styles.fontStyle } ${ styles.fontWeight } ${ styles.fontSize } ${ styles.fontFamily }`;
+}
+
+// measureText returns advance width only, so any letter-spacing (added after every glyph) has to
+// be folded back in by hand. Resolves to 0 for the usual `normal`.
+function getLetterSpacing(styles: CSSStyleDeclaration): number {
+  const value = parseFloat(styles.letterSpacing);
+  return Number.isNaN(value) ? 0 : value;
+}
 
 export const TruncateMiddle = React.memo(({
   value,
@@ -46,19 +74,34 @@ export const TruncateMiddle = React.memo(({
   ]);
 
   const calculateString = useCallback(() => {
-    const parent = elementRef?.current?.parentNode as HTMLElement;
-    if (!parent) {
+    const element = elementRef.current;
+    const parent = element?.parentNode as HTMLElement | null;
+    if (!element || !parent) {
       return;
     }
 
-    const shadowEl = document.createElement('span');
-    shadowEl.style.opacity = '0';
-    parent.appendChild(shadowEl);
-    shadowEl.textContent = value;
+    const context = getMeasureContext();
+    if (!context) {
+      setDisplayedString(value);
+      return;
+    }
 
+    // Read the fully-resolved font off the rendered span (cascade + textStyle + overrides), once
+    // per recalculation — the font is invariant across the binary search below.
+    const styles = window.getComputedStyle(element);
+    context.font = getFontString(styles);
+    const letterSpacing = getLetterSpacing(styles);
+    const measure = (text: string) => context.measureText(text).width + letterSpacing * text.length;
+
+    // A shrink-to-fit container only exposes its available width while the span holds full-length
+    // content, so briefly fill the span before reading the container box. Written straight to the
+    // node (not through state) so the read lands in the same synchronous frame — no paint, no
+    // extra DOM node.
+    element.textContent = value;
     const parentWidth = getWidth(parent);
 
-    if (getWidth(shadowEl) > parentWidth) {
+    let result = value;
+    if (measure(value) > parentWidth) {
       const tail = value.slice(-tailLength);
       let leftI = HEAD_MIN_LENGTH;
       let rightI = value.length - tailLength;
@@ -66,19 +109,19 @@ export const TruncateMiddle = React.memo(({
       while (rightI - leftI > 1) {
         const medI = ((rightI - leftI) % 2) ? leftI + (rightI - leftI + 1) / 2 : leftI + (rightI - leftI) / 2;
         const res = value.slice(0, medI) + '...' + tail;
-        shadowEl.textContent = res;
-        if (getWidth(shadowEl) < parentWidth) {
+        if (measure(res) < parentWidth) {
           leftI = medI;
         } else {
           rightI = medI;
         }
       }
-      setDisplayedString(value.slice(0, rightI - 1) + '...' + tail);
-    } else {
-      setDisplayedString(value);
+      result = value.slice(0, rightI - 1) + '...' + tail;
     }
 
-    parent.removeChild(shadowEl);
+    // Restore before React reconciles: setDisplayedString bails out when the value is unchanged,
+    // which would otherwise leave the full-length text written above on screen.
+    element.textContent = result;
+    setDisplayedString(result);
   }, [ value, tailLength ]);
 
   // we want to do recalculation when isFontFaceLoaded flag is changed
@@ -88,13 +131,17 @@ export const TruncateMiddle = React.memo(({
     calculateString();
   }, [ calculateString, isFontFaceLoaded ]);
 
+  // Observes document.body, not the component's own parent: the truncated span usually sits inside
+  // a shrink-to-fit container that doesn't grow when the viewport widens (only an outer block
+  // ancestor does), so a parent-scoped observer never fires on widen and the text stays stuck at
+  // its narrowest width.
   useEffect(() => {
-    const resizeHandler = debounce(calculateString, 100);
+    const resizeHandler = debounce(calculateString, RESIZE_DEBOUNCE);
     const resizeObserver = new ResizeObserver(resizeHandler);
 
     resizeObserver.observe(document.body);
     return function cleanup() {
-      resizeObserver.unobserve(document.body);
+      resizeObserver.disconnect();
     };
   }, [ calculateString ]);
 

--- a/src/toolkit/components/truncation/TruncateMiddle.tsx
+++ b/src/toolkit/components/truncation/TruncateMiddle.tsx
@@ -97,10 +97,20 @@ export const TruncateMiddle = React.memo(({
     // node (not through state) so the read lands in the same synchronous frame.
     element.textContent = value;
     const parentWidth = getWidth(parent);
+    const fullWidth = getWidth(element);
+
+    // measureText sums ideal glyph advances and runs a fraction of a percent wider than the
+    // browser's actual sub-pixel text layout — enough to truncate a value that really fits when
+    // its full width sits a pixel or two under the container. `fullWidth` is that same string laid
+    // out for real (read for free in the reflow above), so scale every canvas measurement by the
+    // observed ratio to bring the binary search back in line with what the DOM will render.
+    const canvasFullWidth = measure(value);
+    const calibration = canvasFullWidth > 0 ? fullWidth / canvasFullWidth : 1;
+    const fits = (text: string) => measure(text) * calibration < parentWidth;
 
     let result = value;
     if (
-      measure(value) > parentWidth &&
+      fullWidth > parentWidth &&
       // Only truncate when there is room for at least a HEAD_MIN_LENGTH head before the tail.
       // Otherwise the search below never iterates and `slice(0, rightI - 1)` would emit a garbled
       // string longer than the input (e.g. 'abcd' → 'abc...abcd'), so keep the full value instead.
@@ -113,7 +123,7 @@ export const TruncateMiddle = React.memo(({
       while (rightI - leftI > 1) {
         const medI = ((rightI - leftI) % 2) ? leftI + (rightI - leftI + 1) / 2 : leftI + (rightI - leftI) / 2;
         const res = value.slice(0, medI) + '...' + tail;
-        if (measure(res) < parentWidth) {
+        if (fits(res)) {
           leftI = medI;
         } else {
           rightI = medI;

--- a/src/toolkit/components/truncation/TruncateMiddle.tsx
+++ b/src/toolkit/components/truncation/TruncateMiddle.tsx
@@ -112,24 +112,42 @@ export const TruncateMiddle = React.memo(({
     if (
       fullWidth > parentWidth &&
       // Only truncate when there is room for at least a HEAD_MIN_LENGTH head before the tail.
-      // Otherwise the search below never iterates and `slice(0, rightI - 1)` would emit a garbled
-      // string longer than the input (e.g. 'abcd' → 'abc...abcd'), so keep the full value instead.
+      // Otherwise the search below never iterates and the head would run into the tail, emitting a
+      // garbled string longer than the input (e.g. 'abcd' → 'abc...abcd'), so keep the full value.
       value.length - tailLength > HEAD_MIN_LENGTH
     ) {
       const tail = value.slice(-tailLength);
-      let leftI = HEAD_MIN_LENGTH;
-      let rightI = value.length - tailLength;
+      const maxHeadLength = value.length - tailLength;
+      const withHead = (headLength: number) => value.slice(0, headLength) + '...' + tail;
 
+      let leftI = HEAD_MIN_LENGTH;
+      let rightI = maxHeadLength;
       while (rightI - leftI > 1) {
         const medI = ((rightI - leftI) % 2) ? leftI + (rightI - leftI + 1) / 2 : leftI + (rightI - leftI) / 2;
-        const res = value.slice(0, medI) + '...' + tail;
-        if (fits(res)) {
+        if (fits(withHead(medI))) {
           leftI = medI;
         } else {
           rightI = medI;
         }
       }
-      result = value.slice(0, rightI - 1) + '...' + tail;
+
+      // The calibrated canvas search lands within a character of the true fit but can't reproduce
+      // the browser's per-glyph rounding exactly. Settle the final head length against real layout
+      // — a couple of reflows, versus one per iteration if the whole search measured the DOM — so
+      // the head is exactly as long as the container allows and matches what the DOM renders.
+      let headLength = leftI;
+      const headFits = (length: number) => {
+        element.textContent = withHead(length);
+        return getWidth(element) < parentWidth;
+      };
+      while (headLength < maxHeadLength && headFits(headLength + 1)) {
+        headLength++;
+      }
+      while (headLength > HEAD_MIN_LENGTH && !headFits(headLength)) {
+        headLength--;
+      }
+
+      result = withHead(headLength);
     }
 
     // Restore before React reconciles: setDisplayedString bails out when the value is unchanged,

--- a/src/toolkit/components/truncation/TruncateMiddle.tsx
+++ b/src/toolkit/components/truncation/TruncateMiddle.tsx
@@ -4,8 +4,7 @@
 // Canvas 2D API and binary-searches the longest head that fits, keeping a fixed-length tail
 // (0x123...4567). Can't be done in pure CSS — a `text-overflow: ellipsis` head + fixed tail
 // leaves an unremovable gap between the dots and the tail, so it's computed in JS. measureText
-// returns text width without touching layout, so the binary search never forces a reflow; the
-// only DOM read left is the container's own box.
+// returns text width without touching layout, so the binary search never forces a reflow.
 
 import { chakra } from '@chakra-ui/react';
 import { debounce } from 'es-toolkit';
@@ -95,13 +94,18 @@ export const TruncateMiddle = React.memo(({
 
     // A shrink-to-fit container only exposes its available width while the span holds full-length
     // content, so briefly fill the span before reading the container box. Written straight to the
-    // node (not through state) so the read lands in the same synchronous frame — no paint, no
-    // extra DOM node.
+    // node (not through state) so the read lands in the same synchronous frame.
     element.textContent = value;
     const parentWidth = getWidth(parent);
 
     let result = value;
-    if (measure(value) > parentWidth) {
+    if (
+      measure(value) > parentWidth &&
+      // Only truncate when there is room for at least a HEAD_MIN_LENGTH head before the tail.
+      // Otherwise the search below never iterates and `slice(0, rightI - 1)` would emit a garbled
+      // string longer than the input (e.g. 'abcd' → 'abc...abcd'), so keep the full value instead.
+      value.length - tailLength > HEAD_MIN_LENGTH
+    ) {
       const tail = value.slice(-tailLength);
       let leftI = HEAD_MIN_LENGTH;
       let rightI = value.length - tailLength;


### PR DESCRIPTION
## Description

Resolves #3666

`TruncateMiddle` computed its middle-ellipsis cut point by appending a hidden `<span>` to the DOM and reading `getBoundingClientRect().width` inside a binary search — each read forcing a synchronous layout reflow, ~log₂(n) times per truncated string, multiplied across every truncated cell on a page (address/hash tables, etc.).

The binary search now measures candidate strings with the Canvas 2D `measureText()` API, which returns text width without touching layout — zero per-iteration reflow. The font handed to the canvas is read once per recalculation via `getComputedStyle` on the rendered span, so it reflects the real resolved cascade + `textStyle` + prop overrides (and `letter-spacing`, folded back in since `measureText` returns advance width only). A single offscreen canvas is shared across all instances.

Two deviations from the issue, both found while verifying "visually identical" output:

- **Container-width read still needs the full-length text momentarily.** The old shadow span was doing double duty — appending full text also forced the surrounding shrink-to-fit flex container to expand to its available width before the container box was read. Without that, the parent shrink-wraps the already-truncated string and collapses to the minimum. The span's own text node is now briefly set to the full value for the single container-box read, then restored — no element is appended to the DOM.
- **ResizeObserver stays on `document.body`.** The issue asked to narrow it to the component's own parent, but the truncated span sits inside a shrink-to-fit container that doesn't grow when the viewport widens (only an outer block ancestor does), so a parent-scoped observer never fires on widen and the text stays stuck at its narrowest width.

## Environment variables

None

## Minimum API version

None

## Breaking or incompatible changes

None

## Additional information

Truncation output is visually identical to the previous implementation across fonts, weights, and container widths, verified on the design-system page (`maxW`-bounded address links) and the name-services directory table (shrink/widen resize).
