### PR TITLE
Let operators pick Flashblocks or Subblocks naming for the OP Stack feed

### DIFF
--- a/.agents/GLOSSARY.md
+++ b/.agents/GLOSSARY.md
@@ -39,7 +39,7 @@ vars are documented in `docs/ENVS.md`. Architectural concepts like
 | **Eden** | chain | A rollup built on `ev-reth` / evstack. Introduces the **Sponsored Transaction** type. |
 | **Epoch** | entity | A consensus time period specific to **Celo**. Has its own index and detail pages. Always refers to a Celo epoch in this codebase — not a generic blockchain concept. |
 | **Fault Proof System** | feature | Optimism's mechanism for proving the correctness of L2 state transitions on L1 via **Dispute Games**. |
-| **Flashblocks** | feature | Code name for the sub-second pre-confirmation block streaming feature. Surfaced to users as **Subblocks** on OP Stack chains (OP Labs renamed it from "Flashblocks") and as **mini-blocks** on MegaETH. The `flashblocks` code name and `FLASHBLOCKS` env vars are retained. |
+| **Flashblocks** | feature | Code name for the sub-second pre-confirmation block streaming feature. Surfaced to users as **Subblocks** (the default) or **Flashblocks** on OP Stack chains, whichever name the chain uses, and as **mini-blocks** on MegaETH. The `flashblocks` code name and `FLASHBLOCKS` env vars are retained. |
 | **Hot Contracts** | feature | Ranked list of the most recently and frequently interacted-with smart contracts on the network. |
 | **Interchain Indexer** | service | Microservice that indexes cross-chain messages and token transfers across heterogeneous chains. General-purpose interop indexer, not ZetaChain-specific. Provides "Cross chain txs" feature. Distinct from **CCTX**. |
 | **Interop Messages** | entity | **Deprecated** Cross-rollup messages passed between OP Stack chains using the native interoperability protocol. Distinct from **Interchain Indexer** messages. |

--- a/.agents/GLOSSARY.md
+++ b/.agents/GLOSSARY.md
@@ -39,7 +39,7 @@ vars are documented in `docs/ENVS.md`. Architectural concepts like
 | **Eden** | chain | A rollup built on `ev-reth` / evstack. Introduces the **Sponsored Transaction** type. |
 | **Epoch** | entity | A consensus time period specific to **Celo**. Has its own index and detail pages. Always refers to a Celo epoch in this codebase — not a generic blockchain concept. |
 | **Fault Proof System** | feature | Optimism's mechanism for proving the correctness of L2 state transitions on L1 via **Dispute Games**. |
-| **Flashblocks** | feature | Code name for the sub-second pre-confirmation block streaming feature. Surfaced to users as **Subblocks** (the default) or **Flashblocks** on OP Stack chains, whichever name the chain uses, and as **mini-blocks** on MegaETH. The `flashblocks` code name and `FLASHBLOCKS` env vars are retained. |
+| **Flashblocks** | feature | Code name for the sub-second pre-confirmation block streaming feature. Surfaced to users as **Subblocks** or **Flashblocks** on OP Stack chains, whichever name the chain uses (OP Labs renamed it from "Flashblocks"), and as **mini-blocks** on MegaETH. The `flashblocks` code name and `FLASHBLOCKS` env vars are retained. |
 | **Hot Contracts** | feature | Ranked list of the most recently and frequently interacted-with smart contracts on the network. |
 | **Interchain Indexer** | service | Microservice that indexes cross-chain messages and token transfers across heterogeneous chains. General-purpose interop indexer, not ZetaChain-specific. Provides "Cross chain txs" feature. Distinct from **CCTX**. |
 | **Interop Messages** | entity | **Deprecated** Cross-rollup messages passed between OP Stack chains using the native interoperability protocol. Distinct from **Interchain Indexer** messages. |

--- a/deploy/tools/envs-validator/schema.ts
+++ b/deploy/tools/envs-validator/schema.ts
@@ -135,7 +135,6 @@ const schema = yup
 
         return isUndefined || valueSchema.isValidSync(data);
       }),
-    NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL: yup.string().test(urlTest),
     NEXT_PUBLIC_HOT_CONTRACTS_ENABLED: yup.boolean(),
     NEXT_PUBLIC_USERCENTRICS_CONFIG: yup
       .mixed()
@@ -179,6 +178,7 @@ const schema = yup
   .concat(featuresSchemas.bridgedTokensSchema)
   .concat(featuresSchemas.crossChainTxsSchema)
   .concat(featuresSchemas.defiDropdownSchema)
+  .concat(featuresSchemas.flashblocksSchema)
   .concat(featuresSchemas.highlightsConfigSchema)
   .concat(featuresSchemas.marketplaceSchema)
   .concat(featuresSchemas.megaEthSchema)

--- a/deploy/tools/envs-validator/schemas/features/flashblocks.ts
+++ b/deploy/tools/envs-validator/schemas/features/flashblocks.ts
@@ -1,0 +1,19 @@
+import * as yup from 'yup';
+import { FLASHBLOCKS_NAMES } from 'src/features/flashblocks/types/config';
+import type { FlashblocksName } from 'src/features/flashblocks/types/config';
+import { urlTest } from '../../utils';
+
+export const flashblocksSchema = yup
+  .object()
+  .shape({
+    NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL: yup.string().test(urlTest),
+    NEXT_PUBLIC_FLASHBLOCKS_NAME: yup.string<FlashblocksName>().when('NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL', {
+      is: (value: string) => Boolean(value),
+      then: (schema) => schema.oneOf(FLASHBLOCKS_NAMES),
+      otherwise: (schema) => schema.test(
+        'not-exist',
+        'NEXT_PUBLIC_FLASHBLOCKS_NAME can only be used with NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL',
+        value => value === undefined,
+      ),
+    }),
+  });

--- a/deploy/tools/envs-validator/schemas/features/index.ts
+++ b/deploy/tools/envs-validator/schemas/features/index.ts
@@ -6,6 +6,7 @@ export * from './beaconChain';
 export * from './bridgedToken';
 export * from './crossChainTxs';
 export * from './defiDropdown';
+export * from './flashblocks';
 export * from './highlights';
 export * from './marketplace';
 export * from './megaEth';

--- a/deploy/tools/envs-validator/test/.env.base
+++ b/deploy/tools/envs-validator/test/.env.base
@@ -96,6 +96,7 @@ NEXT_PUBLIC_ADDRESS_3RD_PARTY_WIDGETS=['widget-1', 'widget-2']
 NEXT_PUBLIC_ADDRESS_3RD_PARTY_WIDGETS_CONFIG_URL=https://example.com
 NEXT_PUBLIC_NAVIGATION_PROMO_BANNER_CONFIG={'img_url': 'https://example.com/promo.svg', 'text': 'Promo text', 'bg_color': {'light': 'rgb(250, 245, 255)', 'dark': 'rgb(68, 51, 122)'}, 'text_color': {'light': 'rgb(107, 70, 193)', 'dark': 'rgb(233, 216, 253)'}, 'link_url': 'https://example.com'}
 NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL=wss://example.com/ws
+NEXT_PUBLIC_FLASHBLOCKS_NAME=flashblock
 NEXT_PUBLIC_HOMEPAGE_HIGHLIGHTS_CONFIG=https://example.com
 NEXT_PUBLIC_NAME_SERVICE_API_HOST=https://example.com
 NEXT_PUBLIC_NAME_SERVICE_PROTOCOLS=['duck','goose']

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -959,11 +959,12 @@ If the feature is enabled, a single button or a dropdown (if more than 1 item is
 
 ### Flashblocks
 
-Real-time feed of sub-second pre-confirmation blocks. The same feature backs two stacks: on OP Stack chains these blocks are called **Subblocks** (OP Labs' current name; formerly "Flashblocks") and are streamed from the endpoint below; on **MegaETH** they are called **mini-blocks** and are streamed from the MegaETH RPC endpoint (see [MegaETH](#megaeth)). The `FLASHBLOCKS` variable name is retained across both.
+Real-time feed of sub-second pre-confirmation blocks, shown as a tab on the blocks page. The same feature backs two stacks. On **OP Stack** chains the blocks are streamed from the endpoint below, and the chain's own name for them is set with `NEXT_PUBLIC_FLASHBLOCKS_NAME`: the newer **Subblocks** name (the default) or the legacy **Flashblocks** name. Chains are split between the two and both run the same wire protocol, so only the labels differ. On **MegaETH** they are called **mini-blocks** and are streamed from the MegaETH RPC endpoint (see [MegaETH](#megaeth)). The `FLASHBLOCKS` variable name is retained across both.
 
 | Variable | Type | Description | Compulsoriness | Default value | Example value | Version |
 | --- | --- | --- | --- | --- | --- | --- |
-| NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL | `string` | Public WebSocket endpoint to stream Subblocks data on OP Stack chains | Required | - | `wss://mainnet.flashblocks.base.org/ws` | v2.3.0+ |
+| NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL | `string` | Public WebSocket endpoint to stream Flashblocks or Subblocks data on OP Stack chains | Required | - | `wss://mainnet.flashblocks.base.org/ws` | v2.3.0+ |
+| NEXT_PUBLIC_FLASHBLOCKS_NAME | `'flashblock' \| 'subblock'` | What the chain calls its pre-confirmation blocks. Drives every user-facing label and the blocks page tab id (`flashblocks` or `subblocks`); the other tab id keeps working and redirects to the configured one. | - | `subblock` | `flashblock` | upcoming |
 
 &nbsp;
 

--- a/src/config/test-utils/env-presets.ts
+++ b/src/config/test-utils/env-presets.ts
@@ -136,6 +136,9 @@ export const ENVS_MAP: Record<string, Array<[string, string]>> = {
   proApi: [
     [ 'NEXT_PUBLIC_PRO_API_SUPPORTED', 'true' ],
   ],
+  flashblocks: [
+    [ 'NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL', 'wss://localhost:3120/ws' ],
+  ],
   verifiedAddresses: [
     [ 'NEXT_PUBLIC_IS_ACCOUNT_SUPPORTED', 'true' ],
     [ 'NEXT_PUBLIC_TOKEN_INFO_EXPEDITED_REVIEW_HTML', 'Send <b>99 USDC/USDT</b> to one of the addresses below:<br>Duck Chain: 0xFB74767C1ce1aadA0a0E114441173b57f8C1571b<br>Goose Chaing: 0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263' ],

--- a/src/features/flashblocks/config.spec.ts
+++ b/src/features/flashblocks/config.spec.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import { ENVS_MAP } from 'src/config/test-utils/env-presets';
+
+import { describe, expect, it } from 'vitest';
+import withEnvs from 'vitest/utils/mockEnvs';
+
+import type flashblocksConfig from './config';
+
+// the feature config is a frozen module-level singleton, so it has to be imported inside `withEnvs`
+async function loadConfig(envs: Array<[ string, string ]>): Promise<typeof flashblocksConfig> {
+  return withEnvs(envs, async() => (await import('./config')).default);
+}
+
+describe('flashblocks feature config', () => {
+  it('is disabled without a socket url', async() => {
+    expect((await loadConfig([])).isEnabled).toBe(false);
+  });
+
+  it('calls the OP Stack feed "subblock" unless told otherwise', async() => {
+    expect(await loadConfig(ENVS_MAP.flashblocks)).toMatchObject({
+      isEnabled: true,
+      type: 'optimism',
+      name: 'subblock',
+      tabIds: [ 'subblocks', 'flashblocks' ],
+    });
+  });
+
+  it('calls the OP Stack feed "flashblock" when NEXT_PUBLIC_FLASHBLOCKS_NAME says so', async() => {
+    const config = await loadConfig([ ...ENVS_MAP.flashblocks, [ 'NEXT_PUBLIC_FLASHBLOCKS_NAME', 'flashblock' ] ]);
+    expect(config).toMatchObject({
+      isEnabled: true,
+      type: 'optimism',
+      name: 'flashblock',
+      tabIds: [ 'flashblocks', 'subblocks' ],
+    });
+  });
+
+  it('falls back to "subblock" on a name it does not know', async() => {
+    const config = await loadConfig([ ...ENVS_MAP.flashblocks, [ 'NEXT_PUBLIC_FLASHBLOCKS_NAME', 'miniblock' ] ]);
+    expect(config).toMatchObject({ isEnabled: true, name: 'subblock' });
+  });
+
+  it('keeps the MegaETH name and tab whatever NEXT_PUBLIC_FLASHBLOCKS_NAME says', async() => {
+    const config = await loadConfig([
+      [ 'NEXT_PUBLIC_MEGA_ETH_SOCKET_URL_RPC', 'wss://localhost:3121' ],
+      [ 'NEXT_PUBLIC_FLASHBLOCKS_NAME', 'flashblock' ],
+    ]);
+    expect(config).toMatchObject({ isEnabled: true, type: 'megaEth', name: 'mini-block', tabIds: [ 'mini-blocks' ] });
+  });
+});

--- a/src/features/flashblocks/config.ts
+++ b/src/features/flashblocks/config.ts
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
+import type { FlashblocksName } from 'src/features/flashblocks/types/config';
+import { FLASHBLOCKS_NAMES } from 'src/features/flashblocks/types/config';
+
 import megaEthFeature from 'src/features/chain-variants/mega-eth/config';
 
 import { getEnvValue } from 'src/config/utils/envs';
@@ -8,8 +11,19 @@ import type { Feature } from 'src/config/utils/features';
 const title = 'Flashblocks';
 
 const socketUrl = getEnvValue('NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL');
+const nameFromEnv = getEnvValue('NEXT_PUBLIC_FLASHBLOCKS_NAME');
+const opStackName = FLASHBLOCKS_NAMES.find((name) => name === nameFromEnv) ?? 'subblock';
 
-const config: Feature<{ socketUrl: string; type: 'optimism' | 'megaEth'; name: string }> = (() => {
+// The configured name owns the blocks-page tab; the other OP Stack name stays an alias so links
+// written under either name keep resolving (the `blocksTab` guard redirects it to the first id).
+const opStackTabIds = [ opStackName, ...FLASHBLOCKS_NAMES.filter((name) => name !== opStackName) ].map((name) => `${ name }s`);
+
+const config: Feature<{
+  socketUrl: string;
+  type: 'optimism' | 'megaEth';
+  name: FlashblocksName | 'mini-block';
+  tabIds: Array<string>;
+}> = (() => {
   if (megaEthFeature.isEnabled && megaEthFeature.socketUrl.rpc) {
     return Object.freeze({
       title,
@@ -17,6 +31,7 @@ const config: Feature<{ socketUrl: string; type: 'optimism' | 'megaEth'; name: s
       socketUrl: megaEthFeature.socketUrl.rpc,
       type: 'megaEth',
       name: 'mini-block',
+      tabIds: [ 'mini-blocks' ],
     });
   }
 
@@ -26,7 +41,8 @@ const config: Feature<{ socketUrl: string; type: 'optimism' | 'megaEth'; name: s
       isEnabled: true,
       socketUrl,
       type: 'optimism',
-      name: 'subblock',
+      name: opStackName,
+      tabIds: opStackTabIds,
     });
   }
 

--- a/src/features/flashblocks/config.ts
+++ b/src/features/flashblocks/config.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-import type { FlashblocksName } from 'src/features/flashblocks/types/config';
+import type { FlashblocksName, FlashblocksTabId } from 'src/features/flashblocks/types/config';
 import { FLASHBLOCKS_NAMES } from 'src/features/flashblocks/types/config';
 
 import megaEthFeature from 'src/features/chain-variants/mega-eth/config';
@@ -8,21 +8,23 @@ import megaEthFeature from 'src/features/chain-variants/mega-eth/config';
 import { getEnvValue } from 'src/config/utils/envs';
 import type { Feature } from 'src/config/utils/features';
 
+type TabId = FlashblocksTabId | 'mini-blocks';
+
 const title = 'Flashblocks';
 
 const socketUrl = getEnvValue('NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL');
 const nameFromEnv = getEnvValue('NEXT_PUBLIC_FLASHBLOCKS_NAME');
 const opStackName = FLASHBLOCKS_NAMES.find((name) => name === nameFromEnv) ?? 'subblock';
-
-// The configured name owns the blocks-page tab; the other OP Stack name stays an alias so links
-// written under either name keep resolving (the `blocksTab` guard redirects it to the first id).
-const opStackTabIds = [ opStackName, ...FLASHBLOCKS_NAMES.filter((name) => name !== opStackName) ].map((name) => `${ name }s`);
+const opStackTabIds: [ FlashblocksTabId, ...Array<FlashblocksTabId> ] = opStackName === 'subblock' ?
+  [ 'subblocks', 'flashblocks' ] :
+  [ 'flashblocks', 'subblocks' ];
+const megaEthTabIds: [ TabId ] = [ 'mini-blocks' ];
 
 const config: Feature<{
   socketUrl: string;
   type: 'optimism' | 'megaEth';
   name: FlashblocksName | 'mini-block';
-  tabIds: Array<string>;
+  tabIds: [ TabId, ...Array<TabId> ];
 }> = (() => {
   if (megaEthFeature.isEnabled && megaEthFeature.socketUrl.rpc) {
     return Object.freeze({
@@ -31,7 +33,7 @@ const config: Feature<{
       socketUrl: megaEthFeature.socketUrl.rpc,
       type: 'megaEth',
       name: 'mini-block',
-      tabIds: [ 'mini-blocks' ],
+      tabIds: megaEthTabIds,
     });
   }
 

--- a/src/features/flashblocks/config.ts
+++ b/src/features/flashblocks/config.ts
@@ -18,7 +18,7 @@ const opStackName = FLASHBLOCKS_NAMES.find((name) => name === nameFromEnv) ?? 's
 const opStackTabIds: [ FlashblocksTabId, ...Array<FlashblocksTabId> ] = opStackName === 'subblock' ?
   [ 'subblocks', 'flashblocks' ] :
   [ 'flashblocks', 'subblocks' ];
-const megaEthTabIds: [ TabId ] = [ 'mini-blocks' ];
+const megaEthTabIds: [ 'mini-blocks' ] = [ 'mini-blocks' ];
 
 const config: Feature<{
   socketUrl: string;

--- a/src/features/flashblocks/types/config.ts
+++ b/src/features/flashblocks/types/config.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+// What an OP Stack chain calls its sub-second pre-confirmation blocks. Chains are split between
+// the legacy "Flashblocks" name and the newer "Subblocks" name while running the same wire
+// protocol, so the operator picks the label per deployment via NEXT_PUBLIC_FLASHBLOCKS_NAME.
+export const FLASHBLOCKS_NAMES = [
+  'flashblock',
+  'subblock',
+] as const;
+
+export type FlashblocksName = (typeof FLASHBLOCKS_NAMES)[number];

--- a/src/features/flashblocks/types/config.ts
+++ b/src/features/flashblocks/types/config.ts
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-// What an OP Stack chain calls its sub-second pre-confirmation blocks. Chains are split between
-// the legacy "Flashblocks" name and the newer "Subblocks" name while running the same wire
-// protocol, so the operator picks the label per deployment via NEXT_PUBLIC_FLASHBLOCKS_NAME.
 export const FLASHBLOCKS_NAMES = [
   'flashblock',
   'subblock',
 ] as const;
 
 export type FlashblocksName = (typeof FLASHBLOCKS_NAMES)[number];
+
+export const FLASHBLOCKS_TAB_IDS = [
+  'flashblocks',
+  'subblocks',
+] as const;
+
+export type FlashblocksTabId = (typeof FLASHBLOCKS_TAB_IDS)[number];

--- a/src/pages/blocks.tsx
+++ b/src/pages/blocks.tsx
@@ -26,4 +26,4 @@ const Page: NextPage = () => {
 
 export default Page;
 
-export { base as getServerSideProps } from 'src/server/getServerSideProps/main';
+export { blocks as getServerSideProps } from 'src/server/getServerSideProps/main';

--- a/src/server/getServerSideProps/guards.spec.ts
+++ b/src/server/getServerSideProps/guards.spec.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import type { GetServerSidePropsContext } from 'next';
+
+import type config from 'src/config';
+
+import { describe, expect, it } from 'vitest';
+
+import { blocksTab } from './guards';
+
+type FlashblocksFeature = (typeof config)['features']['flashblocks'];
+
+const SUBBLOCKS_FEED: FlashblocksFeature = {
+  title: 'Flashblocks',
+  isEnabled: true,
+  socketUrl: 'wss://localhost:3120/ws',
+  type: 'optimism',
+  name: 'subblock',
+  tabIds: [ 'subblocks', 'flashblocks' ],
+};
+const FLASHBLOCKS_FEED: FlashblocksFeature = { ...SUBBLOCKS_FEED, name: 'flashblock', tabIds: [ 'flashblocks', 'subblocks' ] };
+const DISABLED_FEED: FlashblocksFeature = { title: 'Flashblocks', isEnabled: false };
+
+// the guard reads only the flashblocks feature and the request query, so the rest of both can stay absent
+function runBlocksTab(flashblocks: FlashblocksFeature, query: Record<string, string | Array<string>>): ReturnType<ReturnType<typeof blocksTab>> {
+  const chainConfig = { features: { flashblocks } } as unknown as typeof config;
+  const context = { query } as unknown as GetServerSidePropsContext;
+  return blocksTab(chainConfig)(context);
+}
+
+describe('blocksTab guard', () => {
+  it('does nothing while the feed is disabled', async() => {
+    expect(await runBlocksTab(DISABLED_FEED, { tab: 'flashblocks' })).toBeUndefined();
+  });
+
+  it('lets the canonical tab id through', async() => {
+    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'subblocks' })).toBeUndefined();
+  });
+
+  it('ignores the other tabs', async() => {
+    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'reorgs' })).toBeUndefined();
+    expect(await runBlocksTab(SUBBLOCKS_FEED, {})).toBeUndefined();
+  });
+
+  it('redirects the alias to the canonical id with a temporary redirect', async() => {
+    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'flashblocks' })).toEqual({
+      redirect: { destination: '/blocks?tab=subblocks', permanent: false },
+    });
+  });
+
+  it('follows the configured name in the other direction', async() => {
+    expect(await runBlocksTab(FLASHBLOCKS_FEED, { tab: 'subblocks' })).toEqual({
+      redirect: { destination: '/blocks?tab=flashblocks', permanent: false },
+    });
+  });
+
+  it('keeps the other search params', async() => {
+    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'flashblocks', page: '2' })).toEqual({
+      redirect: { destination: '/blocks?tab=subblocks&page=2', permanent: false },
+    });
+  });
+});

--- a/src/server/getServerSideProps/guards.spec.ts
+++ b/src/server/getServerSideProps/guards.spec.ts
@@ -2,60 +2,56 @@
 
 import type { GetServerSidePropsContext } from 'next';
 
-import type config from 'src/config';
+import { ENVS_MAP } from 'src/config/test-utils/env-presets';
 
 import { describe, expect, it } from 'vitest';
+import withEnvs from 'vitest/utils/mockEnvs';
 
-import { blocksTab } from './guards';
+import type { blocks } from './guards';
 
-type FlashblocksFeature = (typeof config)['features']['flashblocks'];
-
-const SUBBLOCKS_FEED: FlashblocksFeature = {
-  title: 'Flashblocks',
-  isEnabled: true,
-  socketUrl: 'wss://localhost:3120/ws',
-  type: 'optimism',
-  name: 'subblock',
-  tabIds: [ 'subblocks', 'flashblocks' ],
-};
-const FLASHBLOCKS_FEED: FlashblocksFeature = { ...SUBBLOCKS_FEED, name: 'flashblock', tabIds: [ 'flashblocks', 'subblocks' ] };
-const DISABLED_FEED: FlashblocksFeature = { title: 'Flashblocks', isEnabled: false };
-
-// the guard reads only the flashblocks feature and the request query, so the rest of both can stay absent
-function runBlocksTab(flashblocks: FlashblocksFeature, query: Record<string, string | Array<string>>): ReturnType<ReturnType<typeof blocksTab>> {
-  const chainConfig = { features: { flashblocks } } as unknown as typeof config;
-  const context = { query } as unknown as GetServerSidePropsContext;
-  return blocksTab(chainConfig)(context);
+function makeContext(query: Record<string, string | Array<string>>): GetServerSidePropsContext {
+  // the guard reads only `query`, so the rest of the context can stay absent
+  return { query } as unknown as GetServerSidePropsContext;
 }
 
-describe('blocksTab guard', () => {
-  it('does nothing while the feed is disabled', async() => {
-    expect(await runBlocksTab(DISABLED_FEED, { tab: 'flashblocks' })).toBeUndefined();
+// the guard reads the frozen app config, so both are imported inside `withEnvs`
+async function runBlocksGuard(envs: Array<[ string, string ]>, context: GetServerSidePropsContext): ReturnType<ReturnType<typeof blocks>> {
+  return withEnvs(envs, async() => {
+    const guards = await import('./guards');
+    const config = (await import('src/config')).default;
+    return guards.blocks(config)(context);
+  });
+}
+
+describe('blocks guard', () => {
+  it('does nothing while the flashblocks feed is disabled', async() => {
+    expect(await runBlocksGuard([], makeContext({ tab: 'flashblocks' }))).toBeUndefined();
   });
 
   it('lets the canonical tab id through', async() => {
-    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'subblocks' })).toBeUndefined();
+    expect(await runBlocksGuard(ENVS_MAP.flashblocks, makeContext({ tab: 'subblocks' }))).toBeUndefined();
   });
 
   it('ignores the other tabs', async() => {
-    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'reorgs' })).toBeUndefined();
-    expect(await runBlocksTab(SUBBLOCKS_FEED, {})).toBeUndefined();
+    expect(await runBlocksGuard(ENVS_MAP.flashblocks, makeContext({ tab: 'reorgs' }))).toBeUndefined();
+    expect(await runBlocksGuard(ENVS_MAP.flashblocks, makeContext({}))).toBeUndefined();
   });
 
   it('redirects the alias to the canonical id with a temporary redirect', async() => {
-    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'flashblocks' })).toEqual({
+    expect(await runBlocksGuard(ENVS_MAP.flashblocks, makeContext({ tab: 'flashblocks' }))).toEqual({
       redirect: { destination: '/blocks?tab=subblocks', permanent: false },
     });
   });
 
   it('follows the configured name in the other direction', async() => {
-    expect(await runBlocksTab(FLASHBLOCKS_FEED, { tab: 'subblocks' })).toEqual({
+    const envs = [ ...ENVS_MAP.flashblocks, [ 'NEXT_PUBLIC_FLASHBLOCKS_NAME', 'flashblock' ] as [ string, string ] ];
+    expect(await runBlocksGuard(envs, makeContext({ tab: 'subblocks' }))).toEqual({
       redirect: { destination: '/blocks?tab=flashblocks', permanent: false },
     });
   });
 
   it('keeps the other search params', async() => {
-    expect(await runBlocksTab(SUBBLOCKS_FEED, { tab: 'flashblocks', page: '2' })).toEqual({
+    expect(await runBlocksGuard(ENVS_MAP.flashblocks, makeContext({ tab: 'flashblocks', page: '2' }))).toEqual({
       redirect: { destination: '/blocks?tab=subblocks&page=2', permanent: false },
     });
   });

--- a/src/server/getServerSideProps/guards.spec.ts
+++ b/src/server/getServerSideProps/guards.spec.ts
@@ -44,7 +44,7 @@ describe('blocks guard', () => {
   });
 
   it('follows the configured name in the other direction', async() => {
-    const envs = [ ...ENVS_MAP.flashblocks, [ 'NEXT_PUBLIC_FLASHBLOCKS_NAME', 'flashblock' ] as [ string, string ] ];
+    const envs: Array<[ string, string ]> = [ ...ENVS_MAP.flashblocks, [ 'NEXT_PUBLIC_FLASHBLOCKS_NAME', 'flashblock' ] ];
     expect(await runBlocksGuard(envs, makeContext({ tab: 'subblocks' }))).toEqual({
       redirect: { destination: '/blocks?tab=flashblocks', permanent: false },
     });

--- a/src/server/getServerSideProps/guards.ts
+++ b/src/server/getServerSideProps/guards.ts
@@ -2,6 +2,7 @@
 
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import type { Route } from 'nextjs-routes';
+import { route } from 'nextjs-routes';
 
 import type { RollupType } from 'src/features/rollup/common/types/config';
 
@@ -354,4 +355,26 @@ export const megaEth: Guard = () => async() => {
       notFound: true,
     };
   }
+};
+
+// The flashblocks tab answers to both OP Stack ids (see NEXT_PUBLIC_FLASHBLOCKS_NAME); a link
+// using the alias is sent to the canonical id. Temporary, because the operator can flip the name.
+export const blocksTab: Guard = (chainConfig: typeof config) => async(context) => {
+  const feature = chainConfig.features.flashblocks;
+  const tab = context.query.tab;
+  if (!feature.isEnabled || typeof tab !== 'string') {
+    return;
+  }
+
+  const [ canonicalTabId, ...aliasTabIds ] = feature.tabIds;
+  if (!aliasTabIds.includes(tab)) {
+    return;
+  }
+
+  return {
+    redirect: {
+      destination: route({ pathname: '/blocks', query: { ...context.query, tab: canonicalTabId } }),
+      permanent: false,
+    },
+  };
 };

--- a/src/server/getServerSideProps/guards.ts
+++ b/src/server/getServerSideProps/guards.ts
@@ -357,9 +357,7 @@ export const megaEth: Guard = () => async() => {
   }
 };
 
-// The flashblocks tab answers to both OP Stack ids (see NEXT_PUBLIC_FLASHBLOCKS_NAME); a link
-// using the alias is sent to the canonical id. Temporary, because the operator can flip the name.
-export const blocksTab: Guard = (chainConfig: typeof config) => async(context) => {
+export const blocks: Guard = (chainConfig: typeof config) => async(context) => {
   const feature = chainConfig.features.flashblocks;
   const tab = context.query.tab;
   if (!feature.isEnabled || typeof tab !== 'string') {
@@ -367,7 +365,7 @@ export const blocksTab: Guard = (chainConfig: typeof config) => async(context) =
   }
 
   const [ canonicalTabId, ...aliasTabIds ] = feature.tabIds;
-  if (!aliasTabIds.includes(tab)) {
+  if (!aliasTabIds.some((id) => id === tab)) {
     return;
   }
 

--- a/src/server/getServerSideProps/main.ts
+++ b/src/server/getServerSideProps/main.ts
@@ -4,6 +4,7 @@ import * as guards from './guards';
 import { factory } from './utils';
 
 export const base = factory([ ]);
+export const blocks = factory([ guards.blocksTab ]);
 export const block = factory([ guards.notMultichain ]);
 export const tx = factory([ guards.notMultichain ]);
 export const internalTx = factory([ guards.internalTx ]);

--- a/src/server/getServerSideProps/main.ts
+++ b/src/server/getServerSideProps/main.ts
@@ -4,7 +4,7 @@ import * as guards from './guards';
 import { factory } from './utils';
 
 export const base = factory([ ]);
-export const blocks = factory([ guards.blocksTab ]);
+export const blocks = factory([ guards.blocks ]);
 export const block = factory([ guards.notMultichain ]);
 export const tx = factory([ guards.notMultichain ]);
 export const internalTx = factory([ guards.internalTx ]);

--- a/src/slices/block/pages/index/Blocks.tsx
+++ b/src/slices/block/pages/index/Blocks.tsx
@@ -70,8 +70,7 @@ const BlocksPageContent = () => {
     },
   });
 
-  const flashblocksTabId = flashblocksFeature.isEnabled ? flashblocksFeature.name + 's' : undefined;
-  const isFlashblocksTab = tab === flashblocksTabId && flashblocksTabId !== undefined;
+  const isFlashblocksTab = flashblocksFeature.isEnabled && flashblocksFeature.tabIds.includes(tab);
 
   const pagination = (() => {
     if (tab === 'reorgs') {
@@ -81,14 +80,14 @@ const BlocksPageContent = () => {
       return unclesQuery.pagination;
     }
     if (isFlashblocksTab) {
-      return null;;
+      return null;
     }
     return blocksQuery.pagination;
   })();
 
   const tabs: Array<TabItemRegular> = [
     { id: 'blocks', title: 'All', component: <BlocksContent type="block" query={ blocksQuery }/> },
-    flashblocksFeature.isEnabled && flashblocksTabId && { id: flashblocksTabId, title: upperFirst(flashblocksFeature.name) + 's', component: <Flashblocks/> },
+    flashblocksFeature.isEnabled && { id: flashblocksFeature.tabIds, title: upperFirst(flashblocksFeature.name) + 's', component: <Flashblocks/> },
     { id: 'reorgs', title: 'Forked', component: <BlocksContent type="reorg" query={ reorgsQuery }/> },
     { id: 'uncles', title: 'Uncles', component: <BlocksContent type="uncle" query={ unclesQuery }/> },
   ].filter(Boolean);

--- a/src/slices/block/pages/index/Blocks.tsx
+++ b/src/slices/block/pages/index/Blocks.tsx
@@ -70,7 +70,7 @@ const BlocksPageContent = () => {
     },
   });
 
-  const isFlashblocksTab = flashblocksFeature.isEnabled && flashblocksFeature.tabIds.includes(tab);
+  const isFlashblocksTab = flashblocksFeature.isEnabled && flashblocksFeature.tabIds.some((id) => id === tab);
 
   const pagination = (() => {
     if (tab === 'reorgs') {


### PR DESCRIPTION
## Description

OP Stack chains are split between the newer **Subblocks** name and the legacy **Flashblocks** name for their sub-second pre-confirmation feed, while both stream the same wire format. One frontend image serves both kinds of chain, but the label has been hard-coded (`subblock` since blockscout/frontend#3643), so a chain that still runs Flashblocks has no way to keep its name.

- `NEXT_PUBLIC_FLASHBLOCKS_NAME` selects the label per deployment. It drives the `name` field of the flashblocks feature config, from which every user-facing string already derives: the blocks-page tab, the stats labels, the real-time feed hint and the new-items notice. MegaETH keeps `mini-block` regardless.
- The feature config also carries the blocks-page tab ids, the configured name first and the other OP Stack name as an alias, so links written under either name keep resolving. This also fixes a stale `?tab=` link falling back to the "All" tab with its query disabled.
- A `blocks` `getServerSideProps` guard redirects the alias to the canonical id (`/blocks?tab=flashblocks` → `/blocks?tab=subblocks` under the default, and the reverse when the name is `flashblock`), preserving the other query params. The redirect is temporary (307) because an operator can flip the name later.
- Parsers, the socket hook and the table components are untouched: the wire format is identical, so only labels differ.

Two decisions worth a look from reviewers:

- The default stays `subblock`, as introduced in #3643, so this change is purely additive: no deployment's label changes on upgrade. Chains that still run Flashblocks (Base, for one) opt in with `NEXT_PUBLIC_FLASHBLOCKS_NAME=flashblock`.
- Aliases exist only between the two OP Stack names. The MegaETH `mini-blocks` tab has no alias and no redirect.

## Environment variables

- Added `NEXT_PUBLIC_FLASHBLOCKS_NAME` (`flashblock` | `subblock`, default `subblock`) to set what the chain calls its pre-confirmation blocks; it controls every label on the feed and the blocks-page tab id. The envs validator rejects any other value and rejects the variable when `NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL` is not set, since it has no effect without the feed. Both rules moved into a `flashblocks` feature sub-schema.
- `NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL` is unchanged; its description in `docs/ENVS.md` now mentions both names.

## Minimum API version

None. The feed is streamed straight from the sequencer WebSocket; no Core API or microservice change is involved.

## Breaking or incompatible changes

None. Without the new variable every deployment keeps its current "Subblocks" label, and the previously unrecognised `?tab=flashblocks` links now redirect instead of falling back to the "All" tab.

## Additional information

Verification on this branch:

- Vitest: two new spec files (config resolution, redirect guard) with 11 tests; the full suite passes.
- `tsc`, `eslint` and `cspell` clean; the cognitive-complexity / CRAP gate passes with the new guard fully covered; envs-validator presets all pass, and both negative paths are rejected: an unknown name (`must be one of the following values: flashblock, subblock`) and a name without the socket URL (`can only be used with NEXT_PUBLIC_FLASHBLOCKS_SOCKET_URL`).
- Live check on a local dev server with the Base socket URL configured, in both name configurations:

| Config | Request | Result |
| --- | --- | --- |
| default (`subblock`) | `/blocks?tab=flashblocks` | 307 → `/blocks?tab=subblocks` |
| default (`subblock`) | `/blocks?tab=flashblocks&page=3` | 307 → `/blocks?page=3&tab=subblocks` |
| default (`subblock`) | `/blocks?tab=subblocks`, `?tab=reorgs` | 200 |
| `NAME=flashblock` | `/blocks?tab=subblocks` | 307 → `/blocks?tab=flashblocks` |
| `NAME=flashblock` | `/blocks?tab=subblocks&page=2` | 307 → `/blocks?page=2&tab=flashblocks` |
| `NAME=flashblock` | `/blocks?tab=flashblocks`, `?tab=reorgs`, `/blocks` | 200 |

No Playwright snapshot was added: with the feature disabled (the Playwright default) the blocks page renders exactly as before, and the new behaviour has no visual component beyond the label text.

## Review follow-up

Commit 2a78d176e addresses the first review round. Nothing was force-pushed, so the delta is viewable on its own.

- **Tab ids are literal and typed (F1, and the `config.ts:19` suggestion).** `FLASHBLOCKS_TAB_IDS` / `FlashblocksTabId` live in `types/config.ts`, the two OP Stack orderings are written out in `config.ts`, and `tabIds` is a non-empty mutable tuple, so the guard's destructuring of the canonical id is sound and the ids are greppable. The `.map` derivation and its comment are gone. The suggested one-liner was not applied verbatim because it would have dropped the canonical-first ordering that the config spec pins.
- **`includes` became `some` at both call sites.** Once the element type is the literal union, `tabIds.includes(tab)` with `tab: string` fails with TS2345, since call arguments are checked by assignability rather than bivariance. `some((id) => id === tab)` compares instead and compiles without a cast.
- **Guard renamed to `blocks` (maintainer comment and F5).** Matches how the other guards are named for their page and the existing `blocks` export in `main.ts`. F5's `flashblocksTabAlias` was considered and set aside for consistency with the file.
- **Guard spec uses `withEnvs` again (F2).** No more `as unknown as typeof config`; the spec drives the real config through env presets like `config.spec.ts`. Helpers carry return types and the single-use constant is inlined.
- **Glossary row (F3).** The OP Labs rename etymology is back and "(the default)" is out; defaults stay in `docs/ENVS.md`.
- **Rationale stated once (F4).** The code comments in `types/config.ts`, `config.ts` and `guards.ts` are removed; `docs/ENVS.md` is the single statement.

Re-verified on 2a78d176e: `tsc`, `eslint`, `cspell`, the complexity gate, the full Vitest suite (93 files, 663 tests), all 16 validator presets, and both validator negative paths.

**Round 2, commit 713e13864.** Both new nits applied as suggested: the MegaETH `tabIds` constant is typed `[ 'mini-blocks' ]` rather than the full union (F7), and the guard spec annotates its env list as `Array<[ string, string ]>` instead of casting the inline pair (F6). Both call sites keep `some(...)`; the reviewer confirmed `includes` also compiles here thanks to `ts-reset`, so either form is fine and this one stays. Re-verified on 713e13864: `tsc`, `eslint`, `cspell`, the complexity gate, the full Vitest suite (93 files, 663 tests), and all 16 validator presets.


