### PR TITLE
Point Hardhat and Foundry verification instructions at the Pro API on supported chains

### DIFF
--- a/src/slices/contract/pages/contract-verification/methods/ContractVerificationSolidityFoundry.tsx
+++ b/src/slices/contract/pages/contract-verification/methods/ContractVerificationSolidityFoundry.tsx
@@ -13,19 +13,23 @@ import { Link } from 'src/toolkit/chakra/link';
 import ContractVerificationFormCodeSnippet from '../ContractVerificationFormCodeSnippet';
 import ContractVerificationFormRow from '../ContractVerificationFormRow';
 import ContractVerificationMethod from '../ContractVerificationMethod';
+import { getFoundryVerificationParams } from './utils';
 
 const ContractVerificationSolidityFoundry = () => {
   const { watch } = useFormContext<FormFields>();
   const address = watch('address');
-  const coreApiEndpoint = config.apis.core ?
-    `${ config.apis.core.endpoint }${ config.apis.core.basePath ?? '' }` : '';
 
-  const codeSnippet = `forge verify-contract \\
-  --rpc-url ${ config.chain.rpcUrls[0] || (coreApiEndpoint ? `${ coreApiEndpoint }/api/eth-rpc` : '') } \\
-  --verifier blockscout \\
-  --verifier-url '${ coreApiEndpoint ? `${ coreApiEndpoint }/api/` : '' }' \\
-  ${ address || '<address>' } \\
-  [contractFile]:[contractName]`;
+  const { rpcUrl, apiKey, verifierUrl } = getFoundryVerificationParams();
+
+  const codeSnippet = [
+    'forge verify-contract \\',
+    `  --rpc-url ${ rpcUrl } \\`,
+    '  --verifier blockscout \\',
+    `  --verifier-url '${ verifierUrl }' \\`,
+    ...(apiKey ? [ `  --etherscan-api-key ${ apiKey } \\` ] : []),
+    `  ${ address || '<address>' } \\`,
+    '  [contractFile]:[contractName]',
+  ].join('\n');
 
   return (
     <ContractVerificationMethod title="Contract verification via Foundry">
@@ -38,6 +42,14 @@ const ContractVerificationSolidityFoundry = () => {
           <Link href="https://docs.blockscout.com/devs/verification/foundry-verification" external>
             here
           </Link>
+          { config.chain.isProApiSupported && (
+            <Box mt={ 1 }>
+              <span>Get your Pro API key in the </span>
+              <Link href="https://dev.blockscout.com/?utm_source=blockscout&utm_medium=contract_verification" external>
+                Blockscout Dev Portal
+              </Link>
+            </Box>
+          ) }
         </Box>
       </ContractVerificationFormRow>
     </ContractVerificationMethod>

--- a/src/slices/contract/pages/contract-verification/methods/ContractVerificationSolidityHardhat.tsx
+++ b/src/slices/contract/pages/contract-verification/methods/ContractVerificationSolidityHardhat.tsx
@@ -15,6 +15,7 @@ import { Link } from 'src/toolkit/chakra/link';
 import ContractVerificationFormCodeSnippet from '../ContractVerificationFormCodeSnippet';
 import ContractVerificationFormRow from '../ContractVerificationFormRow';
 import ContractVerificationMethod from '../ContractVerificationMethod';
+import { getHardhatVerificationParams } from './utils';
 
 const ContractVerificationSolidityHardhat = ({ config: formConfig }: { config: SmartContractVerificationConfig }) => {
   const chainNameSlug = config.chain.name?.toLowerCase().split(' ').join('-');
@@ -23,23 +24,25 @@ const ContractVerificationSolidityHardhat = ({ config: formConfig }: { config: S
 
   const latestSolidityVersion = formConfig.solidity_compiler_versions.find((version) => !version.includes('nightly'))?.split('+')[0];
 
+  const { rpcUrl, apiKey, apiUrl } = getHardhatVerificationParams();
+
   const firstCodeSnippet = `const config: HardhatUserConfig = {
   solidity: "${ latestSolidityVersion || '0.8.24' }", // replace if necessary
   networks: {
     '${ chainNameSlug }': {
-      url: '${ config.chain.rpcUrls[0] || (config.apis.core ? `${ config.apis.core.endpoint }${ config.apis.core.basePath ?? '' }/api/eth-rpc` : '') }'
+      url: '${ rpcUrl }'
     },
   },
   etherscan: {
     apiKey: {
-      '${ chainNameSlug }': 'empty'
+      '${ chainNameSlug }': '${ apiKey }'
     },
     customChains: [
       {
         network: "${ chainNameSlug }",
         chainId: ${ config.chain.id },
         urls: {
-          apiURL: "${ config.apis.core ? `${ config.apis.core.endpoint }${ config.apis.core.basePath ?? '' }/api` : '' }",
+          apiURL: "${ apiUrl }",
           browserURL: "${ config.app.baseUrl }"
         }
       }
@@ -64,6 +67,14 @@ const ContractVerificationSolidityHardhat = ({ config: formConfig }: { config: S
           <Link href="https://docs.blockscout.com/devs/verification/hardhat-verification-plugin" external>
             here
           </Link>
+          { config.chain.isProApiSupported && (
+            <Box mt={ 1 }>
+              <span>Get your Pro API key in the </span>
+              <Link href="https://dev.blockscout.com/?utm_source=blockscout&utm_medium=contract_verification" external>
+                Blockscout Dev Portal
+              </Link>
+            </Box>
+          ) }
         </Box>
       </ContractVerificationFormRow>
     </ContractVerificationMethod>

--- a/src/slices/contract/pages/contract-verification/methods/utils.spec.ts
+++ b/src/slices/contract/pages/contract-verification/methods/utils.spec.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import { ENVS_MAP } from 'src/config/test-utils/env-presets';
+
+import { describe, expect, it } from 'vitest';
+import withEnvs from 'vitest/utils/mockEnvs';
+
+const NO_RPC_URL: Array<[ string, string ]> = [ [ 'NEXT_PUBLIC_NETWORK_RPC_URL', '' ] ];
+
+describe('on a chain without Pro API support', () => {
+  it('points Hardhat at the instance API and asks for no key', async() => {
+    const { getHardhatVerificationParams } = await import('./utils');
+
+    expect(getHardhatVerificationParams()).toEqual({
+      rpcUrl: 'https://localhost:1111',
+      apiKey: 'empty',
+      apiUrl: 'https://localhost:3003/api',
+    });
+  });
+
+  it('points Foundry at the instance API and passes no key', async() => {
+    const { getFoundryVerificationParams } = await import('./utils');
+
+    expect(getFoundryVerificationParams()).toEqual({
+      rpcUrl: 'https://localhost:1111',
+      apiKey: undefined,
+      verifierUrl: 'https://localhost:3003/api/',
+    });
+  });
+
+  it('keeps the instance API base path in the urls', async() => {
+    await withEnvs([ ...NO_RPC_URL, [ 'NEXT_PUBLIC_API_BASE_PATH', '/poa/core' ] ], async() => {
+      const { getHardhatVerificationParams, getFoundryVerificationParams } = await import('./utils');
+
+      expect(getHardhatVerificationParams().apiUrl).toBe('https://localhost:3003/poa/core/api');
+      expect(getFoundryVerificationParams().verifierUrl).toBe('https://localhost:3003/poa/core/api/');
+      expect(getFoundryVerificationParams().rpcUrl).toBe('https://localhost:3003/poa/core/api/eth-rpc');
+    });
+  });
+
+  it('falls back to the instance eth-rpc endpoint when the chain has no RPC url', async() => {
+    await withEnvs(NO_RPC_URL, async() => {
+      const { getHardhatVerificationParams, getFoundryVerificationParams } = await import('./utils');
+
+      expect(getHardhatVerificationParams().rpcUrl).toBe('https://localhost:3003/api/eth-rpc');
+      expect(getFoundryVerificationParams().rpcUrl).toBe('https://localhost:3003/api/eth-rpc');
+    });
+  });
+});
+
+describe('on a chain with Pro API support', () => {
+  it('points Hardhat at the Pro API and asks for a key', async() => {
+    await withEnvs(ENVS_MAP.proApi, async() => {
+      const { getHardhatVerificationParams } = await import('./utils');
+
+      expect(getHardhatVerificationParams()).toEqual({
+        rpcUrl: 'https://localhost:1111',
+        apiKey: '{PRO_API_KEY}',
+        apiUrl: 'https://api.blockscout.com/1/api',
+      });
+    });
+  });
+
+  it('points Foundry at the Pro API and passes a key', async() => {
+    await withEnvs(ENVS_MAP.proApi, async() => {
+      const { getFoundryVerificationParams } = await import('./utils');
+
+      expect(getFoundryVerificationParams()).toEqual({
+        rpcUrl: 'https://localhost:1111',
+        apiKey: '{PRO_API_KEY}',
+        verifierUrl: 'https://api.blockscout.com/v2/api?chain_id=1',
+      });
+    });
+  });
+
+  it('falls back to the Pro API json-rpc endpoint when the chain has no RPC url', async() => {
+    await withEnvs([ ...ENVS_MAP.proApi, ...NO_RPC_URL ], async() => {
+      const { getHardhatVerificationParams, getFoundryVerificationParams } = await import('./utils');
+
+      expect(getHardhatVerificationParams().rpcUrl).toBe('https://api.blockscout.com/1/json-rpc?apikey={PRO_API_KEY}');
+      expect(getFoundryVerificationParams().rpcUrl).toBe('https://api.blockscout.com/1/json-rpc?apikey={PRO_API_KEY}');
+    });
+  });
+});

--- a/src/slices/contract/pages/contract-verification/methods/utils.ts
+++ b/src/slices/contract/pages/contract-verification/methods/utils.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import config from 'src/config';
+
+const PRO_API_URL = 'https://api.blockscout.com';
+const PRO_API_KEY_PLACEHOLDER = '{PRO_API_KEY}';
+
+function getCoreApiEndpoint() {
+  return config.apis.core ? `${ config.apis.core.endpoint }${ config.apis.core.basePath ?? '' }` : '';
+}
+
+function getRpcUrl() {
+  if (config.chain.rpcUrls[0]) {
+    return config.chain.rpcUrls[0];
+  }
+
+  if (config.chain.isProApiSupported) {
+    return `${ PRO_API_URL }/${ config.chain.id }/json-rpc?apikey=${ PRO_API_KEY_PLACEHOLDER }`;
+  }
+
+  const coreApiEndpoint = getCoreApiEndpoint();
+
+  return coreApiEndpoint ? `${ coreApiEndpoint }/api/eth-rpc` : '';
+}
+
+export function getHardhatVerificationParams() {
+  if (config.chain.isProApiSupported) {
+    return {
+      rpcUrl: getRpcUrl(),
+      apiKey: PRO_API_KEY_PLACEHOLDER,
+      apiUrl: `${ PRO_API_URL }/${ config.chain.id }/api`,
+    };
+  }
+
+  const coreApiEndpoint = getCoreApiEndpoint();
+
+  return {
+    rpcUrl: getRpcUrl(),
+    apiKey: 'empty',
+    apiUrl: coreApiEndpoint ? `${ coreApiEndpoint }/api` : '',
+  };
+}
+
+export function getFoundryVerificationParams() {
+  if (config.chain.isProApiSupported) {
+    return {
+      rpcUrl: getRpcUrl(),
+      apiKey: PRO_API_KEY_PLACEHOLDER,
+      verifierUrl: `${ PRO_API_URL }/v2/api?chain_id=${ config.chain.id }`,
+    };
+  }
+
+  const coreApiEndpoint = getCoreApiEndpoint();
+
+  return {
+    rpcUrl: getRpcUrl(),
+    apiKey: undefined,
+    verifierUrl: coreApiEndpoint ? `${ coreApiEndpoint }/api/` : '',
+  };
+}


### PR DESCRIPTION
## Description

Resolves #3684

On chains covered by the Blockscout Pro API (`NEXT_PUBLIC_PRO_API_SUPPORTED=true`), the Hardhat and
Foundry snippets on the contract verification page pointed users at the instance's own API, which is
not the endpoint those chains are meant to be verified through. Both snippets now target the Pro API
gateway and carry a `{PRO_API_KEY}` placeholder for the user's key:

- Hardhat — `apiURL: https://api.blockscout.com/<chain_id>/api` and `apiKey: '{PRO_API_KEY}'`;
  `browserURL` still points at the explorer.
- Foundry — `--verifier-url 'https://api.blockscout.com/v2/api?chain_id=<chain_id>'` plus a new
  `--etherscan-api-key {PRO_API_KEY}` line.
- Both — when the chain has no `NEXT_PUBLIC_NETWORK_RPC_URL`, the RPC url falls back to
  `https://api.blockscout.com/<chain_id>/json-rpc?apikey={PRO_API_KEY}` instead of the instance's
  `/api/eth-rpc`. A configured public RPC url still wins, so users aren't asked for a key they don't need.
- The existing "Full tutorial …" text now also links to the Blockscout Dev Portal on Pro API instances,
  so the key placeholder isn't a dead end.

Self-hosted instances with Pro API support disabled render exactly what they did before — the URL
selection lives in one helper (`methods/utils.ts`) with unit coverage for both branches.

## Environment variables

None. The behavior is gated on the existing `NEXT_PUBLIC_PRO_API_SUPPORTED`, which is set automatically
at container startup.

## Minimum API version

None.

## Breaking or incompatible changes

None.

## Additional information

- The URL forms are taken verbatim from the issue. Cross-checking the public docs: the Foundry
  `--verifier-url` form matches them exactly, but the Hardhat per-chain `apiURL`
  (`api.blockscout.com/<chain_id>/api`) and the `?apikey=` query param on `json-rpc` are not documented
  publicly — every Pro API path returns `402` without a key, so they couldn't be verified from here.
  Worth a second pair of eyes if you have a Pro API key.
- No Playwright baselines exist for the Pro API variant of either snippet yet.
