### PR TITLE
Let operators set the label on the DeFi dropdown button

### DIFF
--- a/deploy/tools/envs-validator/schemas/features/defiDropdown.ts
+++ b/deploy/tools/envs-validator/schemas/features/defiDropdown.ts
@@ -35,22 +35,17 @@ export const defiDropdownSchema = yup.object({
     .of(deFiDropdownItemSchema),
   NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT: yup
     .mixed()
-    .test(
-      'shape',
-      'Invalid schema were provided for NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT, it should have a required desktop and an optional mobile field',
-      (data) => data === undefined || deFiDropdownButtonTextSchema.isValidSync(data),
-    )
-    .test(
-      'requires-dropdown',
-      `NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT can only be used when NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS contains at least ${ MIN_ITEMS_FOR_DROPDOWN } items`,
-      function(data) {
-        if (data === undefined) {
-          return true;
-        }
-
-        const items = this.parent.NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS;
-
-        return Array.isArray(items) && items.length >= MIN_ITEMS_FOR_DROPDOWN;
-      },
-    ),
+    .when('NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS', {
+      is: (items: unknown) => Array.isArray(items) && items.length >= MIN_ITEMS_FOR_DROPDOWN,
+      then: (schema) => schema.test(
+        'shape',
+        'Invalid schema were provided for NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT, it should have a required desktop and an optional mobile field',
+        (data) => data === undefined || deFiDropdownButtonTextSchema.isValidSync(data),
+      ),
+      otherwise: (schema) => schema.test(
+        'not-exist',
+        `NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT can only be used when NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS contains at least ${ MIN_ITEMS_FOR_DROPDOWN } items`,
+        value => value === undefined,
+      ),
+    }),
 });

--- a/deploy/tools/envs-validator/schemas/features/defiDropdown.ts
+++ b/deploy/tools/envs-validator/schemas/features/defiDropdown.ts
@@ -1,8 +1,10 @@
 import * as yup from 'yup';
-import type { DeFiDropdownItem } from 'src/features/defi-dropdown/types/client';
+import type { DeFiDropdownButtonText, DeFiDropdownItem } from 'src/features/defi-dropdown/types/client';
 import type { IconName } from 'public/icons/name';
 import { urlTest } from '../../utils';
 import { replaceQuotes } from 'src/config/utils/envs';
+
+const MIN_ITEMS_FOR_DROPDOWN = 2;
 
 const deFiDropdownItemSchema: yup.ObjectSchema<DeFiDropdownItem> = yup
   .object({
@@ -16,10 +18,39 @@ const deFiDropdownItemSchema: yup.ObjectSchema<DeFiDropdownItem> = yup
     return Boolean(value.dappId) || Boolean(value.url);
   }) as yup.ObjectSchema<DeFiDropdownItem>;
 
+const deFiDropdownButtonTextSchema = yup
+  .object<DeFiDropdownButtonText>()
+  .transform(replaceQuotes)
+  .json()
+  .shape({
+    desktop: yup.string().required(),
+    mobile: yup.string(),
+  });
+
 export const defiDropdownSchema = yup.object({
     NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS: yup
     .array()
     .transform(replaceQuotes)
     .json()
     .of(deFiDropdownItemSchema),
+  NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT: yup
+    .mixed()
+    .test(
+      'shape',
+      'Invalid schema were provided for NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT, it should have a required desktop and an optional mobile field',
+      (data) => data === undefined || deFiDropdownButtonTextSchema.isValidSync(data),
+    )
+    .test(
+      'requires-dropdown',
+      `NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT can only be used when NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS contains at least ${ MIN_ITEMS_FOR_DROPDOWN } items`,
+      function(data) {
+        if (data === undefined) {
+          return true;
+        }
+
+        const items = this.parent.NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS;
+
+        return Array.isArray(items) && items.length >= MIN_ITEMS_FOR_DROPDOWN;
+      },
+    ),
 });

--- a/deploy/tools/envs-validator/test/.env.base
+++ b/deploy/tools/envs-validator/test/.env.base
@@ -90,6 +90,7 @@ NEXT_PUBLIC_WEB3_DISABLE_ADD_TOKEN_TO_WALLET=false
 NEXT_PUBLIC_WEB3_WALLETS=['coinbase','metamask','token_pocket']
 NEXT_PUBLIC_VALIDATORS_CHAIN_TYPE=stability
 NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS=[{'text':'Swap','icon':'swap','dappId':'uniswap'},{'text':'Payment link','icon':'payment_link','url':'https://example.com'}]
+NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT={'desktop':'Blockscout DeFi','mobile':'DeFi'}
 NEXT_PUBLIC_MULTICHAIN_BALANCE_PROVIDER_CONFIG=[{'name': 'zerion', 'url_template': 'https://app.zerion.io/{address}/overview', 'logo': 'https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/marketplace-logos/zerion.svg'}]
 NEXT_PUBLIC_GAS_REFUEL_PROVIDER_CONFIG={'name': 'Need gas?', 'dapp_id': 'smol-refuel', 'url_template': 'https://smolrefuel.com/?outboundChain={chainId}&partner=blockscout&utm_source=blockscout&utm_medium=address&disableBridges=true', 'logo': 'https://blockscout-content.s3.amazonaws.com/smolrefuel-logo-action-button.png'}
 NEXT_PUBLIC_REWARDS_SERVICE_API_HOST=https://example.com

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -926,6 +926,7 @@ If the feature is enabled, a single button or a dropdown (if more than 1 item is
 | Variable | Type | Description | Compulsoriness | Default value | Example value | Version |
 | --- | --- | --- | --- | --- | --- | --- |
 | NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS | `[{ text: string; icon?: string; dappId?: string, url?: string, isEssentialDapp?: boolean }]` | An array of dropdown items containing the button text, icon name and dappId in Dappscout or an external url | - | - | `[{'text':'Swap','icon':'swap','dappId':'swap','isEssentialDapp':true},{'text':'Payment link','icon':'payment_link','dappId':'peanut-protocol'}]` | v1.31.0+ |
+| NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT | `{ desktop: string; mobile?: string }` | Text on the button that opens the dropdown. `mobile` is the shorter form shown on narrow screens. Keep `desktop` within ~24 characters and `mobile` within ~10. | - | `{'desktop':'Blockscout DeFi','mobile':'DeFi'}` | `{'desktop':'MyChain DeFi','mobile':'DeFi'}` | upcoming |
 
 &nbsp;
 

--- a/src/features/defi-dropdown/components/DeFiDropdown.spec.tsx
+++ b/src/features/defi-dropdown/components/DeFiDropdown.spec.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import React from 'react';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from 'vitest/lib';
+import withEnvs from 'vitest/utils/mockEnvs';
+
+const ITEMS_ENV: [ string, string ] = [
+  'NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS',
+  '[{"text":"Swap","dappId":"uniswap"},{"text":"Payment link","url":"https://example.com"}]',
+];
+
+async function renderDropdown(envs: Array<[ string, string ]>) {
+  return withEnvs(envs, async() => {
+    const { 'default': DeFiDropdown } = await import('./DeFiDropdown');
+    render(<DeFiDropdown/>);
+  });
+}
+
+describe('DeFiDropdown', () => {
+  afterEach(cleanup);
+
+  it('labels the trigger "Blockscout DeFi", shortened to "DeFi", by default', async() => {
+    await renderDropdown([ ITEMS_ENV ]);
+
+    expect(screen.queryByText('Blockscout DeFi')).not.toBeNull();
+    expect(screen.queryByText('DeFi')).not.toBeNull();
+  });
+
+  it('labels the trigger with both forms from NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT', async() => {
+    await renderDropdown([
+      ITEMS_ENV,
+      [ 'NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT', '{"desktop":"MyChain DeFi hub","mobile":"Hub"}' ],
+    ]);
+
+    expect(screen.queryByText('MyChain DeFi hub')).not.toBeNull();
+    expect(screen.queryByText('Hub')).not.toBeNull();
+    expect(screen.queryByText('Blockscout DeFi')).toBeNull();
+  });
+});

--- a/src/features/defi-dropdown/components/DeFiDropdown.spec.tsx
+++ b/src/features/defi-dropdown/components/DeFiDropdown.spec.tsx
@@ -12,7 +12,7 @@ const ITEMS_ENV: [ string, string ] = [
   '[{"text":"Swap","dappId":"uniswap"},{"text":"Payment link","url":"https://example.com"}]',
 ];
 
-async function renderDropdown(envs: Array<[ string, string ]>) {
+async function renderDropdown(envs: Array<[ string, string ]>): Promise<void> {
   return withEnvs(envs, async() => {
     const { 'default': DeFiDropdown } = await import('./DeFiDropdown');
     render(<DeFiDropdown/>);

--- a/src/features/defi-dropdown/components/DeFiDropdown.tsx
+++ b/src/features/defi-dropdown/components/DeFiDropdown.tsx
@@ -12,7 +12,6 @@ import SpriteIcon from 'src/sprite/SpriteIcon';
 import { Button } from 'src/toolkit/chakra/button';
 import { Link } from 'src/toolkit/chakra/link';
 import { PopoverBody, PopoverContent, PopoverRoot, PopoverTrigger } from 'src/toolkit/chakra/popover';
-import { space } from 'src/toolkit/utils/htmlEntities';
 
 import DeFiDropdownItem from './DeFiDropdownItem';
 
@@ -39,10 +38,12 @@ const DeFiDropdown = () => {
     <PopoverRoot>
       <PopoverTrigger>
         <Button size="2xs" gap={ 0 }>
-          <chakra.span display={{ base: 'none', lg: 'inline' }} whiteSpace="pre-wrap">
-            Blockscout{ space }
+          <chakra.span display={{ base: 'none', lg: 'inline' }}>
+            { feature.buttonText.desktop }
           </chakra.span>
-          DeFi
+          <chakra.span display={{ base: 'inline', lg: 'none' }}>
+            { feature.buttonText.mobile }
+          </chakra.span>
           <SpriteIcon name="arrows/east-mini" boxSize={ 4 } ml={ 1 } transform="rotate(-90deg)"/>
         </Button>
       </PopoverTrigger>

--- a/src/features/defi-dropdown/config.spec.ts
+++ b/src/features/defi-dropdown/config.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+import { describe, expect, it } from 'vitest';
+import withEnvs from 'vitest/utils/mockEnvs';
+
+import type deFiDropdownConfig from './config';
+
+const ITEMS_ENV: [ string, string ] = [
+  'NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS',
+  '[{"text":"Swap","dappId":"uniswap"},{"text":"Payment link","url":"https://example.com"}]',
+];
+
+async function loadConfig(envs: Array<[ string, string ]>): Promise<typeof deFiDropdownConfig> {
+  return withEnvs(envs, async() => {
+    await import('src/config');
+    return (await import('./config')).default;
+  });
+}
+
+describe('DeFi dropdown feature config', () => {
+  it('is disabled without any items', async() => {
+    expect((await loadConfig([])).isEnabled).toBe(false);
+  });
+
+  it('labels the button "Blockscout DeFi", shortened to "DeFi", when the text env is unset', async() => {
+    expect(await loadConfig([ ITEMS_ENV ])).toMatchObject({
+      isEnabled: true,
+      buttonText: { desktop: 'Blockscout DeFi', mobile: 'DeFi' },
+    });
+  });
+
+  it('takes both forms from NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT', async() => {
+    const config = await loadConfig([
+      ITEMS_ENV,
+      [ 'NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT', '{"desktop":"MyChain DeFi","mobile":"DeFi"}' ],
+    ]);
+    expect(config).toMatchObject({ buttonText: { desktop: 'MyChain DeFi', mobile: 'DeFi' } });
+  });
+
+  it('reuses the desktop form on mobile when the text env omits a mobile one', async() => {
+    const config = await loadConfig([
+      ITEMS_ENV,
+      [ 'NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT', '{"desktop":"Trade"}' ],
+    ]);
+    expect(config).toMatchObject({ buttonText: { desktop: 'Trade', mobile: 'Trade' } });
+  });
+
+  it('ignores a malformed text env and keeps the default label', async() => {
+    const config = await loadConfig([
+      ITEMS_ENV,
+      [ 'NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT', 'not json' ],
+    ]);
+    expect(config).toMatchObject({ buttonText: { desktop: 'Blockscout DeFi', mobile: 'DeFi' } });
+  });
+});

--- a/src/features/defi-dropdown/config.spec.ts
+++ b/src/features/defi-dropdown/config.spec.ts
@@ -12,6 +12,9 @@ const ITEMS_ENV: [ string, string ] = [
 
 async function loadConfig(envs: Array<[ string, string ]>): Promise<typeof deFiDropdownConfig> {
   return withEnvs(envs, async() => {
+    // `src/config` has to be imported first: reaching it through `./config` instead enters the
+    // graph mid-cycle, and `src/shell/metadata/config` then reads `app.baseUrl` off an
+    // uninitialised module
     await import('src/config');
     return (await import('./config')).default;
   });

--- a/src/features/defi-dropdown/config.ts
+++ b/src/features/defi-dropdown/config.ts
@@ -1,21 +1,34 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-import type { DeFiDropdownItem } from 'src/features/defi-dropdown/types/client';
+import type { DeFiDropdownButtonText, DeFiDropdownItem } from 'src/features/defi-dropdown/types/client';
 
 import app from 'src/config/app';
 import { getEnvValue, parseEnvJson } from 'src/config/utils/envs';
 import type { Feature } from 'src/config/utils/features';
 
 const items = parseEnvJson<Array<DeFiDropdownItem>>(getEnvValue('NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS')) || [];
+const buttonTextEnv = parseEnvJson<DeFiDropdownButtonText>(getEnvValue('NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT'));
+
+const DEFAULT_BUTTON_TEXT = { desktop: 'Blockscout DeFi', mobile: 'DeFi' };
+
+const buttonText = buttonTextEnv ?
+  { desktop: buttonTextEnv.desktop, mobile: buttonTextEnv.mobile || buttonTextEnv.desktop } :
+  DEFAULT_BUTTON_TEXT;
 
 const title = 'DeFi dropdown';
 
-const config: Feature<{ items: Array<DeFiDropdownItem> }> = (() => {
+type Payload = {
+  items: Array<DeFiDropdownItem>;
+  buttonText: Required<DeFiDropdownButtonText>;
+};
+
+const config: Feature<Payload> = (() => {
   if (!app.isPrivateMode && items.length > 0) {
     return Object.freeze({
       title,
       isEnabled: true,
       items,
+      buttonText,
     });
   }
   return Object.freeze({

--- a/src/features/defi-dropdown/types/client.ts
+++ b/src/features/defi-dropdown/types/client.ts
@@ -9,3 +9,8 @@ export type DeFiDropdownItem = {
   { dappId: string; isEssentialDapp?: boolean; url?: never } |
   { url: string; dappId?: never; isEssentialDapp?: never }
 );
+
+export type DeFiDropdownButtonText = {
+  readonly desktop: string;
+  readonly mobile?: string;
+};

--- a/src/shell/top-bar/TopBar.pw.tsx
+++ b/src/shell/top-bar/TopBar.pw.tsx
@@ -59,7 +59,7 @@ test('with DeFi dropdown +@dark-mode +@mobile', async({ render, page, mockApiRes
 
   const component = await render(<TopBar/>);
 
-  await component.getByText(/DeFi/i).click();
+  await component.getByRole('button', { name: /defi/i }).click();
   await expect(page).toHaveScreenshot({ clip: { x: 0, y: 0, width: 1500, height: 220 } });
 });
 


### PR DESCRIPTION
## Description

Resolves #3687

The DeFi dropdown's trigger label was hardcoded — `Blockscout DeFi` on desktop, shortened to
`DeFi` below the `lg` breakpoint — even though the actions inside the dropdown have been
operator-configurable since v1.31.0. A new `NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT` makes the
label configurable too, leaving `NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS` untouched.

The variable is an object rather than a bare string on purpose: the top bar has far less room on
narrow screens, and naming a `mobile` field is what tells an operator that a second, shorter form
is worth setting. It falls back to `desktop` when omitted. Truncation was considered and rejected —
where a label gets clipped depends on the viewport, so the shorter form is the operator's call, not
a runtime guess. The validator rejects the variable unless `NEXT_PUBLIC_DEFI_DROPDOWN_ITEMS` holds
at least two items, because a single item renders as a direct link labelled with that item's own
text and has no dropdown to name — set-but-ignored config fails at startup instead of silently.

## Environment variables

Added `NEXT_PUBLIC_DEFI_DROPDOWN_BUTTON_TEXT` to set the text on the button that opens the DeFi
dropdown, as `{ desktop, mobile? }` so a shorter label can be used where the top bar is narrow.

## Minimum API version

None.

## Breaking or incompatible changes

None. With the variable unset the label defaults to `{ desktop: 'Blockscout DeFi', mobile: 'DeFi' }`,
which reproduces the previous rendering exactly at every width.

## Additional information

Test coverage is Vitest-only, since the change adds no new visual state: `config.ts` gets a spec for
label resolution (default, custom, mobile fallback, malformed JSON) and `DeFiDropdown.tsx` one for
the labels reaching the trigger. The one Playwright change is a forced selector fix — the trigger now
holds the label in two breakpoint-toggled spans, so `getByText(/DeFi/i)` matches twice and trips
strict mode; it becomes `getByRole('button', { name: /defi/i })`. No screenshots change.

The validator's three rejection paths (missing `desktop`, variable set with one item, variable set
with no items) were each confirmed by temporarily breaking `test/.env.base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
